### PR TITLE
v2 redesign: spec and API bake-off spike (Phases 0-1)

### DIFF
--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -1,0 +1,325 @@
+# eye-declare v2: Timeline Architecture
+
+**Status:** Draft for teardown — nothing here is final until the Phase 1 bake-off validates it.
+**Context:** `.binarymuse/library-redesign.md` (assessment, Atuin AI evidence, hazard list).
+**Decisions already made:** new unpublished crate in this workspace; bake-off before engine extraction; current `eye_declare` API fully frozen.
+
+## Thesis
+
+Inline UIs are not trees, they are timelines: an append-only sequence of blocks where old
+content freezes and scrolls away, and only a small live tail is ever dynamic. The current
+library models a general component tree and bolts the timeline on (`freeze`, `commit`,
+`on_commit`); the redesign inverts that.
+
+The conceptual core, and the sentence everything below follows from:
+
+> **Committed output is an effect. The live tail is a view.**
+
+Writing a block toward scrollback is I/O — irreversible, append-only, like `println!`. So
+block emission happens in `update`, as an effect. The tail is the only thing that behaves
+like a screen, so it is the only thing described by a view function — re-run every frame,
+pure, cheap because it is small.
+
+This dissolves rather than solves several current problems: no reconciliation (nothing to
+reconcile — blocks render once, the tail rerenders wholesale), no keys, no dirty tracking,
+no `NodeId`s, no commit detection by key parsing, and per-frame cost bounded by the tail
+regardless of how long the app runs.
+
+## Core types
+
+Sketches, not signatures-of-record. Names are placeholders.
+
+### App
+
+```rust
+pub trait App: Sized + 'static {
+    /// Messages driving the app. Everything that happens becomes one of these.
+    type Msg: Send + 'static;
+    /// What `run()` returns when the app exits (e.g. Atuin's Execute/Insert/Cancel).
+    type Output: Default;
+
+    /// Handle a message: mutate the model, emit effects via ctx.
+    fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<'_, Self>);
+
+    /// Describe the live tail. Re-run every frame. Pure, borrows the model.
+    fn tail(&self) -> impl Element<Self::Msg>;
+
+    /// Declarative recurring inputs, diffed by key after each update.
+    fn subscriptions(&self) -> Subscriptions<Self::Msg> {
+        Subscriptions::none()
+    }
+}
+```
+
+No separate Model type — the implementing struct *is* the model. `update` takes `&mut
+self`; `tail` takes `&self`. The borrow checker enforces the Elm discipline for free.
+
+### Ctx: effects
+
+```rust
+impl<A: App> Ctx<'_, A> {
+    /// Append a finished block to the timeline. Rendered once at current
+    /// width, then owned by the engine; flows into scrollback. Irreversible.
+    pub fn push(&mut self, block: impl Element<A::Msg>);
+
+    /// Spawn a stream of messages (the LLM-turn shape). Each item is fed
+    /// back into update(). Returns a cancel-on-drop Task.
+    #[must_use]
+    pub fn spawn(&mut self, s: impl Stream<Item = A::Msg> + Send + 'static) -> Task;
+
+    /// One-shot future convenience over spawn().
+    #[must_use]
+    pub fn perform(&mut self, f: impl Future<Output = A::Msg> + Send + 'static) -> Task;
+
+    /// End the run loop; run() returns this value after teardown.
+    pub fn exit(&mut self, output: A::Output);
+}
+```
+
+```rust
+/// Handle to spawned work. Dropping it cancels the work.
+pub struct Task(/* … */);
+impl Task {
+    pub fn detach(self);      // fire-and-forget, never cancelled
+}
+```
+
+Held in the model: `streaming: Option<Task>`. Esc-cancels-generation is
+`self.streaming = None;` — no CancelGeneration plumbing, no AtomicBools.
+
+### Subscriptions
+
+```rust
+Subscriptions::none()
+    .every("autosave", Duration::from_secs(30), || Msg::Autosave)
+    .stream("fs-events", || watch_files())          // keyed; diffed across updates
+```
+
+Note what is *absent*: spinner ticks. Widgets declare their own animation
+(`Spinner` reports `animated: Some(80ms)` via the Element trait), and the runtime
+self-ticks the tail while any animated widget is present. Spinners require zero user code.
+
+### Focus
+
+```rust
+pub struct FocusHandle(/* Arc-backed identity */);
+
+impl FocusHandle {
+    pub fn focus(&self);
+    pub fn blur(&self);
+    pub fn is_focused(&self) -> bool;
+}
+```
+
+Created by the app, stored in the model, bound in the tail
+(`.track_focus(&self.input_focus)`). Focus is plain data the app owns; "press `/` to focus
+search" is one line in `update`. There is no framework focus registry to fall out of sync
+with, no autofocus lifecycle, no Tab cycling unless the app binds Tab to a cycling message.
+
+### Keymap
+
+```rust
+fn keymap(&self) -> Keymap<Msg> {
+    Keymap::new()
+        .on(key!(ctrl-c), Msg::Interrupt).global_override()  // fires before widgets; rare
+        .on(key!(esc), Msg::Cancel)                          // global fallback
+        .in_scope(&self.input_focus, key!(enter), Msg::Submit)
+}
+```
+
+Dispatch order for a key event:
+1. `global_override` bindings (explicitly marked; for Ctrl+C-tier chords)
+2. the focused element's own handlers (a focused textarea gets Tab, arrows, chars)
+3. bindings scoped to the focused handle
+4. global bindings
+
+This makes the Atuin Tab-to-insert footgun structurally impossible: Tab means whatever the
+keymap says in the current focus context, and a focused editor can always take it first.
+
+### Elements and the DSL
+
+```rust
+pub trait Element<Msg> {
+    /// Honest measurement. No probe rendering, no 512-row cliff.
+    fn height(&self, width: u16) -> u16;
+    fn render(&self, area: Rect, buf: &mut Buffer);
+    /// Frame interval if self-animating (Spinner → Some(80ms)).
+    fn animated(&self) -> Option<Duration> { None }
+    /// Key handling when focused / message emission — exact shape TBD in bake-off.
+    fn on_key(&self, key: KeyEvent) -> Option<Msg> { None }
+}
+```
+
+Authoring is **fluent builders first** (GPUI-style), macros only as thin sugar if the
+bake-off shows specific pain:
+
+```rust
+fn tail(&self) -> impl Element<Msg> {
+    col()
+        .gap(1)
+        .when(self.streaming.is_some(), |c| c.child(spinner("Thinking…")))
+        .child(
+            text_area(&self.input)
+                .border(Rounded)
+                .title("Ask")
+                .track_focus(&self.input_focus)
+                .on_submit(Msg::Submit),
+        )
+        .children(self.slash_results.iter().take(4).map(slash_row))
+}
+```
+
+Native `if`/`for`/`match` work inside plain Rust; `.when()` and `.children(iter)` cover
+the inline cases. No custom parser, no `#()` grammar, full rust-analyzer support. Layout
+vocabulary carries over from v1: `col`/`row`, `Fixed`/`Fill` widths, content-driven
+height, insets/borders via builder methods.
+
+### Widget state — the open question
+
+Two candidates; the bake-off ports InputBox both ways.
+
+**Candidate A — strict Elm (current lean).** Widget state is a plain value in the model;
+the widget ships a state type with a `handle` method; update owns all mutation:
+
+```rust
+struct Model { input: TextAreaState, /* … */ }
+
+// tail:  text_area(&self.input).on_event(Msg::Input)
+// update:
+Msg::Input(ev) => {
+    if let Some(TextAreaEvent::Submitted(s)) = self.input.apply(ev) {
+        // …
+    }
+}
+```
+
+Maximum explicitness and testability; the cost is one routing arm per stateful widget.
+
+**Candidate B — framework-managed.** Runtime owns per-id widget state (egui-Memory
+style): `ui.text_area(id!(), …)`. Less boilerplate, but reintroduces hidden state,
+identity, and lifetime questions — the things this redesign exists to remove.
+
+The `Arc<Mutex<TextArea>>` in Atuin's InputBox is the case study: whichever candidate
+makes that component honest *and* short wins.
+
+### Engine contract
+
+What Phase 2 extracts, shaped by what the new layer needs — note how small it is:
+
+```rust
+pub struct Engine { /* cursor, emitted_rows, terminal_height, prev tail frame */ }
+
+impl Engine {
+    pub fn new(width: u16, terminal_height: u16) -> Self;
+    /// Append final rows above the tail; they flow into scrollback. Immutable after.
+    pub fn commit(&mut self, rows: &Buffer) -> Vec<u8>;
+    /// Replace the live tail. Diffs against the previous tail frame.
+    pub fn present(&mut self, tail: &Buffer) -> Vec<u8>;
+    pub fn resize(&mut self, width: u16) -> Vec<u8>;
+    /// Full repaint of the tail region; recovery from cursor-state drift.
+    pub fn resync(&mut self) -> Vec<u8>;
+    /// Reclaim trailing blanks, park cursor for shell handoff.
+    pub fn finalize(&mut self) -> Vec<u8>;
+}
+```
+
+Sync, no runtime dependency, bytes out (caller writes them). All the hard-won v1 behavior
+lives behind `commit`/`present`: burst-row streaming into scrollback, `retain_visible`,
+DEC 2026 sync output, relative-only cursor movement, SGR diffing. The VTE `TestTerminal`
+moves with it and becomes a public testing story.
+
+Semantic simplification vs v1: committed rows are immutable immediately (like printed
+output). On width resize only the tail reflows; committed content behaves like any other
+scrollback text. (v1 re-wraps still-visible frozen content; see O3.)
+
+### Runtime
+
+```rust
+let outcome = eye_declare::run(model, RunOptions {
+    keyboard: KeyboardProtocol::Enhanced,
+    bracketed_paste: true,
+    ctrl_c: CtrlC::Deliver,
+    // …
+}).await?;   // tokio driver; core stays sync/runtime-agnostic
+```
+
+Loop shape: wait on (terminal events → keymap/focused element → Msg) ∪ (task/stream
+messages) ∪ (subscription ticks) ∪ (animation tick when tail has animated widgets) →
+`update` → render any pushed blocks → `engine.commit` → build tail → measure → render →
+`engine.present`. No dirty tracking anywhere: identical tails diff to zero bytes, and the
+tail is small enough that rebuilding it every frame is noise.
+
+## Design rules (day one, non-negotiable)
+
+- **No dirty tracking.** Rerendering the tail must be unconditionally cheap; that is an
+  invariant to preserve, not an optimization to add.
+- **Honest measurement.** `height(width)` is part of the Element contract; ship wrapping
+  helpers that make it one line for text. No probe rendering.
+- **Grapheme-correct text.** `unicode-segmentation` alongside `unicode-width` from the
+  first line of the text stack.
+- **Runtime-agnostic core.** Engine and element layers are sync; tokio is one driver.
+- **Ratatui interop is first-class.** Wrapping a `StatefulWidget` (tui-textarea) must be
+  a small, honest adapter — measure + render + `&mut` state access, no `'static` closures.
+- **Markdown:** pulldown-cmark behind a feature flag, or nothing. No hand-rolled parser.
+- **The engine's test terminal ships** as a public snapshot-testing API.
+
+## Phase 1: bake-off protocol
+
+Compile-only spike in a scratch crate (`crates/spike/`, never published, allowed to be
+ugly). `cargo check` is the bar; no runtime needed.
+
+1. Port Atuin AI's `agent_turn_view` and the file-edit diff view
+   (`~/src/atuin/crates/atuin-ai/src/tui/view/mod.rs`) to pure fluent builders. Record
+   every place the builder form reads worse than the `element!` original — that list
+   defines what macro sugar must do, or shows none is needed.
+2. Port `InputBox` (`tui/components/input_box.rs`) twice: Candidate A and Candidate B.
+   Same behavior, side by side, including the tui-textarea wrapping and submit/slash
+   handling.
+3. Sketch the Atuin driver loop (`update`/`Msg`/`push`/`spawn`) far enough to confirm
+   `DriverEventSender`, `sync_view_state`, and the key-parsing `on_commit` all disappear.
+
+**Exit criteria:** chosen DSL shape (+ macro sugar list, possibly empty), chosen widget-
+state model, validated keymap dispatch order, and a written list of everything the engine
+must expose — which parameterizes the Phase 2 extraction.
+
+## Open questions
+
+- **O1 — widget state:** strict Elm (A) vs framework-managed (B). Lean: A. Decide by
+  bake-off, not taste.
+- **O2 — keymap dispatch order:** is override→element→scoped→global right? Validate
+  against: Ctrl+C during tool execution, Tab in editor vs Tab-to-insert, Esc layering.
+- **O3 — resize semantics:** committed-is-immutable means still-visible sealed blocks
+  don't re-wrap on width change (v1 re-wraps them). Acceptable? (Matches plain-println
+  behavior; massive simplification.)
+- **O4 — naming:** working names `eye_declare_engine` / `eye_declare_next`; real names
+  (and whether v2 is `eye_declare 1.0` or a rename) decided at the end.
+- **O5 — `on_key`/message emission shape** on Element: `Option<Msg>` return vs handler
+  closures vs event→Msg mapping combinators. Bake-off decides.
+- **O6 — mid-tail block sealing:** a turn that finishes while a later spinner exists —
+  does `push` suffice (tail reorders freely each frame) or do we need `push_before`?
+  Suspect `push` suffices; confirm in the driver-loop sketch.
+
+## Phases
+
+1. **Spec** — this document; argue until stable.
+2. **Bake-off** — protocol above; throwaway code, keeper decisions.
+3. **Engine extraction** — `inline`/`frame`/`escape`/`wrap` + `TestTerminal` →
+   engine crate with the contract above; pure-refactor PRs; v1 tests keep passing.
+4. **Build the new layer** — new crate, driven by ports of the current `examples/`.
+5. **Atuin AI port** — the validation gate. Success = the four adapters
+   (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus
+   shadow) delete cleanly and the TUI code shrinks.
+6. **Ship** — naming, docs, migration story for v1 users, decide v1's fate.
+
+## Non-goals
+
+- Full-screen / alternate-screen mode. Inline only; ratatui already serves full-screen.
+- General tree reconciliation, keys, or preserved-by-position component state.
+- Vertical flex layout. Content-driven height is correct for unbounded scrollback.
+- Supporting the v1 `Component`/hooks API on the new core. v1 stays frozen as-is.
+
+## What carries over unchanged
+
+The scrollback engine's behavior and its VTE test harness; content-driven layout
+(`Fixed`/`Fill` horizontal, natural vertical); the widget vocabulary (Text, Spinner,
+Viewport, borders/padding); the documentation discipline; the name.

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -1,6 +1,8 @@
 # eye-declare v2: Timeline Architecture
 
-**Status:** Draft for teardown — nothing here is final until the Phase 1 bake-off validates it.
+**Status:** Phase 1 (bake-off) complete — 2026-07-14. Verdicts merged below;
+evidence in `crates/spike/FINDINGS.md`, candidate API in `crates/spike/src/ui.rs`.
+Next: Phase 2, engine extraction.
 **Context:** `.binarymuse/library-redesign.md` (assessment, Atuin AI evidence, hazard list).
 **Decisions already made:** new unpublished crate in this workspace; bake-off before engine extraction; current `eye_declare` API fully frozen.
 
@@ -214,7 +216,8 @@ impl Engine {
     /// Append final rows above the tail; they flow into scrollback. Immutable after.
     pub fn commit(&mut self, rows: &Buffer) -> Vec<u8>;
     /// Replace the live tail. Diffs against the previous tail frame.
-    pub fn present(&mut self, tail: &Buffer) -> Vec<u8>;
+    /// `cursor` is the focused element's hardware-cursor hint.
+    pub fn present(&mut self, tail: &Buffer, cursor: Option<(u16, u16)>) -> Vec<u8>;
     pub fn resize(&mut self, width: u16) -> Vec<u8>;
     /// Full repaint of the tail region; recovery from cursor-state drift.
     pub fn resync(&mut self) -> Vec<u8>;
@@ -284,27 +287,61 @@ must expose — which parameterizes the Phase 2 extraction.
 
 ## Open questions
 
-- **O1 — widget state:** strict Elm (A) vs framework-managed (B). Lean: A. Decide by
-  bake-off, not taste.
-- **O2 — keymap dispatch order:** is override→element→scoped→global right? Validate
-  against: Ctrl+C during tool execution, Tab in editor vs Tab-to-insert, Esc layering.
+Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
+
+- **O1 — widget state: RESOLVED → strict Elm** (controlled components).
+  State is a plain model value, views borrow it, policy is keymap data.
+  Framework-managed state reintroduced the `InputUpdated` echo, callback
+  props, and leaked the store into `Element::height`. Possible later
+  carve-out: an opt-in store for ephemeral view state the app never reads
+  (scroll offsets) — uncontrolled components, explicitly second-class.
+- **O2 — keymap dispatch: RESOLVED, simplified** →
+  override → focus-scoped → global → focus-fallthrough, first match in
+  declaration order. The "focused element's own editing keys" layer proved
+  unnecessary: editing reaches the widget as fallthrough messages
+  (`Msg::Edit(ev)` → `state.handle(ev)` in update).
+- **O5 — element-level emission: RESOLVED → none needed.** Every ported
+  behavior routed through the keymap. See O7.
+- **O6 — sealing: RESOLVED → `push` suffices.** A sealed turn lands above
+  the tail while the input box keeps rendering below; no `push_before`.
+
+Still open:
+
 - **O3 — resize semantics:** committed-is-immutable means still-visible sealed blocks
   don't re-wrap on width change (v1 re-wraps them). Acceptable? (Matches plain-println
   behavior; massive simplification.)
 - **O4 — naming:** working names `eye_declare_engine` / `eye_declare_next`; real names
   (and whether v2 is `eye_declare 1.0` or a rename) decided at the end.
-- **O5 — `on_key`/message emission shape** on Element: `Option<Msg>` return vs handler
-  closures vs event→Msg mapping combinators. Bake-off decides.
-- **O6 — mid-tail block sealing:** a turn that finishes while a later spinner exists —
-  does `push` suffice (tail reorders freely each frame) or do we need `push_before`?
-  Suspect `push` suffices; confirm in the driver-loop sketch.
+- **O7 — is `Element<Msg>` vestigial? (new, from Port 4.)** With keymap-only
+  emission, nothing on `Element` carries `Msg`; `map_msg` is a phantom
+  re-wrap. A `Msg`-free `Element` would dissolve the `ElementExt`/`Fluent`
+  trait split and all `Msg`-inference concerns. Counterpoint: element-level
+  `on_click` might want it back for mouse support (alternative: runtime
+  hit-testing routed through focus/keymap). Lean: build `Msg`-free first.
+
+## Bake-off outcomes (Phase 1 exit criteria)
+
+- **DSL: fluent builders, no macro.** Won every case including the diff
+  view's stateful line numbering, where `element!` needed an escape-block
+  workaround. Keys and identity props deleted throughout. If sugar is ever
+  added, it targets `.any()` density and multi-span text — method-level
+  polish, not a parser.
+- **API rules:** combinators live on a `Msg`-free trait; `&data -> impl
+  Element` helpers need `+ use<>` (or a boxed-return house style);
+  `AnyElement<'a, Msg>` carries a lifetime so views borrow the model;
+  `Element` exposes `cursor()`; `Engine::present` takes the cursor hint:
+  `present(tail: &Buffer, cursor: Option<(u16, u16)>)`.
+- **Composition pattern:** sub-model messages embed by enum; `Keymap::map`
+  and element `map_msg` re-target them; parents claim child messages by
+  pattern matching (no OutMsg machinery).
 
 ## Phases
 
-1. **Spec** — this document; argue until stable.
-2. **Bake-off** — protocol above; throwaway code, keeper decisions.
+1. **Spec** — this document; argue until stable. ✅
+2. **Bake-off** — protocol above; throwaway code, keeper decisions. ✅ (2026-07-14)
 3. **Engine extraction** — `inline`/`frame`/`escape`/`wrap` + `TestTerminal` →
    engine crate with the contract above; pure-refactor PRs; v1 tests keep passing.
+   **← next**
 4. **Build the new layer** — new crate, driven by ports of the current `examples/`.
 5. **Atuin AI port** — the validation gate. Success = the four adapters
    (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spike"
+version = "0.0.0"
+dependencies = [
+ "ratatui-core",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ name = "spike"
 version = "0.0.0"
 dependencies = [
  "crossterm",
+ "futures",
  "ratatui-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "spike"
 version = "0.0.0"
 dependencies = [
+ "crossterm",
  "ratatui-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "3"
 members = [
     "crates/eye_declare",
     "crates/eye_declare_macros",
+    "crates/spike",
 ]

--- a/crates/spike/Cargo.toml
+++ b/crates/spike/Cargo.toml
@@ -7,4 +7,5 @@ description = "Compile-only bake-off spike for the v2 DSL. Never published. See 
 
 [dependencies]
 crossterm = "0.29"
+futures = "0.3"
 ratatui-core = "0.1"

--- a/crates/spike/Cargo.toml
+++ b/crates/spike/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 description = "Compile-only bake-off spike for the v2 DSL. Never published. See .planning/REDESIGN.md."
 
 [dependencies]
+crossterm = "0.29"
 ratatui-core = "0.1"

--- a/crates/spike/Cargo.toml
+++ b/crates/spike/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "spike"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Compile-only bake-off spike for the v2 DSL. Never published. See .planning/REDESIGN.md."
+
+[dependencies]
+ratatui-core = "0.1"

--- a/crates/spike/FINDINGS.md
+++ b/crates/spike/FINDINGS.md
@@ -150,4 +150,85 @@ app to either mirror it (the echo) or query the store (breaking view purity).
   needs documented precedence (first-match-wins in declaration order is the
   obvious rule).
 
-## Port 4: driver-loop sketch (`update`/`push`/`spawn`) — TODO
+## Port 4: driver-loop sketch (`update`/`push`/`spawn`)
+
+Source: the *shape* of `driver.rs` (1,088 lines) + `commands/inline.rs`'s
+channel/thread scaffolding → `src/ports/driver.rs` (~230 lines, honest
+caveat: the sketch omits session persistence, permissions, and real SSE —
+the claim is that the *adapters* died, not the business logic).
+
+### The four adapters, checked off
+
+- **`DriverEventSender`** — gone. Messages go straight to `update`;
+  sub-models compose by enum embedding (`AppMsg::Input(input_box_a::Msg)`)
+  plus `Keymap::map` / `map_msg`. Parent policy over child messages is
+  plain pattern matching (parent claims `Submit`, delegates the rest) — no
+  OutMsg machinery needed.
+- **`sync_view_state`** — gone, structurally. There is no `ViewState` to
+  clone the FSM into: the model holds only the live turn (5 fields vs 18,
+  no `all_events`/`visible_events`/`archived_events`/`turns` clones per
+  event, no `committed_turn_count` filtering per frame). The driver-thread
+  turn pre-computation is unnecessary because per-frame work is bounded by
+  the live turn, not conversation length.
+- **`on_commit` key parsing** — gone. Sealing a turn is
+  `ctx.push(agent_turn_view(&events, ..)); self.streaming = None;` — the
+  turn leaves the model at push time; there is nothing to prune later.
+- **The `spawn_blocking` driver thread + `mpsc` bridge** — gone; the
+  runtime's loop delivers stream items as messages.
+
+Bonus deletions: the `usize::MAX` sentinel pending-turn (the tail composes
+a spinner), and `CancelGeneration` plumbing — Esc/Ctrl+C-while-busy is
+`self.streaming = None` (cancel-on-drop `Task`), four lines of `update`.
+
+### O6: resolved — `push` suffices
+
+Sealing pushes the completed turn *above* the tail while the input box keeps
+rendering *in* the tail below it — exactly the visual order the app wants,
+with no `push_before` or ordering primitive. The streaming turn lives in the
+tail until sealed; its committed position is where the tail was.
+
+### New design fork discovered (→ spec as O7)
+
+`map_msg` compiled as a **pure phantom re-wrap** — nothing on `Element`
+actually carries `Msg` in the strict-Elm candidate, because all message
+emission lives in the keymap (bindings + fallthrough). The `Msg` parameter
+on `Element` is currently vestigial. Dropping it would dissolve the
+`ElementExt<Msg>`/`Fluent` split from Port 1 and every `Msg`-inference
+concern. Counterpoint: element-level emission may return with mouse support
+(`on_click`) — though runtime hit-testing → `FocusHandle`/keymap routing is
+a plausible alternative there too. Lean: try a `Msg`-free `Element` first.
+
+### Engine contract addendum
+
+`Element::cursor` (from Port 3) has to reach the terminal:
+`Engine::present` needs a cursor-position parameter (or sibling call) —
+`present(tail: &Buffer, cursor: Option<(u16, u16)>)`. Update the spec.
+
+---
+
+# Bake-off verdict (exit criteria from REDESIGN.md Phase 1)
+
+1. **DSL: fluent builders, no macro.** Builders won every case including
+   the hardest (Port 2's stateful diff numbering, where the macro needed an
+   escape-block workaround). Keys/identity deleted throughout. Sugar
+   candidates if ever wanted — `.any()` density, multi-span text — are
+   method-level polish, not grounds for a parser.
+2. **Widget state (O1): strict Elm** — controlled components. State lives
+   in the model as plain values; views borrow it; policy is keymap data.
+   Framework-managed state reintroduced the `InputUpdated` echo, callback
+   props, and a store-leak into `Element::height`. Possible future
+   carve-out: a B-style store for ephemeral view state the app never reads
+   (scroll offsets) — uncontrolled components, explicitly opt-in.
+3. **Event emission (O5): keymap-only.** No element-level key handlers were
+   needed for any ported behavior; dispatch simplifies to
+   override → focus-scoped → global → focus-fallthrough, first match in
+   declaration order wins. (Whether `Element` keeps its `Msg` parameter at
+   all is O7.)
+4. **Block lifecycle (O6): `push` alone suffices.**
+5. **API rules for the real implementation:** (1) combinators live on a
+   `Msg`-free trait; (2) `&data -> impl Element` helpers need `+ use<>` or
+   a boxed-return house style; (3) `AnyElement` carries a lifetime so views
+   borrow the model; (4) `Element` exposes `cursor()`; (5) `Engine::present`
+   takes the cursor hint.
+6. **What the engine must expose** (unchanged from the spec otherwise):
+   `commit(rows)`, `present(tail, cursor)`, `resize`, `resync`, `finalize`.

--- a/crates/spike/FINDINGS.md
+++ b/crates/spike/FINDINGS.md
@@ -100,6 +100,54 @@ friction.
 - None new. `.any()` density unchanged from Port 1; format-string gutter
   alignment identical to the original.
 
-## Port 3: InputBox ×2 (widget state candidates) — TODO
+## Port 3: InputBox ×2 — the widget-state decision (O1)
+
+Source: `components/input_box.rs` + the Tab policy from `components/atuin_ai.rs`
+→ `src/ports/input_box_a.rs` (strict Elm) and `input_box_b.rs`
+(framework-managed, egui-Memory style). Both cover submit, Shift+Enter/Ctrl+J
+newline, Tab slash-accept, Tab insert-command, paste, and focus-driven visuals.
+
+### Preliminary verdict: **Candidate A (strict Elm), decisively.**
+
+Every pathology in the original maps to a structural fix in A and survives —
+or returns — in B:
+
+| Original pathology | A (state in model) | B (framework store) |
+|---|---|---|
+| `Arc<Mutex<TextArea>>` | plain model value, view borrows | store + `Any` downcasts |
+| `InputUpdated` echo per keystroke | **deleted** — `is_blank`/slash results are derived reads | **reintroduced verbatim** (`input_text` mirror + `on_change`) |
+| `tx` context plumbing | handlers are messages | `Box<dyn Fn>` callback props return (`on_submit`, `on_change`, `intercept_key`) |
+| `active` prop shadowing focus | `FocusHandle::is_focused()` | same fix available |
+| Tab spread across 3 dispatch layers | conditional keymap data, one place, rebuilt per update | config flags + escape hatches; slash-accept **hit a wall** — `intercept_key` can read widget text but can't write it (needs yet another read-write hook); A does it in 3 lines of `update` |
+| widget measurement | `height()` reads borrowed state | `height()` needs store access — the managed model leaks into the core `Element` trait |
+
+Fair credit to B: it's the right shape for ephemeral *view* state the app
+genuinely never reads (scroll offsets, hover, spinner phase), and it avoids
+A's per-widget routing arm (`Msg::Edit`). Worth revisiting a store for
+Viewport-style scroll later — but text input is app data, and B forces the
+app to either mirror it (the echo) or query the store (breaking view purity).
+
+### API design rules learned (bind for v2)
+
+3. **`AnyElement` must carry a lifetime.** A strict-Elm text area renders
+   from `&TextAreaState` in the model; the previous implicit `'static` was
+   an artifact of Ports 1–2 cloning small strings. Now
+   `AnyElement<'a, Msg> = Box<dyn Element<Msg> + 'a>`, `ElementExt::any`
+   generic over `'a` with `Self: 'a`. The tail is built/rendered/dropped in
+   one frame, so model borrows are naturally scoped. Old ports annotate
+   `'static` and needed no other changes.
+4. **The blanket `Fluent` impl paid off**: `Keymap` got `.when(cond, ...)`
+   conditional bindings for free — conditional Tab policy is one combinator.
+5. **`Element` grew `fn cursor(&self, area) -> Option<(u16, u16)>`** — the
+   focused-cursor runtime contract, settled naturally by this port.
+
+### Open points for the real implementation
+
+- `Keymap` stores `Msg` values, so `Msg: Clone` (hence the `EditEvent`
+  wrapper for the raw-event variant). Alternative: store `Fn() -> Msg`
+  constructors. Decide with the runtime.
+- Two conditional Tab bindings can theoretically both be active; keymap
+  needs documented precedence (first-match-wins in declaration order is the
+  obvious rule).
 
 ## Port 4: driver-loop sketch (`update`/`push`/`spawn`) — TODO

--- a/crates/spike/FINDINGS.md
+++ b/crates/spike/FINDINGS.md
@@ -66,7 +66,39 @@ completed turns are *pushed blocks* and only the active turn renders in the
 tail — the block lifecycle is Port 4's (driver sketch) job. This port only
 validates the DSL shape.
 
-## Port 2: file-edit diff view — TODO
+## Port 2: `file_edit_tool_view` / `file_write_tool_view` (nesting stress test)
+
+Source: view/mod.rs lines ~640–830 → `src/ports/file_edit.rs`. Compiled first
+try; the Port 1 design rules (Msg-free `Fluent`, `+ use<>`) held with no new
+friction.
+
+### Wins
+
+- **The escape-block workaround dissolved — the headline finding.** The
+  original's diff body is `#(for ...)` wrapping `#({ ... })` which
+  pre-collects `lines_rendered: Vec<(idx, prefix, text, style, gutter_text,
+  gutter_style)>`, because the macro's `#(for)` cannot thread the mutable
+  `before_pos`/`after_pos` line counters through iteration. In builder form
+  the counters mutate inside an ordinary `FnMut` closure in
+  `.children(hunk.lines.iter().map(...))` — the intermediate `Vec`, the
+  6-tuple, and both levels of `#()` ceremony are gone. The gnarliest view
+  code in atuin-ai became unremarkable Rust. This was the case the bake-off
+  most needed to test, and builders won it outright.
+- **The 6-tuple was partly macro-induced:** `gutter_style` was always equal
+  to the line style; the pair collapses to one once you're in plain code.
+- **Cross-view dedup became natural.** Edit and write views each carried a
+  near-identical ~25-line pending/success/error status match; extracting
+  `tool_status_line` was trivial because elements are just values. (Possible
+  with `Elements` too, but the original didn't — block-macro syntax seems to
+  discourage small extractions.)
+- **Two more `key: &str` parameters** and ~6 `key:` props deleted.
+- Guard clauses (`let Some(preview) else return status_line`) carry over
+  verbatim — parity, since the original also used early returns.
+
+### Costs
+
+- None new. `.any()` density unchanged from Port 1; format-string gutter
+  alignment identical to the original.
 
 ## Port 3: InputBox ×2 (widget state candidates) — TODO
 

--- a/crates/spike/FINDINGS.md
+++ b/crates/spike/FINDINGS.md
@@ -1,0 +1,73 @@
+# Bake-off findings
+
+Running log, one section per port. Verdicts go in `.planning/REDESIGN.md` once
+all ports land.
+
+## Port 1: `agent_turn_view` (pure builders, display-only)
+
+Source: `~/src/atuin/crates/atuin-ai/src/tui/view/mod.rs` → `src/ports/agent_turn.rs`.
+Overall length is rough parity with the `element!` original (rustfmt expands
+method chains about as much as the macro's nesting). The wins are structural,
+not line count.
+
+### Wins
+
+- **Keys deleted wholesale.** ~11 `key:` props and the `turn_id` parameter
+  (which existed only to build key strings) have no equivalent — reconciliation-
+  free rendering makes element identity meaningless. This includes the
+  `on_commit` key-parsing contract keys were load-bearing for.
+- **Native control flow.** `match`, `if let`, early returns, and iterator
+  chains replace the `#(...)` grammar. `shell_tool_view`'s `Option<&ToolPreview>`
+  handling reads better as a plain `match` than the original's `#(if let ... } else {`.
+- **`group_row_view` collapsed**: three nested `View(width: ...)` wrappers in
+  an `HStack` became `row().fixed(2, ..).fixed(2, ..).fill(..)`.
+- **Padding-only `View` wrappers** became `.pad_left(n)` on the child.
+- **`.when_some()`** replaces the original's `#(if cond && x.is_some())` guard
+  + `x.unwrap()` in the body (twice in `suggested_command_view`).
+- **Plain Rust tooling.** Every error hit while porting was an ordinary rustc
+  diagnostic pointing at the real line; rust-analyzer completes everything.
+
+### Costs
+
+- **`.any()` density is the #1 noise source.** Every heterogeneous match arm
+  and every `El`-returning helper ends in `.any()` (~15 in this port). Same tax
+  as GPUI's `.into_any_element()`. Tolerable; would be the first target if we
+  add any sugar.
+- **Match-in-children needs a named helper** (`event_view`) or immediate
+  closure — the macro allowed `#(match ...)` inline. Arguably better factoring,
+  but it is extra ceremony the original didn't have.
+- **Multi-span text is the weakest leaf API.** `text(a).style(s1).span(b, s2)`
+  works, but `.style()` mutating "the most recent span" is subtle, and the
+  conditional trailing span in `history_search_row` needed `.when()` on `Text`
+  plus a `.span(" ", Style::default())` spacer. Wants design attention
+  (`span_unstyled`, tuple-list constructor, or a tiny `spans![]` macro).
+
+### API design rules learned (bind for v2)
+
+1. **Combinators must live on a `Msg`-free trait.** Display-only elements
+   implement `Element<Msg>` for *every* `Msg`; a combinator on an
+   `ElementExt<Msg>` trait whose signature doesn't mention `Msg`
+   (`pad_left(self) -> Padded<Self>`) is uninferrable on such receivers
+   (E0282). Hence the `Fluent` (Msg-free) / `ElementExt<Msg>` (only `any()`,
+   which names `Msg` in its return type) split in `ui.rs`. Rule: a method may
+   be `Msg`-parameterized only if `Msg` appears in its argument or return
+   types.
+2. **Edition-2024 implicit capture bites every `&data -> impl Element` helper.**
+   Returning `impl Element<Msg>` from a function taking references captures
+   those lifetimes, so `.any()` (needing `'static`) fails with E0521 even when
+   the returned value is fully owned. Fix is `-> impl Element<Msg> + use<>`.
+   Recurring paper cut; v2 docs must establish a house style (probably: helpers
+   return `AnyElement<Msg>` and eat the box, or always `+ use<>`).
+
+### Not yet validated here
+
+This port keeps `agent_turn_view` as a view function. In the real v2 model,
+completed turns are *pushed blocks* and only the active turn renders in the
+tail — the block lifecycle is Port 4's (driver sketch) job. This port only
+validates the DSL shape.
+
+## Port 2: file-edit diff view — TODO
+
+## Port 3: InputBox ×2 (widget state candidates) — TODO
+
+## Port 4: driver-loop sketch (`update`/`push`/`spawn`) — TODO

--- a/crates/spike/src/fixtures.rs
+++ b/crates/spike/src/fixtures.rs
@@ -1,0 +1,141 @@
+//! Simplified copies of the atuin-ai data types the ported views consume.
+//! Shapes mirror `~/src/atuin/crates/atuin-ai/src/tui/view/turn.rs` closely
+//! enough to preserve the control flow the views exercise (nested matches,
+//! optional previews, grouped calls). Field-level fidelity is not the point.
+
+use std::path::PathBuf;
+
+pub enum UiEvent {
+    Text { content: String },
+    ToolSummary(ToolSummary),
+    SuggestedCommand(SuggestedCommandDetails),
+    ToolCall(ToolCallDetails),
+    ToolGroup(ToolGroup),
+    Other,
+}
+
+pub struct ToolSummary {
+    pub label: String,
+    pub pending: usize,
+}
+
+impl ToolSummary {
+    pub fn summary(&self) -> String {
+        self.label.clone()
+    }
+
+    pub fn any_pending(&self) -> bool {
+        self.pending > 0
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ToolResultStatus {
+    Pending,
+    Success,
+    Error,
+}
+
+pub struct ToolCallDetails {
+    pub tool_use_id: String,
+    pub name: String,
+    pub status: ToolResultStatus,
+    pub render_data: ToolRenderData,
+}
+
+pub enum ToolRenderData {
+    Shell {
+        command: String,
+        preview: Option<ToolPreview>,
+    },
+    FileEdit {
+        path: PathBuf,
+    },
+    FileWrite {
+        path: PathBuf,
+    },
+    Remote,
+    FileRead {
+        path: PathBuf,
+    },
+    HistorySearch {
+        query: String,
+        filter_modes: Vec<HistorySearchFilterMode>,
+    },
+    SkillLoad,
+}
+
+#[derive(Clone)]
+pub struct ToolPreview {
+    pub lines: Vec<String>,
+    pub exit_code: Option<i32>,
+    pub interrupted: Option<InterruptReason>,
+}
+
+#[derive(Clone)]
+pub enum InterruptReason {
+    User,
+    Timeout(u64),
+}
+
+pub enum HistorySearchFilterMode {
+    Global,
+    Host,
+    Session,
+    Directory,
+    Workspace,
+}
+
+pub struct ToolGroup {
+    pub kind: ToolGroupKind,
+    pub calls: Vec<ToolCallDetails>,
+}
+
+impl ToolGroup {
+    pub fn any_pending(&self) -> bool {
+        self.calls
+            .iter()
+            .any(|c| c.status == ToolResultStatus::Pending)
+    }
+}
+
+pub enum ToolGroupKind {
+    FileRead,
+    HistorySearch,
+}
+
+pub enum DangerLevel {
+    High(Option<String>),
+    Medium(Option<String>),
+    Low(Option<String>),
+    Unknown(Option<String>),
+}
+
+impl DangerLevel {
+    pub fn notes(&self) -> Option<&str> {
+        match self {
+            Self::High(n) | Self::Medium(n) | Self::Low(n) | Self::Unknown(n) => n.as_deref(),
+        }
+    }
+}
+
+pub enum ConfidenceLevel {
+    High(Option<String>),
+    Medium(Option<String>),
+    Low(Option<String>),
+    Unknown(Option<String>),
+}
+
+impl ConfidenceLevel {
+    pub fn notes(&self) -> Option<&str> {
+        match self {
+            Self::High(n) | Self::Medium(n) | Self::Low(n) | Self::Unknown(n) => n.as_deref(),
+        }
+    }
+}
+
+pub struct SuggestedCommandDetails {
+    pub command: String,
+    pub danger_level: DangerLevel,
+    pub confidence_level: ConfidenceLevel,
+}

--- a/crates/spike/src/fixtures.rs
+++ b/crates/spike/src/fixtures.rs
@@ -50,9 +50,11 @@ pub enum ToolRenderData {
     },
     FileEdit {
         path: PathBuf,
+        preview: Option<EditPreview>,
     },
     FileWrite {
         path: PathBuf,
+        preview: Option<WritePreview>,
     },
     Remote,
     FileRead {
@@ -102,6 +104,44 @@ impl ToolGroup {
 pub enum ToolGroupKind {
     FileRead,
     HistorySearch,
+}
+
+pub enum DiffLine {
+    Context(String),
+    Removed(String),
+    Added(String),
+}
+
+pub struct DiffHunk {
+    pub before_start: usize,
+    pub after_start: usize,
+    pub lines: Vec<DiffLine>,
+}
+
+pub struct EditPreview {
+    pub hunks: Vec<DiffHunk>,
+}
+
+impl EditPreview {
+    /// Highest line number the diff will display, for gutter sizing.
+    pub fn max_line_number(&self) -> usize {
+        self.hunks
+            .iter()
+            .map(|h| h.before_start.max(h.after_start) + h.lines.len())
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+pub struct WritePreview {
+    pub lines: Vec<String>,
+    pub total_lines: usize,
+}
+
+impl WritePreview {
+    pub fn remaining_lines(&self) -> usize {
+        self.total_lines.saturating_sub(self.lines.len())
+    }
 }
 
 pub enum DangerLevel {

--- a/crates/spike/src/lib.rs
+++ b/crates/spike/src/lib.rs
@@ -1,0 +1,12 @@
+//! Compile-only bake-off spike for the eye-declare v2 DSL.
+//!
+//! Phase 1 of `.planning/REDESIGN.md`. This crate exists to test the *call-site
+//! shape* of the candidate API against real views ported from Atuin AI
+//! (`~/src/atuin/crates/atuin-ai/src/tui/`). Nothing here renders; `cargo check`
+//! is the bar. Ergonomics findings accumulate in `FINDINGS.md`.
+
+#![allow(dead_code)]
+
+pub mod fixtures;
+pub mod ports;
+pub mod ui;

--- a/crates/spike/src/ports/agent_turn.rs
+++ b/crates/spike/src/ports/agent_turn.rs
@@ -59,8 +59,9 @@ pub fn agent_turn_view(
 
 /// The per-event dispatch that was a `#(match ...)` block inline in the
 /// original. Native `match` needs a named function (or an immediate closure)
-/// plus `.any()` per arm to unify types.
-fn event_view(event: &UiEvent) -> El {
+/// plus `.any()` per arm to unify types. `pub(crate)`: Port 4's live-turn
+/// tail reuses it.
+pub(crate) fn event_view(event: &UiEvent) -> El {
     match event {
         UiEvent::Text { content } => markdown(content.clone()).pad_left(2).any(),
         UiEvent::ToolSummary(summary) => tool_summary_view(summary).any(),

--- a/crates/spike/src/ports/agent_turn.rs
+++ b/crates/spike/src/ports/agent_turn.rs
@@ -16,8 +16,10 @@ use crate::ui::*;
 /// Placeholder app message type. These views are display-only and never emit.
 pub enum Msg {}
 
-/// Type-erased element alias, for heterogeneous match arms.
-type El = AnyElement<Msg>;
+/// Type-erased element alias, for heterogeneous match arms. These views
+/// clone their strings, so `'static` is accurate here; borrowing views
+/// (Port 3) use the lifetime.
+type El = AnyElement<'static, Msg>;
 
 /// Max output lines shown for a shell command preview.
 const MAX_SHELL_PREVIEW_LINES: u16 = 5;

--- a/crates/spike/src/ports/agent_turn.rs
+++ b/crates/spike/src/ports/agent_turn.rs
@@ -74,11 +74,17 @@ fn tool_summary_view(summary: &ToolSummary) -> impl Element<Msg> + use<> {
 }
 
 fn tool_call_view(details: &ToolCallDetails) -> El {
+    use crate::ports::file_edit::{file_edit_tool_view, file_write_tool_view};
+
     match &details.render_data {
         ToolRenderData::Shell { command, preview } => shell_tool_view(command, preview.as_ref()),
         ToolRenderData::Remote => tool_status_view(&details.name, &details.status),
-        // Diff/write previews are Port 2 (file_edit_tool_view / file_write_tool_view).
-        ToolRenderData::FileEdit { .. } | ToolRenderData::FileWrite { .. } => empty().any(),
+        ToolRenderData::FileEdit { path, preview } => {
+            file_edit_tool_view(&details.status, path, preview.as_ref())
+        }
+        ToolRenderData::FileWrite { path, preview } => {
+            file_write_tool_view(&details.status, path, preview.as_ref())
+        }
         ToolRenderData::FileRead { .. }
         | ToolRenderData::HistorySearch { .. }
         | ToolRenderData::SkillLoad => empty().any(),

--- a/crates/spike/src/ports/agent_turn.rs
+++ b/crates/spike/src/ports/agent_turn.rs
@@ -1,0 +1,387 @@
+//! Port 1: `agent_turn_view` and its helpers, from
+//! `~/src/atuin/crates/atuin-ai/src/tui/view/mod.rs` (lines ~334–530 and
+//! ~805–930 at the time of porting). Faithful to the original's structure so
+//! the two read side-by-side; deliberate differences are called out in
+//! comments and logged in FINDINGS.md.
+//!
+//! Notable wholesale deletions vs the original: every `key:` prop (no
+//! reconciliation in v2, so element identity is meaningless) and the
+//! `turn_id` parameter that existed only to build keys.
+
+use ratatui_core::style::{Color, Modifier, Style};
+
+use crate::fixtures::*;
+use crate::ui::*;
+
+/// Placeholder app message type. These views are display-only and never emit.
+pub enum Msg {}
+
+/// Type-erased element alias, for heterogeneous match arms.
+type El = AnyElement<Msg>;
+
+/// Max output lines shown for a shell command preview.
+const MAX_SHELL_PREVIEW_LINES: u16 = 5;
+
+/// Max entries shown under a tool group header.
+const MAX_GROUP_ENTRIES: usize = 5;
+
+pub fn agent_turn_view(
+    events: &[UiEvent],
+    busy: bool,
+    showing_ui: bool,
+) -> impl Element<Msg> + use<> {
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+
+    col()
+        .child(text(" Atuin AI ").style(label_style.add_modifier(Modifier::REVERSED)))
+        .children(events.iter().enumerate().map(|(i, event)| {
+            col()
+                .when(i > 0, |c| c.child(text("")))
+                .child(event_view(event))
+        }))
+        .when(busy && !showing_ui, |c| {
+            c.child(
+                spinner("")
+                    .spinner_style(
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .pad_left(2)
+                    .pad_top(1),
+            )
+        })
+}
+
+/// The per-event dispatch that was a `#(match ...)` block inline in the
+/// original. Native `match` needs a named function (or an immediate closure)
+/// plus `.any()` per arm to unify types.
+fn event_view(event: &UiEvent) -> El {
+    match event {
+        UiEvent::Text { content } => markdown(content.clone()).pad_left(2).any(),
+        UiEvent::ToolSummary(summary) => tool_summary_view(summary).any(),
+        UiEvent::SuggestedCommand(details) => suggested_command_view(details).any(),
+        UiEvent::ToolCall(details) => tool_call_view(details).pad_left(2).any(),
+        UiEvent::ToolGroup(group) => group_view(group).pad_left(2).any(),
+        UiEvent::Other => empty().any(),
+    }
+}
+
+fn tool_summary_view(summary: &ToolSummary) -> impl Element<Msg> + use<> {
+    spinner(summary.summary()).done(!summary.any_pending())
+}
+
+fn tool_call_view(details: &ToolCallDetails) -> El {
+    match &details.render_data {
+        ToolRenderData::Shell { command, preview } => shell_tool_view(command, preview.as_ref()),
+        ToolRenderData::Remote => tool_status_view(&details.name, &details.status),
+        // Diff/write previews are Port 2 (file_edit_tool_view / file_write_tool_view).
+        ToolRenderData::FileEdit { .. } | ToolRenderData::FileWrite { .. } => empty().any(),
+        ToolRenderData::FileRead { .. }
+        | ToolRenderData::HistorySearch { .. }
+        | ToolRenderData::SkillLoad => empty().any(),
+    }
+}
+
+/// Status indicator for a non-preview tool call.
+fn tool_status_view(name: &str, status: &ToolResultStatus) -> El {
+    match status {
+        ToolResultStatus::Pending => spinner(format!("Running: {name}"))
+            .label_style(Style::default().fg(Color::Yellow))
+            .done(false)
+            .any(),
+        ToolResultStatus::Success => spinner(format!("Ran: {name}")).done(true).any(),
+        ToolResultStatus::Error => text("✗ ")
+            .style(Style::default().fg(Color::Red))
+            .span(format!("{name}: denied"), Style::default().fg(Color::Red))
+            .any(),
+    }
+}
+
+/// Shell command execution with live output viewport.
+fn shell_tool_view(command: &str, preview: Option<&ToolPreview>) -> El {
+    let done = preview.is_some_and(|p| p.exit_code.is_some() || p.interrupted.is_some());
+
+    match preview {
+        Some(preview) => col()
+            .child(
+                spinner(if done {
+                    format!("Ran: {command}")
+                } else {
+                    format!("Running: {command}")
+                })
+                .done(done)
+                .hide_checkmark(),
+            )
+            .child(
+                row().fixed(2, text("└ ")).fill(
+                    viewport(preview.lines.clone())
+                        .height((preview.lines.len() as u16).clamp(1, MAX_SHELL_PREVIEW_LINES))
+                        .style(Style::default().fg(Color::Gray))
+                        .wrap(false),
+                ),
+            )
+            .child(shell_tool_footer(preview, done))
+            .any(),
+        None => spinner(format!("Running: {command}"))
+            .label_style(Style::default().fg(Color::Yellow))
+            .done(false)
+            .any(),
+    }
+}
+
+fn shell_tool_footer(preview: &ToolPreview, done: bool) -> El {
+    if let Some(reason) = &preview.interrupted {
+        let label = match reason {
+            InterruptReason::User => "Interrupted".to_string(),
+            InterruptReason::Timeout(secs) => format!("Timed out ({secs}s)"),
+        };
+        return text(label)
+            .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+            .any();
+    }
+    if !done {
+        return text("[Ctrl+C] Interrupt")
+            .style(Style::default().fg(Color::DarkGray))
+            .any();
+    }
+    if let Some(code) = preview.exit_code {
+        let style = if code == 0 {
+            Style::default().fg(Color::Green)
+        } else {
+            Style::default().fg(Color::Red)
+        };
+        return text(format!("Exit code: {code}")).style(style).any();
+    }
+    empty().any()
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Tool groups
+// ───────────────────────────────────────────────────────────────────
+
+fn group_view(group: &ToolGroup) -> El {
+    match group.kind {
+        ToolGroupKind::FileRead => file_read_group_view(group).any(),
+        ToolGroupKind::HistorySearch => history_search_group_view(group).any(),
+    }
+}
+
+/// Tree-connector marker: `└ ` for the first visible row, spaces after.
+fn tree_marker(is_first: bool) -> &'static str {
+    if is_first { "└ " } else { "  " }
+}
+
+/// 2-char status marker column: ✓ / ✗ / blank.
+fn status_marker_view(status: &ToolResultStatus) -> El {
+    match status {
+        ToolResultStatus::Pending => text("  ").any(),
+        ToolResultStatus::Success => text("✓ ").style(Style::default().fg(Color::Green)).any(),
+        ToolResultStatus::Error => text("✗ ").style(Style::default().fg(Color::Red)).any(),
+    }
+}
+
+fn visible_group_calls(group: &ToolGroup) -> &[ToolCallDetails] {
+    let start = group.calls.len().saturating_sub(MAX_GROUP_ENTRIES);
+    &group.calls[start..]
+}
+
+/// One row in a grouped list: `[tree marker][status][content]`.
+///
+/// The original was an HStack with three `View(width: ...)` wrappers; the
+/// `Width` cell model collapses it to three calls.
+fn group_row_view(is_first: bool, status: &ToolResultStatus, content: El) -> El {
+    row()
+        .fixed(2, text(tree_marker(is_first)))
+        .fixed(2, status_marker_view(status))
+        .fill(content)
+        .any()
+}
+
+fn file_read_group_view(group: &ToolGroup) -> impl Element<Msg> + use<> {
+    let count = group.calls.len();
+    let label = if count == 1 {
+        "Read 1 file".to_string()
+    } else {
+        format!("Read {count} files")
+    };
+    let done = !group.any_pending();
+
+    col()
+        .child(spinner(label).done(done).hide_checkmark())
+        .children(
+            visible_group_calls(group)
+                .iter()
+                .enumerate()
+                .map(|(i, details)| file_read_row(i == 0, details)),
+        )
+}
+
+fn file_read_row(is_first: bool, details: &ToolCallDetails) -> El {
+    let path_str = match &details.render_data {
+        ToolRenderData::FileRead { path } => format_path_for_display(path),
+        _ => String::new(),
+    };
+
+    group_row_view(is_first, &details.status, text(path_str).any())
+}
+
+fn history_search_group_view(group: &ToolGroup) -> impl Element<Msg> + use<> {
+    let done = !group.any_pending();
+
+    col()
+        .child(
+            spinner("Searched Atuin history:")
+                .done(done)
+                .hide_checkmark(),
+        )
+        .children(
+            visible_group_calls(group)
+                .iter()
+                .enumerate()
+                .map(|(i, details)| history_search_row(i == 0, details)),
+        )
+}
+
+fn history_search_row(is_first: bool, details: &ToolCallDetails) -> El {
+    let (query, filter_modes) = match &details.render_data {
+        ToolRenderData::HistorySearch {
+            query,
+            filter_modes,
+        } => (query.as_str(), filter_modes.as_slice()),
+        _ => ("", [].as_slice()),
+    };
+
+    let filter_label = format_filter_modes(filter_modes);
+    let filter_style = Style::default().fg(Color::DarkGray);
+
+    let content = if query.trim().is_empty() {
+        text("recent commands")
+            .style(
+                Style::default()
+                    .fg(Color::Gray)
+                    .add_modifier(Modifier::ITALIC),
+            )
+            .when(!filter_label.is_empty(), |t| {
+                t.span(" ", Style::default())
+                    .span(&filter_label, filter_style)
+            })
+            .any()
+    } else {
+        text(query)
+            .when(!filter_label.is_empty(), |t| {
+                t.span(" ", Style::default())
+                    .span(&filter_label, filter_style)
+            })
+            .any()
+    };
+
+    group_row_view(is_first, &details.status, content)
+}
+
+fn filter_mode_label(mode: &HistorySearchFilterMode) -> &'static str {
+    match mode {
+        HistorySearchFilterMode::Global => "global",
+        HistorySearchFilterMode::Host => "host",
+        HistorySearchFilterMode::Session => "session",
+        HistorySearchFilterMode::Directory => "directory",
+        HistorySearchFilterMode::Workspace => "workspace",
+    }
+}
+
+fn format_filter_modes(modes: &[HistorySearchFilterMode]) -> String {
+    if modes.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<&'static str> = modes.iter().map(filter_mode_label).collect();
+    format!("({})", parts.join(", "))
+}
+
+/// Simplified vs the original (no cwd/home relativization) — path formatting
+/// is not what this port is testing.
+fn format_path_for_display(path: &std::path::Path) -> String {
+    path.display().to_string()
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Suggested command — the `.when()` stress test
+// ───────────────────────────────────────────────────────────────────
+
+fn suggested_command_view(details: &SuggestedCommandDetails) -> impl Element<Msg> + use<> {
+    let is_dangerous = matches!(
+        details.danger_level,
+        DangerLevel::High(_) | DangerLevel::Medium(_)
+    );
+    let danger_notes = details.danger_level.notes();
+    let danger_style = match details.danger_level {
+        DangerLevel::High(_) => Style::default().fg(Color::Red),
+        DangerLevel::Medium(_) => Style::default().fg(Color::Yellow),
+        DangerLevel::Low(_) | DangerLevel::Unknown(_) => Style::default().fg(Color::Green),
+    };
+    let danger_text = match details.danger_level {
+        DangerLevel::High(_) => "High",
+        DangerLevel::Medium(_) => "Medium",
+        DangerLevel::Low(_) => "Low",
+        DangerLevel::Unknown(_) => "Unknown",
+    };
+
+    let low_confidence = matches!(
+        details.confidence_level,
+        ConfidenceLevel::Low(_) | ConfidenceLevel::Medium(_)
+    );
+    let confidence_level = match details.confidence_level {
+        ConfidenceLevel::Low(_) => "Low",
+        ConfidenceLevel::Medium(_) => "Medium",
+        ConfidenceLevel::High(_) => "High",
+        ConfidenceLevel::Unknown(_) => "Unknown",
+    };
+    let confidence_notes = details.confidence_level.notes();
+
+    col()
+        .child(text("  Suggested command:").style(Style::default().fg(Color::Cyan)))
+        .child(
+            row()
+                .fixed(
+                    2,
+                    if is_dangerous || low_confidence {
+                        text("! ").style(Style::default().fg(Color::Yellow))
+                    } else {
+                        text("$ ").style(Style::default().fg(Color::Blue))
+                    },
+                )
+                .fill(text(details.command.clone()).style(Style::default().fg(Color::Green))),
+        )
+        .when(is_dangerous, |c| {
+            c.child(
+                text("Danger: ")
+                    .style(danger_style)
+                    .span(danger_text, danger_style.add_modifier(Modifier::BOLD))
+                    .pad_left(2),
+            )
+        })
+        // `.when_some()` replaces the original's `cond && x.is_some()` guard
+        // followed by `x.unwrap()` inside the body.
+        .when_some(
+            is_dangerous.then_some(danger_notes).flatten(),
+            |c, notes| c.child(row().fixed(2, text("└")).fill(markdown(notes)).pad_left(2)),
+        )
+        .when(low_confidence, |c| {
+            c.child(
+                text("Confidence: ")
+                    .style(Style::default().fg(Color::Blue))
+                    .span(
+                        confidence_level,
+                        Style::default()
+                            .fg(Color::Blue)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .pad_left(2),
+            )
+        })
+        .when_some(
+            low_confidence.then_some(confidence_notes).flatten(),
+            |c, notes| c.child(row().fixed(2, text("└")).fill(markdown(notes)).pad_left(2)),
+        )
+}

--- a/crates/spike/src/ports/driver.rs
+++ b/crates/spike/src/ports/driver.rs
@@ -1,0 +1,226 @@
+//! Port 4: the driver loop. What `driver.rs` (1,088 lines) +
+//! `commands/inline.rs`'s channel/thread scaffolding reduce to when the
+//! runtime is Elm-shaped and the timeline owns block lifecycle.
+//!
+//! Infrastructure from the original that has **no equivalent here**:
+//!
+//! - `DriverEventSender` + `with_context` smuggling — messages go straight
+//!   to `update`; sub-components compose by enum embedding + `Keymap::map`.
+//! - `sync_view_state` — there is no `ViewState` to clone the FSM into;
+//!   the model IS the state, and it holds only the *live* turn. The
+//!   original cloned `all_events` + `visible_events` + `archived_events` +
+//!   rebuilt `turns` on every FSM event, then filtered by
+//!   `committed_turn_count` per frame.
+//! - `on_commit` key-string parsing (`"turn-{id}"` → counter) — completed
+//!   turns leave the model at `ctx.push` time; there is nothing to prune.
+//! - The `spawn_blocking` driver thread + `std::sync::mpsc` bridge — the
+//!   runtime's own loop delivers messages.
+//! - The `usize::MAX` sentinel turn for the pending banner — the tail just
+//!   composes a spinner.
+//! - The driver-thread turn pre-computation ("so the render-thread view
+//!   function doesn't redo O(n) work every frame") — per-frame work is
+//!   bounded by the live turn, not conversation length, by construction.
+//!
+//! O6 check (does `push` suffice, or do we need `push_before`?): sealing a
+//! completed turn pushes it *above* the tail while the input box continues
+//! to render *in* the tail below — exactly the visual order the app wants.
+//! `push` suffices; no ordering primitive needed.
+
+use futures::StreamExt;
+
+use crate::fixtures::{ToolCallDetails, ToolRenderData, ToolResultStatus, UiEvent};
+use crate::ports::agent_turn;
+use crate::ports::input_box_a::{self, InputModel};
+use crate::ui::*;
+
+/// The app's message type. Sub-model messages embed by enum; stream events
+/// arrive from the spawned task.
+#[derive(Clone)]
+pub enum AppMsg {
+    Input(input_box_a::Msg),
+    Stream(StreamEvent),
+    CancelStream,
+}
+
+#[derive(Clone)]
+pub enum StreamEvent {
+    Delta(String),
+    ToolStarted { id: String, command: String },
+    ToolFinished { id: String, ok: bool },
+    Completed,
+    Failed(String),
+}
+
+/// What the app returns to the shell integration on exit.
+#[derive(Default)]
+pub enum ExitAction {
+    #[default]
+    Cancel,
+    Execute(String),
+    Insert(String),
+}
+
+/// The whole app model. Compare `driver.rs`'s `ViewState` (18 fields, most
+/// of them clones of FSM history): this holds only what is *live*.
+pub struct AtuinApp {
+    input: InputModel,
+    /// Events of the in-progress agent turn only. Completed turns are
+    /// pushed as blocks and leave the model.
+    active: Vec<UiEvent>,
+    /// Streaming text not yet committed to `active`.
+    current_response: String,
+    /// Cancel-on-drop handle for the running turn. Cancellation is
+    /// `self.streaming = None` — no CancelGeneration plumbing, no atomics.
+    streaming: Option<Task>,
+    error: Option<String>,
+}
+
+impl App for AtuinApp {
+    type Msg = AppMsg;
+    type Output = ExitAction;
+
+    fn update(&mut self, msg: AppMsg, ctx: &mut Ctx<Self>) {
+        match msg {
+            // Parent policy for a child message: plain pattern matching, no
+            // OutMsg machinery. Submit is app policy (start a turn), so the
+            // parent claims it and delegates the rest.
+            AppMsg::Input(input_box_a::Msg::Submit) => {
+                let prompt = self.input.input.take_text();
+                if !prompt.trim().is_empty() {
+                    self.begin_turn(prompt, ctx);
+                }
+            }
+            AppMsg::Input(input_box_a::Msg::Interrupt) => {
+                if self.streaming.is_some() {
+                    self.streaming = None; // cancel-on-drop
+                } else {
+                    ctx.exit(ExitAction::Cancel);
+                }
+            }
+            AppMsg::Input(imsg) => self.input.update(imsg),
+
+            AppMsg::Stream(ev) => self.on_stream_event(ev, ctx),
+
+            AppMsg::CancelStream => {
+                self.streaming = None;
+            }
+        }
+    }
+
+    fn tail(&self) -> impl Element<AppMsg> + '_ {
+        let busy = self.streaming.is_some();
+
+        col()
+            .when(busy || !self.active.is_empty(), |c| {
+                c.child(live_turn_view(&self.active, &self.current_response, busy))
+            })
+            .when_some(self.error.as_deref(), |c, e| {
+                c.child(text(format!("Error: {e}")).pad_left(2).pad_top(1))
+            })
+            .child(map_msg(self.input.tail()))
+    }
+
+    fn keymap(&self) -> Keymap<AppMsg> {
+        self.input
+            .keymap()
+            .map(AppMsg::Input)
+            .when(self.streaming.is_some(), |k| {
+                k.on(key(crossterm::event::KeyCode::Esc), AppMsg::CancelStream)
+            })
+    }
+}
+
+impl AtuinApp {
+    fn begin_turn(&mut self, prompt: String, ctx: &mut Ctx<Self>) {
+        // The user turn is finished the moment it exists: push, gone.
+        ctx.push(user_turn_block(&prompt));
+        self.error = None;
+        self.streaming = Some(ctx.spawn(agent_stream(prompt)));
+    }
+
+    fn on_stream_event(&mut self, ev: StreamEvent, ctx: &mut Ctx<Self>) {
+        match ev {
+            StreamEvent::Delta(s) => self.current_response.push_str(&s),
+            StreamEvent::ToolStarted { id, command } => {
+                self.flush_response();
+                self.active.push(UiEvent::ToolCall(ToolCallDetails {
+                    tool_use_id: id,
+                    name: "shell".into(),
+                    status: ToolResultStatus::Pending,
+                    render_data: ToolRenderData::Shell {
+                        command,
+                        preview: None,
+                    },
+                }));
+            }
+            StreamEvent::ToolFinished { id, ok } => {
+                for ev in &mut self.active {
+                    if let UiEvent::ToolCall(d) = ev
+                        && d.tool_use_id == id
+                    {
+                        d.status = if ok {
+                            ToolResultStatus::Success
+                        } else {
+                            ToolResultStatus::Error
+                        };
+                    }
+                }
+            }
+            StreamEvent::Completed => {
+                // Seal the turn: it becomes a block, above the tail (which
+                // still holds the input box below — the O6 case), and every
+                // trace of it leaves the model.
+                self.flush_response();
+                let events = std::mem::take(&mut self.active);
+                ctx.push(map_msg(agent_turn::agent_turn_view(&events, false, false)));
+                self.streaming = None;
+            }
+            StreamEvent::Failed(e) => {
+                self.error = Some(e);
+                self.streaming = None;
+            }
+        }
+    }
+
+    fn flush_response(&mut self) {
+        if !self.current_response.is_empty() {
+            self.active.push(UiEvent::Text {
+                content: std::mem::take(&mut self.current_response),
+            });
+        }
+    }
+}
+
+/// The in-progress agent turn, rendered in the tail. Reuses Port 1's
+/// per-event views; the pending "banner" is just the spinner branch — no
+/// `usize::MAX` sentinel turn.
+fn live_turn_view<'a>(
+    events: &'a [UiEvent],
+    current_response: &str,
+    busy: bool,
+) -> impl Element<AppMsg> + 'a {
+    let streaming_md = (!current_response.is_empty()).then(|| current_response.to_string());
+
+    col()
+        .child(text(" Atuin AI "))
+        .children(events.iter().map(|ev| map_msg(agent_turn::event_view(ev))))
+        .when_some(streaming_md, |c, md| c.child(markdown(md).pad_left(2)))
+        .when(busy, |c| c.child(spinner("").pad_left(2)))
+}
+
+/// A submitted user prompt as a block: rendered once, then scrollback.
+fn user_turn_block(prompt: &str) -> impl Element<AppMsg> + use<> {
+    col()
+        .child(text(" You "))
+        .child(text(prompt.to_string()).pad_left(2))
+        .pad_top(1)
+}
+
+/// Stand-in for the real agent turn (SSE stream → StreamEvents → AppMsg).
+fn agent_stream(prompt: String) -> impl futures::Stream<Item = AppMsg> + Send {
+    futures::stream::iter([
+        StreamEvent::Delta(format!("Thinking about: {prompt}")),
+        StreamEvent::Completed,
+    ])
+    .map(AppMsg::Stream)
+}

--- a/crates/spike/src/ports/file_edit.rs
+++ b/crates/spike/src/ports/file_edit.rs
@@ -1,0 +1,175 @@
+//! Port 2: `file_edit_tool_view` / `file_write_tool_view`, from
+//! `~/src/atuin/crates/atuin-ai/src/tui/view/mod.rs` (lines ~640–830 at the
+//! time of porting). This is the nesting stress test: the original's diff
+//! body is a `#(for ...)` containing a `#({ ... })` escape block that
+//! pre-collects a `Vec` of 6-tuples, because the macro's `#(for)` cannot
+//! thread mutable line-number state through iteration. In builder form the
+//! stateful numbering runs directly inside a `.children(iter.map(...))`
+//! closure and the intermediate collection disappears.
+//!
+//! As in Port 1: the `key: &str` parameters and every `key:` prop are
+//! deleted outright.
+
+use ratatui_core::style::{Color, Style};
+
+use crate::fixtures::*;
+use crate::ports::agent_turn::Msg;
+use crate::ui::*;
+
+type El = AnyElement<Msg>;
+
+/// File edit tool call with diff preview.
+pub fn file_edit_tool_view(
+    status: &ToolResultStatus,
+    path: &std::path::Path,
+    preview: Option<&EditPreview>,
+) -> El {
+    let display_path = format_path_for_display(path);
+    let status_line = tool_status_line(status, "Editing", "Edited", "Edit", &display_path, "");
+
+    let Some(preview) = preview else {
+        return status_line;
+    };
+    if preview.hunks.is_empty() {
+        return status_line;
+    }
+
+    let gutter_w = gutter_width(preview.max_line_number());
+
+    col()
+        .child(status_line)
+        .child(
+            col()
+                .children(preview.hunks.iter().map(|hunk| hunk_view(hunk, gutter_w)))
+                .pad_left(2),
+        )
+        .any()
+}
+
+/// One diff hunk: gutter-numbered context/removed/added lines.
+///
+/// The original pre-collected `lines_rendered: Vec<(idx, prefix, text, style,
+/// gutter_text, gutter_style)>` in an escape block, then looped over it with
+/// `#(for)`. Here the `before_pos`/`after_pos` counters mutate inside the
+/// `map` closure directly. (The original's separate `gutter_style` was always
+/// equal to the line style, so the pair collapses to one.)
+fn hunk_view(hunk: &DiffHunk, gutter_w: u16) -> impl Element<Msg> + use<> {
+    let mut before_pos = hunk.before_start;
+    let mut after_pos = hunk.after_start;
+    let num_w = (gutter_w - 1) as usize;
+
+    col().children(hunk.lines.iter().map(move |line| {
+        let (prefix, content, style, gutter) = match line {
+            DiffLine::Context(t) => {
+                let num = format!("{after_pos:>num_w$}");
+                before_pos += 1;
+                after_pos += 1;
+                (" ", t, Style::default().fg(Color::DarkGray), num)
+            }
+            DiffLine::Removed(t) => {
+                let num = format!("{before_pos:>num_w$}");
+                before_pos += 1;
+                ("-", t, Style::default().fg(Color::Red), num)
+            }
+            DiffLine::Added(t) => {
+                let num = format!("{after_pos:>num_w$}");
+                after_pos += 1;
+                ("+", t, Style::default().fg(Color::Green), num)
+            }
+        };
+
+        row()
+            .fixed(gutter_w, text(gutter).style(style))
+            .fill(text(prefix).style(style).span(content.clone(), style))
+    }))
+}
+
+/// File write tool call with content preview.
+pub fn file_write_tool_view(
+    status: &ToolResultStatus,
+    path: &std::path::Path,
+    preview: Option<&WritePreview>,
+) -> El {
+    let display_path = format_path_for_display(path);
+    let line_info = match (status, preview) {
+        (ToolResultStatus::Success, Some(p)) => format!(" ({} lines)", p.total_lines),
+        _ => String::new(),
+    };
+    let status_line = tool_status_line(
+        status,
+        "Writing",
+        "Wrote",
+        "Write",
+        &display_path,
+        &line_info,
+    );
+
+    let Some(preview) = preview else {
+        return status_line;
+    };
+    if preview.lines.is_empty() {
+        return status_line;
+    }
+
+    let gutter_w = gutter_width(preview.total_lines);
+    let num_w = (gutter_w - 1) as usize;
+    let remaining = preview.remaining_lines();
+    let dim = Style::default().fg(Color::DarkGray);
+
+    col()
+        .child(status_line)
+        .child(
+            col()
+                .children(preview.lines.iter().enumerate().map(|(idx, line)| {
+                    row()
+                        .fixed(gutter_w, text(format!("{:>num_w$}", idx + 1)).style(dim))
+                        .fill(text(line.clone()).style(dim))
+                }))
+                .when(remaining > 0, |c| {
+                    c.child(text(format!("     ... +{remaining} more lines")).style(dim))
+                })
+                .pad_left(2),
+        )
+        .any()
+}
+
+/// Line-number gutter width for the highest displayed number, plus spacing.
+fn gutter_width(max_line_num: usize) -> u16 {
+    max_line_num.to_string().len().max(2) as u16 + 1
+}
+
+/// Shared pending/success/error status line for edit and write.
+///
+/// The original duplicated this ~25-line match in both views (differing only
+/// in verbs and the write view's `line_info` suffix); the builder form makes
+/// the extraction natural since the result is just a value.
+fn tool_status_line(
+    status: &ToolResultStatus,
+    doing: &str,
+    did: &str,
+    noun: &str,
+    display_path: &str,
+    suffix: &str,
+) -> El {
+    match status {
+        ToolResultStatus::Pending => spinner(format!("{doing}: {display_path}"))
+            .label_style(Style::default().fg(Color::Yellow))
+            .done(false)
+            .any(),
+        ToolResultStatus::Success => spinner(format!("{did}: {display_path}{suffix}"))
+            .done(true)
+            .any(),
+        ToolResultStatus::Error => text("✗ ")
+            .style(Style::default().fg(Color::Red))
+            .span(
+                format!("{noun} {display_path}: failed"),
+                Style::default().fg(Color::Red),
+            )
+            .any(),
+    }
+}
+
+/// Simplified vs the original (no cwd/home relativization), as in Port 1.
+fn format_path_for_display(path: &std::path::Path) -> String {
+    path.display().to_string()
+}

--- a/crates/spike/src/ports/file_edit.rs
+++ b/crates/spike/src/ports/file_edit.rs
@@ -16,7 +16,7 @@ use crate::fixtures::*;
 use crate::ports::agent_turn::Msg;
 use crate::ui::*;
 
-type El = AnyElement<Msg>;
+type El = AnyElement<'static, Msg>;
 
 /// File edit tool call with diff preview.
 pub fn file_edit_tool_view(

--- a/crates/spike/src/ports/input_box_a.rs
+++ b/crates/spike/src/ports/input_box_a.rs
@@ -1,0 +1,175 @@
+//! Port 3, Candidate A: InputBox with **strict-Elm widget state**.
+//!
+//! Original: `~/src/atuin/crates/atuin-ai/src/tui/components/input_box.rs`
+//! plus the input-policy fragments of `components/atuin_ai.rs` (Tab-to-insert)
+//! and `view/mod.rs` `input_view` (slash suggestion rows).
+//!
+//! The original's shape: `Arc<Mutex<TextArea>>` in component state (because
+//! Canvas demands a `'static` closure), a `tx: Option<DriverEventSender>`
+//! fetched via `use_context` so handlers can emit, an `active` prop shadowing
+//! focus, and an `InputUpdated` message sent to the driver **on every
+//! keystroke** so app state could know the text (for `is_input_blank` and
+//! slash search).
+//!
+//! Candidate A's shape: `TextAreaState` is a plain value in the model.
+//! `update` owns all mutation; the keymap owns all policy; the view borrows.
+//! Consequences visible below:
+//!
+//! - **No `Arc<Mutex>`** — the view borrows `&TextAreaState` (this is what
+//!   forced `AnyElement` to carry a lifetime).
+//! - **No event-sender plumbing** — handlers ARE messages.
+//! - **No `active` prop** — visuals key off `FocusHandle::is_focused()`.
+//! - **The `InputUpdated` echo is deleted** — `slash_results()` and
+//!   `is_blank()` are derived reads of model state.
+//! - **Tab policy is conditional keymap data**, rebuilt per update — the
+//!   Tab-to-insert vs slash-accept vs focus-cycle footgun becomes
+//!   impossible-by-construction (all Tab meanings are in one place, ordered).
+
+use crossterm::event::KeyCode;
+
+use crate::ui::*;
+
+/// Messages this slice of the app produces. Note the absence of any
+/// "InputUpdated" — update mutates state directly, and reads are derived.
+#[derive(Clone)]
+pub enum Msg {
+    /// Enter (unmodified) in the input.
+    Submit,
+    /// Shift+Enter or Ctrl+J.
+    InputNewline,
+    /// Tab while a slash suggestion matches.
+    AcceptSlashSuggestion,
+    /// Tab while input is blank and a suggested command exists.
+    InsertSuggestedCommand,
+    /// Ctrl+C.
+    Interrupt,
+    /// Everything else while the input is focused: ordinary editing.
+    Edit(EditEvent),
+}
+
+/// Raw event wrapper so `Msg` can stay `Clone` and the fallthrough mapper
+/// can be the plain enum constructor `Msg::Edit`.
+#[derive(Clone)]
+pub struct EditEvent(pub InputEvent);
+
+pub struct SlashCommand {
+    pub name: String,
+    pub description: String,
+}
+
+/// The app-model slice for the input area.
+pub struct InputModel {
+    pub input: TextAreaState,
+    pub input_focus: FocusHandle,
+    pub slash_registry: Vec<SlashCommand>,
+    pub has_command: bool,
+    /// Stand-in for "what submit does" (the real app pushes a turn + spawns
+    /// a stream here).
+    pub submitted: Vec<String>,
+}
+
+impl InputModel {
+    /// Slash-command matches, **derived** from the input text on demand.
+    /// In the original this was `slash_command_search_results` app state,
+    /// kept in sync by the per-keystroke `InputUpdated` round-trip through
+    /// the driver thread.
+    pub fn slash_results(&self) -> Vec<&SlashCommand> {
+        let text = self.input.text();
+        let Some(query) = text.strip_prefix('/') else {
+            return Vec::new();
+        };
+        self.slash_registry
+            .iter()
+            .filter(|c| c.name.starts_with(query))
+            .collect()
+    }
+
+    fn best_slash(&self) -> Option<&SlashCommand> {
+        self.slash_results().into_iter().next()
+    }
+
+    pub fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Submit => {
+                let text = self.input.take_text();
+                if !text.trim().is_empty() {
+                    // Real app: push the user turn as a block, spawn the
+                    // agent stream, hold the Task in the model.
+                    self.submitted.push(text);
+                }
+            }
+            Msg::InputNewline => self.input.insert_newline(),
+            Msg::AcceptSlashSuggestion => {
+                if let Some(cmd) = self.best_slash() {
+                    let name = cmd.name.clone();
+                    self.input.set_text(&format!("/{name}"));
+                }
+            }
+            Msg::InsertSuggestedCommand => {
+                // Real app: ctx.exit(ExitAction::Insert(..)).
+            }
+            Msg::Interrupt => {
+                // Real app: drop the streaming Task, or ctx.exit(Cancel).
+            }
+            Msg::Edit(EditEvent(ev)) => self.input.handle(&ev),
+        }
+    }
+
+    /// All input policy in one place, conditional on model state, rebuilt
+    /// each update. Compare: the original spread Tab across the InputBox
+    /// bubble handler, the AtuinAi capture handler, and the framework's
+    /// hardcoded Tab-cycling — and broke silently when a second focusable
+    /// appeared.
+    pub fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Interrupt)
+            .in_scope(&self.input_focus, key(KeyCode::Enter), Msg::Submit)
+            .in_scope(
+                &self.input_focus,
+                key(KeyCode::Enter).shift(),
+                Msg::InputNewline,
+            )
+            .in_scope(
+                &self.input_focus,
+                key(KeyCode::Char('j')).ctrl(),
+                Msg::InputNewline,
+            )
+            .when(self.best_slash().is_some(), |k| {
+                k.in_scope(
+                    &self.input_focus,
+                    key(KeyCode::Tab),
+                    Msg::AcceptSlashSuggestion,
+                )
+            })
+            .when(self.has_command && self.input.is_blank(), |k| {
+                k.in_scope(
+                    &self.input_focus,
+                    key(KeyCode::Tab),
+                    Msg::InsertSuggestedCommand,
+                )
+            })
+            .fallthrough(&self.input_focus, |ev| Msg::Edit(EditEvent(ev)))
+    }
+
+    /// The live-tail view for the input area. Borrows the model.
+    pub fn tail(&self) -> impl Element<Msg> + '_ {
+        let results = self.slash_results();
+
+        col()
+            .child(
+                text_area(&self.input)
+                    .title("Generate a command or ask a question")
+                    .title_right("Atuin AI")
+                    .footer("[Enter] Send  [Shift+Enter] Newline")
+                    .placeholder("Type a message...")
+                    .max_height(7)
+                    .track_focus(&self.input_focus),
+            )
+            .children(results.into_iter().take(4).enumerate().map(|(i, cmd)| {
+                text(format!("/{}", cmd.name))
+                    .span(" - ", Default::default())
+                    .span(cmd.description.as_str(), Default::default())
+                    .when(i == 0, |t| t.span(" [Tab] Insert", Default::default()))
+            }))
+    }
+}

--- a/crates/spike/src/ports/input_box_b.rs
+++ b/crates/spike/src/ports/input_box_b.rs
@@ -1,0 +1,240 @@
+//! Port 3, Candidate B: InputBox with **framework-managed widget state**
+//! (egui-Memory style). Self-contained sketch: the store, the managed
+//! widget, and the app slice all live here so A and B read side by side.
+//!
+//! Shape: the app never holds textarea state. The view declares
+//! `text_area_managed(id)` with message-mapping callbacks; the runtime owns
+//! a `WidgetStore` keyed by id, routes focused input to the widget's
+//! `handle`, and delivers whatever messages the callbacks produce.
+
+use std::any::Any;
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::ui::{Element, InputEvent, TextAreaState};
+
+/// Widget identity. With no model-side state to anchor identity, ids return
+/// (Port 1 deleted keys; Candidate B reintroduces them for stateful widgets).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WidgetId(pub &'static str);
+
+/// Runtime-owned per-widget state, keyed by id. The framework would create,
+/// persist, and garbage-collect entries; the app never sees inside except
+/// through explicit queries.
+#[derive(Default)]
+pub struct WidgetStore {
+    slots: HashMap<WidgetId, Box<dyn Any>>,
+}
+
+impl WidgetStore {
+    pub fn get_or_default<T: Default + 'static>(&mut self, id: WidgetId) -> &mut T {
+        self.slots
+            .entry(id)
+            .or_insert_with(|| Box::new(T::default()))
+            .downcast_mut()
+            .expect("widget state type mismatch for id")
+    }
+
+    /// App-side escape hatch to inspect widget state (needed for anything
+    /// like `is_input_blank` unless the app mirrors via on_change).
+    pub fn get<T: 'static>(&self, id: WidgetId) -> Option<&T> {
+        self.slots.get(&id).and_then(|b| b.downcast_ref())
+    }
+}
+
+pub enum Msg {
+    /// Carries the submitted text — the app never touches the textarea.
+    Submitted(String),
+    /// The echo: apps that need to *know* the current text (blank checks,
+    /// slash search) must mirror it into their model on every keystroke.
+    InputChanged(String),
+    InsertSuggestedCommand,
+    Interrupt,
+}
+
+/// The managed text area element. Policy that Candidate A expressed as
+/// keymap data must be expressed here as configuration flags and callback
+/// props — and every app-specific behavior needs its own escape hatch.
+pub struct ManagedTextArea<Msg> {
+    id: WidgetId,
+    title: String,
+    footer: String,
+    max_height: u16,
+    submit_on_enter: bool,
+    newline_on_shift_enter: bool,
+    newline_on_ctrl_j: bool,
+    on_submit: Option<Box<dyn Fn(String) -> Msg>>,
+    on_change: Option<Box<dyn Fn(String) -> Msg>>,
+    /// Escape hatch for behaviors the flags don't cover (the Tab
+    /// slash-accept). Sees the key + current text, may consume with a Msg.
+    /// This is the Select `on_select: Box<dyn Fn...>` pattern returning.
+    intercept_key: Option<KeyInterceptFn<Msg>>,
+}
+
+/// Complex enough that clippy demands a name for it — which is itself
+/// evidence for the Candidate A side of the comparison.
+type KeyInterceptFn<Msg> = Box<dyn Fn(&KeyEvent, &str) -> Option<Msg>>;
+
+pub fn text_area_managed<Msg>(id: WidgetId) -> ManagedTextArea<Msg> {
+    ManagedTextArea {
+        id,
+        title: String::new(),
+        footer: String::new(),
+        max_height: u16::MAX,
+        submit_on_enter: true,
+        newline_on_shift_enter: true,
+        newline_on_ctrl_j: false,
+        on_submit: None,
+        on_change: None,
+        intercept_key: None,
+    }
+}
+
+impl<Msg> ManagedTextArea<Msg> {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.footer = footer.into();
+        self
+    }
+
+    pub fn max_height(mut self, rows: u16) -> Self {
+        self.max_height = rows;
+        self
+    }
+
+    pub fn newline_on_ctrl_j(mut self, enabled: bool) -> Self {
+        self.newline_on_ctrl_j = enabled;
+        self
+    }
+
+    pub fn on_submit(mut self, f: impl Fn(String) -> Msg + 'static) -> Self {
+        self.on_submit = Some(Box::new(f));
+        self
+    }
+
+    pub fn on_change(mut self, f: impl Fn(String) -> Msg + 'static) -> Self {
+        self.on_change = Some(Box::new(f));
+        self
+    }
+
+    pub fn intercept_key(mut self, f: impl Fn(&KeyEvent, &str) -> Option<Msg> + 'static) -> Self {
+        self.intercept_key = Some(Box::new(f));
+        self
+    }
+
+    /// The runtime calls this with the store while this widget is focused.
+    /// (In a real design this hangs off a `ManagedElement` trait; a plain
+    /// method keeps the sketch small.)
+    pub fn handle(&self, event: &InputEvent, store: &mut WidgetStore) -> Option<Msg> {
+        let state: &mut TextAreaState = store.get_or_default(self.id);
+
+        if let InputEvent::Key(k) = event {
+            if let Some(intercept) = &self.intercept_key
+                && let Some(msg) = intercept(k, &state.text())
+            {
+                return msg.into();
+            }
+            if k.code == KeyCode::Enter {
+                if self.newline_on_shift_enter && k.modifiers.contains(KeyModifiers::SHIFT) {
+                    state.insert_newline();
+                    return self.on_change.as_ref().map(|f| f(state.text()));
+                }
+                if self.submit_on_enter {
+                    let text = state.take_text();
+                    if text.trim().is_empty() {
+                        return None;
+                    }
+                    return self.on_submit.as_ref().map(|f| f(text));
+                }
+            }
+            if self.newline_on_ctrl_j
+                && k.code == KeyCode::Char('j')
+                && k.modifiers.contains(KeyModifiers::CONTROL)
+            {
+                state.insert_newline();
+                return self.on_change.as_ref().map(|f| f(state.text()));
+            }
+        }
+
+        state.handle(event);
+        self.on_change.as_ref().map(|f| f(state.text()))
+    }
+}
+
+impl<M> Element<M> for ManagedTextArea<M> {
+    // height() needs the store to measure content — the Element trait
+    // would have to grow store access (or heights get cached by id).
+    // Left as the default stub; this wrinkle is a finding in itself.
+}
+
+// ───────────────────────────────────────────────────────────────────
+// The app slice, Candidate B
+// ───────────────────────────────────────────────────────────────────
+
+pub struct SlashCommand {
+    pub name: String,
+    pub description: String,
+}
+
+pub struct InputModelB {
+    /// The mirror. `is_input_blank` and slash search need the text, the
+    /// framework owns the text, so every keystroke echoes it back into the
+    /// model via `Msg::InputChanged` — the exact `InputUpdated` round-trip
+    /// the original atuin-ai driver had, reintroduced by the state model.
+    pub input_text: String,
+    pub slash_registry: Vec<SlashCommand>,
+    pub has_command: bool,
+    pub submitted: Vec<String>,
+}
+
+impl InputModelB {
+    pub fn slash_results(&self) -> Vec<&SlashCommand> {
+        let Some(query) = self.input_text.strip_prefix('/') else {
+            return Vec::new();
+        };
+        self.slash_registry
+            .iter()
+            .filter(|c| c.name.starts_with(query))
+            .collect()
+    }
+
+    pub fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Submitted(text) => {
+                self.submitted.push(text);
+                self.input_text.clear();
+            }
+            Msg::InputChanged(text) => self.input_text = text,
+            Msg::InsertSuggestedCommand | Msg::Interrupt => {}
+        }
+    }
+
+    pub fn tail(&self) -> impl Element<Msg> + '_ {
+        let suggestion = self.slash_results().first().map(|c| format!("/{}", c.name));
+
+        text_area_managed(WidgetId("input"))
+            .title("Generate a command or ask a question")
+            .footer("[Enter] Send  [Shift+Enter] Newline")
+            .max_height(7)
+            .newline_on_ctrl_j(true)
+            .on_submit(Msg::Submitted)
+            .on_change(Msg::InputChanged)
+            .intercept_key(move |key, _text| {
+                if key.code == KeyCode::Tab
+                    && let Some(s) = &suggestion
+                {
+                    // Can't set the textarea text from here — the store isn't
+                    // in scope. The widget would need yet another hook
+                    // (`on_tab_complete`?) that both reads AND writes state.
+                    // Candidate A does this with three lines in update().
+                    let _ = s;
+                }
+                None
+            })
+    }
+}

--- a/crates/spike/src/ports/mod.rs
+++ b/crates/spike/src/ports/mod.rs
@@ -2,6 +2,7 @@
 //! see `.planning/REDESIGN.md` Phase 1 for the protocol.
 
 pub mod agent_turn;
+pub mod driver;
 pub mod file_edit;
 pub mod input_box_a;
 pub mod input_box_b;

--- a/crates/spike/src/ports/mod.rs
+++ b/crates/spike/src/ports/mod.rs
@@ -3,3 +3,5 @@
 
 pub mod agent_turn;
 pub mod file_edit;
+pub mod input_box_a;
+pub mod input_box_b;

--- a/crates/spike/src/ports/mod.rs
+++ b/crates/spike/src/ports/mod.rs
@@ -1,0 +1,4 @@
+//! Ports of real Atuin AI views to the candidate DSL. One module per port;
+//! see `.planning/REDESIGN.md` Phase 1 for the protocol.
+
+pub mod agent_turn;

--- a/crates/spike/src/ports/mod.rs
+++ b/crates/spike/src/ports/mod.rs
@@ -2,3 +2,4 @@
 //! see `.planning/REDESIGN.md` Phase 1 for the protocol.
 
 pub mod agent_turn;
+pub mod file_edit;

--- a/crates/spike/src/ui.rs
+++ b/crates/spike/src/ui.rs
@@ -1,0 +1,316 @@
+//! Candidate v2 DSL — stub implementation for the bake-off.
+//!
+//! Fluent builders, no macro. The `Element` trait matches the REDESIGN.md
+//! sketch: honest `height(width)` measurement, plain `render`, optional
+//! self-animation. Rendering is unimplemented — only call-site shape is
+//! under test here.
+
+use std::time::Duration;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+
+/// A renderable piece of UI. `Msg` is the app's message type (Elm-style);
+/// display-only elements implement it for every `Msg`.
+pub trait Element<Msg> {
+    /// Honest measurement: rows needed at the given width.
+    fn height(&self, _width: u16) -> u16 {
+        0
+    }
+
+    fn render(&self, _area: Rect, _buf: &mut Buffer) {}
+
+    /// Frame interval if self-animating (e.g. a live spinner). The runtime
+    /// self-ticks the tail while any animated element is present.
+    fn animated(&self) -> Option<Duration> {
+        None
+    }
+}
+
+/// A boxed, type-erased element. Match arms that produce different element
+/// types converge on this via [`ElementExt::any`].
+pub type AnyElement<Msg> = Box<dyn Element<Msg>>;
+
+impl<Msg> Element<Msg> for Box<dyn Element<Msg>> {
+    fn height(&self, width: u16) -> u16 {
+        self.as_ref().height(width)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        self.as_ref().render(area, buf)
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        self.as_ref().animated()
+    }
+}
+
+/// Type erasure. Separate from [`Fluent`] because `any()` mentions `Msg` in
+/// its return type (so inference can pin it from context), while the
+/// combinators must NOT be `Msg`-parameterized at all — display-only elements
+/// implement `Element<Msg>` for every `Msg`, and a `Msg`-generic `pad_left`
+/// on such a receiver is uninferrable (found the hard way; see FINDINGS.md).
+pub trait ElementExt<Msg>: Element<Msg> + Sized + 'static {
+    /// Type-erase, for heterogeneous branches.
+    fn any(self) -> AnyElement<Msg> {
+        Box::new(self)
+    }
+}
+
+impl<Msg, E: Element<Msg> + 'static> ElementExt<Msg> for E {}
+
+/// `Msg`-free combinators, available on every builder.
+pub trait Fluent: Sized {
+    /// Apply `f` only when `cond` holds. The `#(if ...)` analog.
+    fn when(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond { f(self) } else { self }
+    }
+
+    /// Apply `f` with the value when present. The `#(if let Some ...)` analog.
+    fn when_some<T>(self, value: Option<T>, f: impl FnOnce(Self, T) -> Self) -> Self {
+        match value {
+            Some(v) => f(self, v),
+            None => self,
+        }
+    }
+
+    fn pad_left(self, cols: u16) -> Padded<Self> {
+        Padded {
+            inner: self,
+            left: cols,
+            top: 0,
+        }
+    }
+
+    fn pad_top(self, rows: u16) -> Padded<Self> {
+        Padded {
+            inner: self,
+            left: 0,
+            top: rows,
+        }
+    }
+}
+
+impl<T> Fluent for T {}
+
+/// An element offset by padding. Produced by [`Fluent::pad_left`] /
+/// [`Fluent::pad_top`].
+pub struct Padded<E> {
+    inner: E,
+    left: u16,
+    top: u16,
+}
+
+impl<Msg, E: Element<Msg>> Element<Msg> for Padded<E> {}
+
+// ───────────────────────────────────────────────────────────────────
+// Containers
+// ───────────────────────────────────────────────────────────────────
+
+/// Vertical stack. Children get full width; height is content-driven.
+pub struct Col<Msg> {
+    children: Vec<AnyElement<Msg>>,
+    gap: u16,
+}
+
+pub fn col<Msg>() -> Col<Msg> {
+    Col {
+        children: Vec::new(),
+        gap: 0,
+    }
+}
+
+impl<Msg> Col<Msg> {
+    /// Blank rows between children.
+    pub fn gap(mut self, rows: u16) -> Self {
+        self.gap = rows;
+        self
+    }
+
+    pub fn child(mut self, child: impl Element<Msg> + 'static) -> Self {
+        self.children.push(Box::new(child));
+        self
+    }
+
+    pub fn children<I>(mut self, children: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Element<Msg> + 'static,
+    {
+        self.children
+            .extend(children.into_iter().map(|c| Box::new(c) as AnyElement<Msg>));
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for Col<Msg> {}
+
+/// Column width within a [`Row`].
+pub enum Width {
+    Fixed(u16),
+    /// Remaining space, split equally among `Fill` cells.
+    Fill,
+}
+
+/// Horizontal layout. Cells declare `Fixed(n)` or `Fill` widths;
+/// row height is the max of cell heights.
+pub struct Row<Msg> {
+    cells: Vec<(Width, AnyElement<Msg>)>,
+}
+
+pub fn row<Msg>() -> Row<Msg> {
+    Row { cells: Vec::new() }
+}
+
+impl<Msg> Row<Msg> {
+    pub fn fixed(mut self, cols: u16, child: impl Element<Msg> + 'static) -> Self {
+        self.cells.push((Width::Fixed(cols), Box::new(child)));
+        self
+    }
+
+    pub fn fill(mut self, child: impl Element<Msg> + 'static) -> Self {
+        self.cells.push((Width::Fill, Box::new(child)));
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for Row<Msg> {}
+
+// ───────────────────────────────────────────────────────────────────
+// Leaves
+// ───────────────────────────────────────────────────────────────────
+
+/// One word-wrapped run of styled spans.
+pub struct Text {
+    spans: Vec<(String, Style)>,
+}
+
+/// Single-span text. `.style()` styles it; `.span()` appends further
+/// styled spans.
+pub fn text(content: impl Into<String>) -> Text {
+    Text {
+        spans: vec![(content.into(), Style::default())],
+    }
+}
+
+impl Text {
+    /// Style the most recently added span (the initial one if none added).
+    pub fn style(mut self, style: Style) -> Self {
+        if let Some(last) = self.spans.last_mut() {
+            last.1 = style;
+        }
+        self
+    }
+
+    pub fn span(mut self, content: impl Into<String>, style: Style) -> Self {
+        self.spans.push((content.into(), style));
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for Text {}
+
+/// The nothing element, for match arms with no output.
+pub struct Empty;
+
+pub fn empty() -> Empty {
+    Empty
+}
+
+impl<Msg> Element<Msg> for Empty {}
+
+pub struct Spinner {
+    label: String,
+    done: bool,
+    hide_checkmark: bool,
+    label_style: Style,
+    spinner_style: Style,
+}
+
+pub fn spinner(label: impl Into<String>) -> Spinner {
+    Spinner {
+        label: label.into(),
+        done: false,
+        hide_checkmark: false,
+        label_style: Style::default(),
+        spinner_style: Style::default(),
+    }
+}
+
+impl Spinner {
+    pub fn done(mut self, done: bool) -> Self {
+        self.done = done;
+        self
+    }
+
+    pub fn hide_checkmark(mut self) -> Self {
+        self.hide_checkmark = true;
+        self
+    }
+
+    pub fn label_style(mut self, style: Style) -> Self {
+        self.label_style = style;
+        self
+    }
+
+    pub fn spinner_style(mut self, style: Style) -> Self {
+        self.spinner_style = style;
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for Spinner {
+    fn animated(&self) -> Option<Duration> {
+        (!self.done).then(|| Duration::from_millis(80))
+    }
+}
+
+/// CommonMark rendering (pulldown-cmark behind the scenes in the real thing).
+pub struct Markdown {
+    source: String,
+}
+
+pub fn markdown(source: impl Into<String>) -> Markdown {
+    Markdown {
+        source: source.into(),
+    }
+}
+
+impl<Msg> Element<Msg> for Markdown {}
+
+/// Fixed-height tail window over a list of lines.
+pub struct Viewport {
+    lines: Vec<String>,
+    height: u16,
+    style: Style,
+    wrap: bool,
+}
+
+pub fn viewport(lines: Vec<String>) -> Viewport {
+    Viewport {
+        lines,
+        height: 1,
+        style: Style::default(),
+        wrap: true,
+    }
+}
+
+impl Viewport {
+    pub fn height(mut self, rows: u16) -> Self {
+        self.height = rows;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn wrap(mut self, wrap: bool) -> Self {
+        self.wrap = wrap;
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for Viewport {}

--- a/crates/spike/src/ui.rs
+++ b/crates/spike/src/ui.rs
@@ -615,3 +615,128 @@ impl<Msg> Element<Msg> for TextArea<'_> {
         ))
     }
 }
+
+// ───────────────────────────────────────────────────────────────────
+// Runtime surface: App, Ctx, Task (added for Port 4)
+// ───────────────────────────────────────────────────────────────────
+
+/// The application, Elm-shaped. The implementing struct IS the model:
+/// `update` takes `&mut self`, `tail` takes `&self` — the borrow checker
+/// enforces the discipline.
+pub trait App: Sized + 'static {
+    type Msg: 'static;
+    /// What `run()` returns after `ctx.exit(..)`.
+    type Output: Default;
+
+    fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<Self>);
+
+    /// The live tail. Re-run every frame; borrows the model.
+    fn tail(&self) -> impl Element<Self::Msg> + '_;
+
+    /// Key bindings, rebuilt from the model each update.
+    fn keymap(&self) -> Keymap<Self::Msg> {
+        keymap()
+    }
+}
+
+/// Effect context handed to `update`. Blocks pushed here are rendered once
+/// (at current width) and flow toward scrollback — committed output is an
+/// effect; only the tail is a view.
+pub struct Ctx<A: App> {
+    pushed: Vec<AnyElement<'static, A::Msg>>,
+    exit_with: Option<A::Output>,
+}
+
+impl<A: App> Ctx<A> {
+    /// Append a finished block to the timeline. Irreversible, like
+    /// `println!`. Blocks are `'static`: they leave the model at push time.
+    pub fn push(&mut self, block: impl Element<A::Msg> + 'static) {
+        self.pushed.push(Box::new(block));
+    }
+
+    /// Spawn a stream of messages (the LLM-turn shape); each item feeds
+    /// back into `update`. The returned Task cancels on drop.
+    #[must_use]
+    pub fn spawn<S>(&mut self, stream: S) -> Task
+    where
+        S: futures::Stream<Item = A::Msg> + Send + 'static,
+    {
+        let _ = stream;
+        Task(())
+    }
+
+    /// End the run loop; `run()` returns this value after teardown.
+    pub fn exit(&mut self, output: A::Output) {
+        self.exit_with = Some(output);
+    }
+}
+
+/// Handle to spawned work. **Dropping it cancels the work** — holding it in
+/// the model makes cancellation a plain assignment (`self.streaming = None`).
+pub struct Task(());
+
+impl Task {
+    /// Fire-and-forget: run to completion even after the handle is gone.
+    pub fn detach(self) {
+        std::mem::forget(self);
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
+        // Stub: the real runtime aborts the spawned work here.
+    }
+}
+
+impl<Msg: 'static> Keymap<Msg> {
+    /// Re-target bindings to a parent message type (Elm's `Html.map` for
+    /// keymaps) — how a sub-model's keymap embeds into the app's.
+    pub fn map<M2>(self, f: impl Fn(Msg) -> M2 + Clone + 'static) -> Keymap<M2> {
+        Keymap {
+            bindings: self
+                .bindings
+                .into_iter()
+                .map(|(scope, key, msg)| (scope, key, f(msg)))
+                .collect(),
+            fallthrough: self
+                .fallthrough
+                .into_iter()
+                .map(|(focus, g)| {
+                    let f = f.clone();
+                    let mapped: FallthroughFn<M2> = Box::new(move |ev| f(g(ev)));
+                    (focus, mapped)
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Adapt an element from one message type to another (Elm's `Html.map`).
+///
+/// Trivially a phantom re-wrap today, because nothing on `Element` actually
+/// carries `Msg` in the strict-Elm candidate — emission happens in the
+/// keymap. See FINDINGS: this is evidence the `Msg` parameter on `Element`
+/// itself may be vestigial.
+pub fn map_msg<'a, M1: 'a, M2>(el: impl Element<M1> + 'a) -> impl Element<M2> + 'a {
+    struct Map<E, M1>(E, std::marker::PhantomData<fn() -> M1>);
+
+    impl<M1, M2, E: Element<M1>> Element<M2> for Map<E, M1> {
+        fn height(&self, width: u16) -> u16 {
+            self.0.height(width)
+        }
+
+        fn render(&self, area: Rect, buf: &mut Buffer) {
+            self.0.render(area, buf)
+        }
+
+        fn animated(&self) -> Option<Duration> {
+            self.0.animated()
+        }
+
+        fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+            self.0.cursor(area)
+        }
+    }
+
+    Map(el, std::marker::PhantomData)
+}

--- a/crates/spike/src/ui.rs
+++ b/crates/spike/src/ui.rs
@@ -26,13 +26,25 @@ pub trait Element<Msg> {
     fn animated(&self) -> Option<Duration> {
         None
     }
+
+    /// Hardware cursor position (relative to `area`) when this element is
+    /// focused. `None` hides the cursor.
+    fn cursor(&self, _area: Rect) -> Option<(u16, u16)> {
+        None
+    }
 }
 
 /// A boxed, type-erased element. Match arms that produce different element
 /// types converge on this via [`ElementExt::any`].
-pub type AnyElement<Msg> = Box<dyn Element<Msg>>;
+///
+/// Carries a lifetime: views borrow from the model (Port 3 finding — a
+/// strict-Elm text area renders from `&TextAreaState` living in the app
+/// model; an implicit `'static` bound here would force cloning every
+/// stateful widget per frame). The tail is built, rendered, and dropped
+/// within one frame, so model borrows are naturally scoped.
+pub type AnyElement<'a, Msg> = Box<dyn Element<Msg> + 'a>;
 
-impl<Msg> Element<Msg> for Box<dyn Element<Msg>> {
+impl<Msg> Element<Msg> for Box<dyn Element<Msg> + '_> {
     fn height(&self, width: u16) -> u16 {
         self.as_ref().height(width)
     }
@@ -44,6 +56,10 @@ impl<Msg> Element<Msg> for Box<dyn Element<Msg>> {
     fn animated(&self) -> Option<Duration> {
         self.as_ref().animated()
     }
+
+    fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+        self.as_ref().cursor(area)
+    }
 }
 
 /// Type erasure. Separate from [`Fluent`] because `any()` mentions `Msg` in
@@ -51,14 +67,17 @@ impl<Msg> Element<Msg> for Box<dyn Element<Msg>> {
 /// combinators must NOT be `Msg`-parameterized at all — display-only elements
 /// implement `Element<Msg>` for every `Msg`, and a `Msg`-generic `pad_left`
 /// on such a receiver is uninferrable (found the hard way; see FINDINGS.md).
-pub trait ElementExt<Msg>: Element<Msg> + Sized + 'static {
+pub trait ElementExt<Msg>: Element<Msg> + Sized {
     /// Type-erase, for heterogeneous branches.
-    fn any(self) -> AnyElement<Msg> {
+    fn any<'a>(self) -> AnyElement<'a, Msg>
+    where
+        Self: 'a,
+    {
         Box::new(self)
     }
 }
 
-impl<Msg, E: Element<Msg> + 'static> ElementExt<Msg> for E {}
+impl<Msg, E: Element<Msg>> ElementExt<Msg> for E {}
 
 /// `Msg`-free combinators, available on every builder.
 pub trait Fluent: Sized {
@@ -109,26 +128,26 @@ impl<Msg, E: Element<Msg>> Element<Msg> for Padded<E> {}
 // ───────────────────────────────────────────────────────────────────
 
 /// Vertical stack. Children get full width; height is content-driven.
-pub struct Col<Msg> {
-    children: Vec<AnyElement<Msg>>,
+pub struct Col<'a, Msg> {
+    children: Vec<AnyElement<'a, Msg>>,
     gap: u16,
 }
 
-pub fn col<Msg>() -> Col<Msg> {
+pub fn col<'a, Msg>() -> Col<'a, Msg> {
     Col {
         children: Vec::new(),
         gap: 0,
     }
 }
 
-impl<Msg> Col<Msg> {
+impl<'a, Msg> Col<'a, Msg> {
     /// Blank rows between children.
     pub fn gap(mut self, rows: u16) -> Self {
         self.gap = rows;
         self
     }
 
-    pub fn child(mut self, child: impl Element<Msg> + 'static) -> Self {
+    pub fn child(mut self, child: impl Element<Msg> + 'a) -> Self {
         self.children.push(Box::new(child));
         self
     }
@@ -136,15 +155,18 @@ impl<Msg> Col<Msg> {
     pub fn children<I>(mut self, children: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Element<Msg> + 'static,
+        I::Item: Element<Msg> + 'a,
     {
-        self.children
-            .extend(children.into_iter().map(|c| Box::new(c) as AnyElement<Msg>));
+        self.children.extend(
+            children
+                .into_iter()
+                .map(|c| Box::new(c) as AnyElement<'a, Msg>),
+        );
         self
     }
 }
 
-impl<Msg> Element<Msg> for Col<Msg> {}
+impl<Msg> Element<Msg> for Col<'_, Msg> {}
 
 /// Column width within a [`Row`].
 pub enum Width {
@@ -155,27 +177,27 @@ pub enum Width {
 
 /// Horizontal layout. Cells declare `Fixed(n)` or `Fill` widths;
 /// row height is the max of cell heights.
-pub struct Row<Msg> {
-    cells: Vec<(Width, AnyElement<Msg>)>,
+pub struct Row<'a, Msg> {
+    cells: Vec<(Width, AnyElement<'a, Msg>)>,
 }
 
-pub fn row<Msg>() -> Row<Msg> {
+pub fn row<'a, Msg>() -> Row<'a, Msg> {
     Row { cells: Vec::new() }
 }
 
-impl<Msg> Row<Msg> {
-    pub fn fixed(mut self, cols: u16, child: impl Element<Msg> + 'static) -> Self {
+impl<'a, Msg> Row<'a, Msg> {
+    pub fn fixed(mut self, cols: u16, child: impl Element<Msg> + 'a) -> Self {
         self.cells.push((Width::Fixed(cols), Box::new(child)));
         self
     }
 
-    pub fn fill(mut self, child: impl Element<Msg> + 'static) -> Self {
+    pub fn fill(mut self, child: impl Element<Msg> + 'a) -> Self {
         self.cells.push((Width::Fill, Box::new(child)));
         self
     }
 }
 
-impl<Msg> Element<Msg> for Row<Msg> {}
+impl<Msg> Element<Msg> for Row<'_, Msg> {}
 
 // ───────────────────────────────────────────────────────────────────
 // Leaves
@@ -314,3 +336,282 @@ impl Viewport {
 }
 
 impl<Msg> Element<Msg> for Viewport {}
+
+// ───────────────────────────────────────────────────────────────────
+// Input: events, focus, keymap (added for Port 3)
+// ───────────────────────────────────────────────────────────────────
+
+/// A terminal input event as delivered to the app: key press or paste.
+#[derive(Clone, Debug)]
+pub enum InputEvent {
+    Key(crossterm::event::KeyEvent),
+    Paste(String),
+}
+
+/// A key pattern for keymap bindings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Key {
+    pub code: crossterm::event::KeyCode,
+    pub mods: crossterm::event::KeyModifiers,
+}
+
+pub fn key(code: crossterm::event::KeyCode) -> Key {
+    Key {
+        code,
+        mods: crossterm::event::KeyModifiers::NONE,
+    }
+}
+
+impl Key {
+    pub fn ctrl(mut self) -> Self {
+        self.mods |= crossterm::event::KeyModifiers::CONTROL;
+        self
+    }
+
+    pub fn shift(mut self) -> Self {
+        self.mods |= crossterm::event::KeyModifiers::SHIFT;
+        self
+    }
+}
+
+/// Focus identity, owned by the app and stored in its model (GPUI-style).
+///
+/// The runtime tracks which handle is currently focused; elements bind via
+/// `track_focus`, keymap bindings scope via `in_scope`. Stub: real semantics
+/// (single focused handle per runtime) live in the runtime, not here.
+#[derive(Clone, Default)]
+pub struct FocusHandle(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl FocusHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn focus(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn blur(&self) {
+        self.0.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn is_focused(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+enum BindingScope {
+    /// Fires before the focused element sees the event. For Ctrl+C-tier
+    /// chords only.
+    GlobalOverride,
+    /// Fires if neither the focused element nor a focus-scoped binding
+    /// consumed the event.
+    Global,
+    /// Fires when the given handle has focus (after the focused element).
+    Focus(FocusHandle),
+}
+
+/// Key → message bindings, rebuilt from the model each update (so bindings
+/// can be conditional on app state — see the Tab bindings in Port 3A).
+///
+/// Dispatch order for a key event:
+/// 1. `on_override` bindings
+/// 2. the focused element's own editing keys
+/// 3. `in_scope` bindings for the focused handle
+/// 4. `on` (global) bindings
+/// 5. `fallthrough` mappers for the focused handle (raw event → Msg)
+type FallthroughFn<Msg> = Box<dyn Fn(InputEvent) -> Msg>;
+
+pub struct Keymap<Msg> {
+    bindings: Vec<(BindingScope, Key, Msg)>,
+    fallthrough: Vec<(FocusHandle, FallthroughFn<Msg>)>,
+}
+
+pub fn keymap<Msg>() -> Keymap<Msg> {
+    Keymap {
+        bindings: Vec::new(),
+        fallthrough: Vec::new(),
+    }
+}
+
+impl<Msg> Keymap<Msg> {
+    pub fn on(mut self, key: Key, msg: Msg) -> Self {
+        self.bindings.push((BindingScope::Global, key, msg));
+        self
+    }
+
+    pub fn on_override(mut self, key: Key, msg: Msg) -> Self {
+        self.bindings.push((BindingScope::GlobalOverride, key, msg));
+        self
+    }
+
+    pub fn in_scope(mut self, focus: &FocusHandle, key: Key, msg: Msg) -> Self {
+        self.bindings
+            .push((BindingScope::Focus(focus.clone()), key, msg));
+        self
+    }
+
+    /// Route unbound events to a message while `focus` is focused. This is
+    /// how a text input receives ordinary typing without the framework
+    /// owning any editing logic.
+    pub fn fallthrough(
+        mut self,
+        focus: &FocusHandle,
+        map: impl Fn(InputEvent) -> Msg + 'static,
+    ) -> Self {
+        self.fallthrough.push((focus.clone(), Box::new(map)));
+        self
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Text area (Candidate A: state is a plain value in the app model)
+// ───────────────────────────────────────────────────────────────────
+
+/// Editable multi-line text state. Lives in the app model; `update` mutates
+/// it, the view borrows it.
+///
+/// Spike shim: stands in for tui-textarea behind the real ratatui interop
+/// adapter (which needs measure + cursor + render on `&self` — all of which
+/// tui-textarea provides). Editing behavior here is deliberately minimal.
+#[derive(Default)]
+pub struct TextAreaState {
+    lines: Vec<String>,
+    cursor: (usize, usize),
+}
+
+impl TextAreaState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply an ordinary editing event (typed char, backspace, arrows,
+    /// paste). Policy keys (submit, newline chords) are the keymap's job,
+    /// not this widget's.
+    pub fn handle(&mut self, event: &InputEvent) {
+        match event {
+            InputEvent::Key(k) => {
+                if let crossterm::event::KeyCode::Char(c) = k.code {
+                    if self.lines.is_empty() {
+                        self.lines.push(String::new());
+                    }
+                    self.lines[self.cursor.1].push(c);
+                    self.cursor.0 += 1;
+                }
+                // Backspace/arrows/etc. elided in the shim.
+            }
+            InputEvent::Paste(s) => {
+                if self.lines.is_empty() {
+                    self.lines.push(String::new());
+                }
+                self.lines[self.cursor.1].push_str(s);
+            }
+        }
+    }
+
+    pub fn insert_newline(&mut self) {
+        self.lines.push(String::new());
+        self.cursor = (0, self.lines.len() - 1);
+    }
+
+    pub fn text(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    pub fn set_text(&mut self, text: &str) {
+        self.lines = text.split('\n').map(String::from).collect();
+        let last = self.lines.len().saturating_sub(1);
+        self.cursor = (self.lines.get(last).map_or(0, String::len), last);
+    }
+
+    /// Take the content and clear (the submit path).
+    pub fn take_text(&mut self) -> String {
+        let text = self.text();
+        self.lines.clear();
+        self.cursor = (0, 0);
+        text
+    }
+
+    pub fn is_blank(&self) -> bool {
+        self.lines.iter().all(|l| l.trim().is_empty())
+    }
+
+    /// Rows needed at the given content width (honest measurement).
+    pub fn measure(&self, _width: u16) -> u16 {
+        (self.lines.len() as u16).max(1)
+    }
+}
+
+/// Bordered text area view. Borrows its state from the model.
+pub struct TextArea<'a> {
+    state: &'a TextAreaState,
+    title: String,
+    title_right: String,
+    footer: String,
+    placeholder: String,
+    max_height: u16,
+    focus: Option<FocusHandle>,
+}
+
+pub fn text_area(state: &TextAreaState) -> TextArea<'_> {
+    TextArea {
+        state,
+        title: String::new(),
+        title_right: String::new(),
+        footer: String::new(),
+        placeholder: String::new(),
+        max_height: u16::MAX,
+        focus: None,
+    }
+}
+
+impl<'a> TextArea<'a> {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    pub fn title_right(mut self, title: impl Into<String>) -> Self {
+        self.title_right = title.into();
+        self
+    }
+
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.footer = footer.into();
+        self
+    }
+
+    pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
+    }
+
+    pub fn max_height(mut self, rows: u16) -> Self {
+        self.max_height = rows;
+        self
+    }
+
+    /// Bind focus: the runtime shows this element's cursor and routes
+    /// events here while the handle is focused. Focus-dependent visuals
+    /// (cursor visibility, placeholder) come from `handle.is_focused()` —
+    /// no `active` prop shadowing focus in app state.
+    pub fn track_focus(mut self, focus: &FocusHandle) -> Self {
+        self.focus = Some(focus.clone());
+        self
+    }
+}
+
+impl<Msg> Element<Msg> for TextArea<'_> {
+    fn height(&self, width: u16) -> u16 {
+        // content + border chrome, capped
+        (self.state.measure(width.saturating_sub(4)) + 2).min(self.max_height)
+    }
+
+    fn cursor(&self, _area: Rect) -> Option<(u16, u16)> {
+        let focused = self.focus.as_ref().is_some_and(FocusHandle::is_focused);
+        focused.then_some((
+            self.state.cursor.0 as u16 + 2,
+            self.state.cursor.1 as u16 + 1,
+        ))
+    }
+}


### PR DESCRIPTION
The spec for the v2 timeline/Elm redesign (`.planning/REDESIGN.md` — "committed output is an effect; the live tail is a view") plus the compile-only bake-off crate (`crates/spike`) that ported Atuin AI's agent turn view, the diff views, InputBox (twice: strict-Elm vs framework-managed state), and a driver-loop sketch into the candidate API. Verdicts live in `crates/spike/FINDINGS.md`: fluent builders over a macro, strict-Elm widget state, keymap-only message emission.

The spike is never published and exists as the evidence trail for the API decisions; happy to drop it from the merge if we'd rather not carry it on `main`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
