### PR TITLE
fix: Re-render components when use_mount dirties state

### DIFF
--- a/crates/eye_declare/examples/mount_rerender.rs
+++ b/crates/eye_declare/examples/mount_rerender.rs
@@ -40,10 +40,7 @@ fn mount_label(
     });
 
     let (text, style) = match &state.label {
-        Some(label) => (
-            label.clone(),
-            Style::default().fg(Color::Green),
-        ),
+        Some(label) => (label.clone(), Style::default().fg(Color::Green)),
         None => (
             "[mount has not fired yet]".to_string(),
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),

--- a/crates/eye_declare/examples/mount_rerender.rs
+++ b/crates/eye_declare/examples/mount_rerender.rs
@@ -1,0 +1,117 @@
+//! Demonstrates that use_mount state changes should trigger a re-render.
+//!
+//! A component uses use_mount to set a label in state. The label should
+//! be visible immediately without needing any external event to trigger
+//! a re-render.
+//!
+//! BUG: The label shows "[mount has not fired yet]" until an external
+//! event causes a re-render, even though mount fires and sets state.
+//!
+//! Run with: cargo run --example mount_rerender
+
+use std::io;
+use std::time::Duration;
+
+use eye_declare::{Application, Elements, Hooks, Span, Text, component, element, props};
+use ratatui_core::style::{Color, Modifier, Style};
+
+// ---------------------------------------------------------------------------
+// Component that sets its label via use_mount
+// ---------------------------------------------------------------------------
+
+#[props]
+struct MountLabel {
+    value: String,
+}
+
+#[derive(Default)]
+struct MountLabelState {
+    label: Option<String>,
+}
+
+#[component(props = MountLabel, state = MountLabelState)]
+fn mount_label(
+    _props: &MountLabel,
+    state: &MountLabelState,
+    hooks: &mut Hooks<MountLabel, MountLabelState>,
+) -> Elements {
+    hooks.use_mount(|props, state| {
+        state.label = Some(format!("Mounted with: {}", props.value));
+    });
+
+    let (text, style) = match &state.label {
+        Some(label) => (
+            label.clone(),
+            Style::default().fg(Color::Green),
+        ),
+        None => (
+            "[mount has not fired yet]".to_string(),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+    };
+
+    element! {
+        Text {
+            Span(text: text, style: style)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// App state + view
+// ---------------------------------------------------------------------------
+
+struct AppState {
+    show_component: bool,
+}
+
+fn app_view(state: &AppState) -> Elements {
+    element! {
+        Text {
+            Span(
+                text: "Mount re-render test",
+                style: Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            )
+        }
+
+        #(if state.show_component {
+            MountLabel(key: "mount-label", value: "hello from mount")
+        })
+
+        Text {
+            Span(text: "---", style: Style::default().fg(Color::DarkGray))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let (mut app, handle) = Application::builder()
+        .state(AppState {
+            show_component: false,
+        })
+        .view(app_view)
+        .build()?;
+
+    tokio::spawn(async move {
+        // Step 1: Show the component — mount should fire and set the label
+        handle.update(|s| {
+            s.show_component = true;
+        });
+
+        // Wait to observe — if the label says "[mount has not fired yet]",
+        // the bug is present. It should say "Mounted with: hello from mount".
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // handle dropped → app exits
+    });
+
+    app.run().await?;
+
+    println!();
+    Ok(())
+}

--- a/crates/eye_declare/src/renderer.rs
+++ b/crates/eye_declare/src/renderer.rs
@@ -448,10 +448,11 @@ impl Renderer {
     /// renderer.rebuild(container, my_view(&state));
     /// ```
     pub fn rebuild(&mut self, parent: NodeId, elements: Elements) {
-        self.reconcile_children(parent, elements.into_items());
-        // Full rebuild reconciles all dirty nodes — no need for the
-        // pre-render refresh pass to repeat that work.
+        // Clear the refresh flag before reconciliation. If mount effects
+        // dirty component state during the rebuild, fire_mount will set
+        // it back to true so refresh_dirty_views runs on the next render.
         self.needs_refresh = false;
+        self.reconcile_children(parent, elements.into_items());
     }
 
     /// Find a direct child of `parent` by its key.
@@ -631,6 +632,12 @@ impl Renderer {
                 effect
                     .handler
                     .call(node.component.props_as_any(), node.state.as_any_mut());
+            }
+
+            // If a mount handler dirtied the state, schedule a refresh so the
+            // component re-renders on the next frame.
+            if self.nodes[id].state.is_dirty() {
+                self.needs_refresh = true;
             }
 
             // Reinsert remaining effects (if any)


### PR DESCRIPTION
## Summary

- Mount effects that mutate component state via `use_mount` were not triggering a re-render, causing the component to display stale default state until an unrelated event forced a rebuild.
- Root cause: `rebuild()` unconditionally cleared `needs_refresh` *after* `reconcile_children()`, wiping the flag that `fire_mount` set during reconciliation. Additionally, `fire_mount` itself wasn't setting `needs_refresh` at all.
- Fix: clear `needs_refresh` *before* reconciliation so mount effects can set it back, and check the dirty flag after each mount handler fires.

## Reproduction

`cargo run --example mount_rerender` — a component sets its label in `use_mount`. Before this fix, the label shows `[mount has not fired yet]` until an external event triggers a re-render. After this fix, it correctly shows `Mounted with: hello from mount` immediately.

## Test plan

- [x] All 259 existing tests pass
- [x] New `mount_rerender` example demonstrates the fix visually
- [x] Verified in Atuin AI's `SessionContinue` component (the original trigger for this bug)