### PR TITLE
v2 redesign: Msg-free element layer, Engine::commit, and Timeline

### DIFF
--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -312,12 +312,11 @@ Still open:
   behavior; massive simplification.)
 - **O4 — naming:** working names `eye_declare_engine` / `eye_declare_next`; real names
   (and whether v2 is `eye_declare 1.0` or a rename) decided at the end.
-- **O7 — is `Element<Msg>` vestigial? (new, from Port 4.)** With keymap-only
-  emission, nothing on `Element` carries `Msg`; `map_msg` is a phantom
-  re-wrap. A `Msg`-free `Element` would dissolve the `ElementExt`/`Fluent`
-  trait split and all `Msg`-inference concerns. Counterpoint: element-level
-  `on_click` might want it back for mouse support (alternative: runtime
-  hit-testing routed through focus/keymap). Lean: build `Msg`-free first.
+- **O7 — RESOLVED → `Element` is `Msg`-free** (built that way in
+  `eye_declare_next`; dissolved the `ElementExt<Msg>`/`Fluent` split and
+  all `Msg`-inference concerns). Revisit only if mouse support wants
+  element-level emission; runtime hit-testing → focus/keymap is the
+  planned alternative.
 
 ## Bake-off outcomes (Phase 1 exit criteria)
 
@@ -351,6 +350,19 @@ Still open:
    is the clear-and-redraw fallback). No crossterm dependency in the engine.
    **← Phase 4 next**
 4. **Build the new layer** — new crate, driven by ports of the current `examples/`.
+   **In progress** (`crates/eye_declare_next`, working name):
+   - Slice 1 ✅ (2026-07-15): `Msg`-free element layer — `Element` with
+     required `height(width)`, `AnyElement<'a>` borrowing views, `Col`/`Row`/
+     `Padded`/`Empty`/`Text`/wall-clock `Spinner`, engine-composition tests.
+   - Slice 2 ✅ (2026-07-15): `Engine::commit(rows)` (the v2 append-commit,
+     built on present + `commit_scrolled`), `commit_scrolled` hardened to
+     return cursor-repositioning bytes (the parked-cursor invariant lives in
+     the engine now), and the sync `Timeline` runtime (`push`/`present`/
+     `finalize`) with conversation-flow tests through the VTE terminal.
+   - Next slices: keymap/focus/events + `App`/`update` loop → async driver
+     (tokio, `spawn`/`Task`/subscriptions, animation self-tick) → widgets
+     (`TextAreaState`, feature-flagged markdown, viewport) → resize story
+     (needs O3 decided).
 5. **Atuin AI port** — the validation gate. Success = the four adapters
    (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus
    shadow) delete cleanly and the TUI code shrinks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "eye_declare_next"
+version = "0.0.0"
+dependencies = [
+ "eye_declare_engine",
+ "ratatui-core",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "crates/eye_declare",
     "crates/eye_declare_engine",
     "crates/eye_declare_macros",
+    "crates/eye_declare_next",
     "crates/spike",
 ]

--- a/crates/eye_declare/src/inline.rs
+++ b/crates/eye_declare/src/inline.rs
@@ -319,8 +319,15 @@ impl InlineRenderer {
         }
 
         // Drop the committed rows from the engine's tracking so subsequent
-        // diffs only cover the active region.
-        self.engine.commit_scrolled(committed_height);
+        // diffs only cover the active region. v1 commits only rows already
+        // in scrollback, and the cursor is never in scrollback, so the
+        // cursor-repositioning bytes the engine can emit are impossible
+        // here.
+        let bytes = self.engine.commit_scrolled(committed_height);
+        debug_assert!(
+            bytes.is_empty(),
+            "v1 commits scrollback-only rows; cursor cannot be above them"
+        );
     }
 
     /// Reclaim trailing blank rows after the frame has shrunk.

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -3,6 +3,9 @@
 //! `InlineRenderer` (Phase 2, step 2) — that type now delegates all
 //! terminal mechanics here and keeps only the component-tree concerns.
 
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
 use crate::escape::CursorState;
 use crate::frame::Frame;
 
@@ -203,18 +206,55 @@ impl Engine {
         b"\x1b[2J\x1b[H".to_vec()
     }
 
-    /// Drop the top `committed_height` rows from tracking: they have fully
-    /// scrolled into terminal scrollback and will never be repainted.
-    /// Subsequent diffs only cover the remaining active region.
-    pub fn commit_scrolled(&mut self, committed_height: u16) {
+    /// Commit finished rows above the live tail (the v2 timeline surface).
+    ///
+    /// Stacks `rows` on top of the current tail (the previous frame) and
+    /// presents the combined frame — so growth, burst streaming into
+    /// scrollback, and diffing all go through the verified present path —
+    /// then shifts the committed rows out of tracking via
+    /// [`commit_scrolled`](Engine::commit_scrolled). From the next present
+    /// on, the committed rows behave like any earlier terminal output:
+    /// unaddressable, immutable, drifting into scrollback naturally.
+    pub fn commit(&mut self, rows: &Buffer) -> Vec<u8> {
+        let committed_height = rows.area.height;
         if committed_height == 0 {
-            return;
+            return Vec::new();
         }
+
+        let tail = self.prev_frame.as_ref().map(|f| f.buffer().clone());
+        let stacked = vstack(rows, tail.as_ref(), self.width);
+        let mut output = self.present(Frame::new(stacked), None);
+        output.extend_from_slice(&self.commit_scrolled(committed_height));
+        output
+    }
+
+    /// Drop the top `committed_height` rows from tracking: a pure origin
+    /// shift — those rows become unaddressable and will never be repainted.
+    /// Subsequent diffs only cover the remaining active region.
+    ///
+    /// Invariant: the physical cursor must sit at or below the new origin
+    /// when the shift happens, or region coordinates would desync from the
+    /// terminal. If the cursor is parked above (e.g. the presenting frame's
+    /// cursor hint pointed into the committed rows), this emits a relative
+    /// move down to the new origin first — hence the returned bytes, which
+    /// are empty in the common case.
+    #[must_use]
+    pub fn commit_scrolled(&mut self, committed_height: u16) -> Vec<u8> {
+        if committed_height == 0 {
+            return Vec::new();
+        }
+
+        let mut output = Vec::new();
+        if self.cursor.row < committed_height {
+            crate::escape::write_relative_move(&mut output, &mut self.cursor, committed_height, 0);
+        }
+
         if let Some(ref prev) = self.prev_frame {
             self.prev_frame = Some(prev.slice_top_rows(committed_height));
         }
         self.emitted_rows = self.emitted_rows.saturating_sub(committed_height);
         self.cursor.row = self.cursor.row.saturating_sub(committed_height);
+        output
     }
 
     /// Reclaim trailing blank rows after the frame has shrunk.
@@ -319,5 +359,104 @@ impl Engine {
             // No cursor hint — hide cursor
             output.extend_from_slice(b"\x1b[?25l");
         }
+    }
+}
+
+/// Stack `top` above `bottom` in a fresh buffer of the given width.
+fn vstack(top: &Buffer, bottom: Option<&Buffer>, width: u16) -> Buffer {
+    let top_h = top.area.height;
+    let bottom_h = bottom.map_or(0, |b| b.area.height);
+    let mut out = Buffer::empty(Rect::new(0, 0, width, top_h.saturating_add(bottom_h)));
+    copy_into(&mut out, top, 0);
+    if let Some(bottom) = bottom {
+        copy_into(&mut out, bottom, top_h);
+    }
+    out
+}
+
+fn copy_into(dst: &mut Buffer, src: &Buffer, y_offset: u16) {
+    for y in 0..src.area.height {
+        for x in 0..src.area.width.min(dst.area.width) {
+            dst[(x, y + y_offset)] = src[(src.area.x + x, src.area.y + y)].clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer_with_lines(width: u16, lines: &[&str]) -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, width, lines.len() as u16));
+        for (y, line) in lines.iter().enumerate() {
+            buf.set_stringn(
+                0,
+                y as u16,
+                line,
+                width as usize,
+                ratatui_core::style::Style::default(),
+            );
+        }
+        buf
+    }
+
+    #[test]
+    fn commit_scrolled_is_silent_when_cursor_below_origin() {
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["aaa", "bbb"])), None);
+        // Cursor ended on the last diffed row (row 1), at/below origin 1.
+        let bytes = engine.commit_scrolled(1);
+        assert!(bytes.is_empty());
+        assert_eq!(engine.emitted_rows(), 1);
+    }
+
+    #[test]
+    fn commit_scrolled_moves_cursor_parked_in_committed_rows() {
+        let mut engine = Engine::new(10, 24);
+        // Cursor hint parks the physical cursor at the very top row.
+        let _ = engine.present(
+            Frame::new(buffer_with_lines(10, &["aaa", "bbb"])),
+            Some((0, 0)),
+        );
+        let bytes = engine.commit_scrolled(1);
+        assert!(
+            !bytes.is_empty(),
+            "cursor above the new origin must be moved down before the shift"
+        );
+        assert_eq!(engine.cursor.row, 0, "cursor is at the new origin");
+        assert_eq!(engine.emitted_rows(), 1);
+    }
+
+    #[test]
+    fn commit_stacks_rows_above_tail_and_shrinks_tracking() {
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["> tail"])), None);
+
+        let _ = engine.commit(&buffer_with_lines(10, &["block one", "block two"]));
+
+        // Tracking covers only the tail again; the block is gone from
+        // the engine's world.
+        assert_eq!(engine.emitted_rows(), 1);
+        let prev = engine.prev_frame.as_ref().unwrap();
+        assert_eq!(prev.area().height, 1);
+        assert_eq!(prev.buffer()[(0, 0)].symbol(), ">");
+    }
+
+    #[test]
+    fn commit_with_empty_rows_is_a_no_op() {
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["> tail"])), None);
+        let bytes = engine.commit(&Buffer::empty(Rect::new(0, 0, 10, 0)));
+        assert!(bytes.is_empty());
+        assert_eq!(engine.emitted_rows(), 1);
+    }
+
+    #[test]
+    fn commit_before_any_present_works() {
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.commit(&buffer_with_lines(10, &["hello"]));
+        assert_eq!(engine.emitted_rows(), 0);
+        let prev = engine.prev_frame.as_ref().unwrap();
+        assert_eq!(prev.area().height, 0);
     }
 }

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -4,7 +4,6 @@
 //! terminal mechanics here and keeps only the component-tree concerns.
 
 use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
 
 use crate::escape::CursorState;
 use crate::frame::Frame;
@@ -208,12 +207,20 @@ impl Engine {
 
     /// Commit finished rows above the live tail (the v2 timeline surface).
     ///
-    /// Stacks `rows` on top of the current tail (the previous frame) and
-    /// presents the combined frame — so growth, burst streaming into
-    /// scrollback, and diffing all go through the verified present path —
-    /// then shifts the committed rows out of tracking via
-    /// [`commit_scrolled`](Engine::commit_scrolled). From the next present
-    /// on, the committed rows behave like any earlier terminal output:
+    /// Presents `rows` as the whole frame — replacing the tail, not
+    /// stacking above it — then shifts them out of tracking via
+    /// [`commit_scrolled`](Engine::commit_scrolled). Presenting the block
+    /// alone is what makes sealing cheap and correct: in the common case
+    /// the block *was* the live tail a moment ago, so identical rows diff
+    /// to nothing and rows already burst-streamed into scrollback are
+    /// never re-emitted. (The earlier stack-above-the-tail formulation
+    /// re-streamed that overlap whenever block + tail exceeded the
+    /// terminal height: the transcript duplicated into scrollback and the
+    /// screen jumped by the block height.)
+    ///
+    /// The region is left empty; callers present the tail again afterward
+    /// (the runtime does so in the same flush). From the next present on,
+    /// the committed rows behave like any earlier terminal output:
     /// unaddressable, immutable, drifting into scrollback naturally.
     pub fn commit(&mut self, rows: &Buffer) -> Vec<u8> {
         let committed_height = rows.area.height;
@@ -221,9 +228,21 @@ impl Engine {
             return Vec::new();
         }
 
-        let tail = self.prev_frame.as_ref().map(|f| f.buffer().clone());
-        let stacked = vstack(rows, tail.as_ref(), self.width);
-        let mut output = self.present(Frame::new(stacked), None);
+        let mut output = self.present(Frame::new(rows.clone()), None);
+
+        // The next region origin is the row below the block. Make it
+        // physically exist with the cursor on it before the shift: an LF
+        // at the screen bottom scrolls one row, elsewhere it only moves
+        // down. This claims exactly the genuinely-new rows.
+        if self.cursor.row < committed_height {
+            output.push(b'\r');
+            self.cursor.col = 0;
+            let down = (committed_height - self.cursor.row) as usize;
+            output.resize(output.len() + down, b'\n');
+            self.cursor.row = committed_height;
+            self.emitted_rows = self.emitted_rows.max(committed_height + 1);
+        }
+
         output.extend_from_slice(&self.commit_scrolled(committed_height));
         output
     }
@@ -362,29 +381,10 @@ impl Engine {
     }
 }
 
-/// Stack `top` above `bottom` in a fresh buffer of the given width.
-fn vstack(top: &Buffer, bottom: Option<&Buffer>, width: u16) -> Buffer {
-    let top_h = top.area.height;
-    let bottom_h = bottom.map_or(0, |b| b.area.height);
-    let mut out = Buffer::empty(Rect::new(0, 0, width, top_h.saturating_add(bottom_h)));
-    copy_into(&mut out, top, 0);
-    if let Some(bottom) = bottom {
-        copy_into(&mut out, bottom, top_h);
-    }
-    out
-}
-
-fn copy_into(dst: &mut Buffer, src: &Buffer, y_offset: u16) {
-    for y in 0..src.area.height {
-        for x in 0..src.area.width.min(dst.area.width) {
-            dst[(x, y + y_offset)] = src[(src.area.x + x, src.area.y + y)].clone();
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui_core::layout::Rect;
 
     fn buffer_with_lines(width: u16, lines: &[&str]) -> Buffer {
         let mut buf = Buffer::empty(Rect::new(0, 0, width, lines.len() as u16));
@@ -428,18 +428,39 @@ mod tests {
     }
 
     #[test]
-    fn commit_stacks_rows_above_tail_and_shrinks_tracking() {
+    fn commit_replaces_tail_and_leaves_an_empty_region() {
         let mut engine = Engine::new(10, 24);
         let _ = engine.present(Frame::new(buffer_with_lines(10, &["> tail"])), None);
 
         let _ = engine.commit(&buffer_with_lines(10, &["block one", "block two"]));
 
-        // Tracking covers only the tail again; the block is gone from
-        // the engine's world.
+        // The block is gone from the engine's world; the region is the
+        // single claimed origin row, empty until the caller re-presents
+        // the tail (as the runtime does in the same flush).
         assert_eq!(engine.emitted_rows(), 1);
         let prev = engine.prev_frame.as_ref().unwrap();
-        assert_eq!(prev.area().height, 1);
-        assert_eq!(prev.buffer()[(0, 0)].symbol(), ">");
+        assert_eq!(prev.area().height, 0);
+    }
+
+    #[test]
+    fn commit_of_the_presented_tail_emits_no_content_bytes() {
+        // The seal case: the block IS the previous tail. Nothing needs
+        // repainting — the only bytes claim the new origin row.
+        let mut engine = Engine::new(10, 24);
+        let content = buffer_with_lines(10, &["aaa", "bbb", "ccc"]);
+        let _ = engine.present(Frame::new(content.clone()), None);
+
+        let bytes = engine.commit(&content);
+        let printable: String = String::from_utf8_lossy(&bytes).into_owned();
+        assert!(
+            !printable.contains("aaa") && !printable.contains("ccc"),
+            "sealing identical content must not repaint it, got {printable:?}"
+        );
+        assert!(
+            printable.ends_with("\r\n"),
+            "seal should end by claiming the origin row, got {printable:?}"
+        );
+        assert_eq!(engine.emitted_rows(), 1);
     }
 
     #[test]
@@ -455,7 +476,8 @@ mod tests {
     fn commit_before_any_present_works() {
         let mut engine = Engine::new(10, 24);
         let _ = engine.commit(&buffer_with_lines(10, &["hello"]));
-        assert_eq!(engine.emitted_rows(), 0);
+        // The claimed origin row below the block is the whole region.
+        assert_eq!(engine.emitted_rows(), 1);
         let prev = engine.prev_frame.as_ref().unwrap();
         assert_eq!(prev.area().height, 0);
     }

--- a/crates/eye_declare_next/Cargo.toml
+++ b/crates/eye_declare_next/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "eye_declare_next"
+description = "Timeline/Elm inline TUI layer (v2 redesign, working name — see .planning/REDESIGN.md)"
+repository = "https://github.com/BinaryMuse/eye-declare"
+version = "0.0.0"
+edition = "2024"
+license = "MIT"
+publish = false
+
+[dependencies]
+eye_declare_engine = { path = "../eye_declare_engine" }
+ratatui-core = "0.1"
+
+[dev-dependencies]
+eye_declare_engine = { path = "../eye_declare_engine", features = ["test-util"] }

--- a/crates/eye_declare_next/src/element.rs
+++ b/crates/eye_declare_next/src/element.rs
@@ -1,0 +1,218 @@
+//! The core `Element` trait and universal combinators.
+//!
+//! Elements are `Msg`-free (bake-off O7): they describe structure and
+//! pixels. Message emission lives in the keymap layer, so display code
+//! never names the app's message type and none of the spike's
+//! `Msg`-inference workarounds are needed.
+
+use std::time::Duration;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+/// A renderable piece of UI.
+///
+/// The contract is honest measurement: [`height`](Element::height) must
+/// return exactly the rows [`render`](Element::render) will use at the
+/// given width, and must be cheap — the runtime calls it every frame for
+/// every element in the live tail.
+pub trait Element {
+    /// Rows needed at the given width. Exact, cheap, no side effects.
+    fn height(&self, width: u16) -> u16;
+
+    /// Draw into `area` of `buf`. `area` is sized by the caller from
+    /// [`height`](Element::height) (possibly clamped at the buffer edge).
+    fn render(&self, area: Rect, buf: &mut Buffer);
+
+    /// Frame interval if self-animating (e.g. a live spinner). The runtime
+    /// re-presents the tail at the smallest returned interval while any
+    /// animated element is present.
+    fn animated(&self) -> Option<Duration> {
+        None
+    }
+
+    /// Hardware cursor position relative to `area`, when this element is
+    /// focused. `None` hides the cursor.
+    fn cursor(&self, _area: Rect) -> Option<(u16, u16)> {
+        None
+    }
+}
+
+/// A boxed, type-erased element. Heterogeneous match arms converge on this
+/// via [`ElementExt::any`].
+///
+/// Carries a lifetime so views can borrow the app model (bake-off rule 3):
+/// the tail is built, rendered, and dropped within one frame, so model
+/// borrows are naturally scoped. Fully-owned trees are `AnyElement<'static>`.
+pub type AnyElement<'a> = Box<dyn Element + 'a>;
+
+impl Element for Box<dyn Element + '_> {
+    fn height(&self, width: u16) -> u16 {
+        self.as_ref().height(width)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        self.as_ref().render(area, buf)
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        self.as_ref().animated()
+    }
+
+    fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+        self.as_ref().cursor(area)
+    }
+}
+
+/// Combinators available on every element.
+pub trait ElementExt: Element + Sized {
+    /// Type-erase, for heterogeneous branches.
+    fn any<'a>(self) -> AnyElement<'a>
+    where
+        Self: 'a,
+    {
+        Box::new(self)
+    }
+
+    /// Offset by `cols` columns of left padding.
+    fn pad_left(self, cols: u16) -> Padded<Self> {
+        Padded {
+            inner: self,
+            left: cols,
+            top: 0,
+        }
+    }
+
+    /// Offset by `rows` rows of top padding.
+    fn pad_top(self, rows: u16) -> Padded<Self> {
+        Padded {
+            inner: self,
+            left: 0,
+            top: rows,
+        }
+    }
+}
+
+impl<E: Element> ElementExt for E {}
+
+/// Conditional-builder combinators, available on every builder type
+/// (elements, keymaps, anything chainable).
+pub trait Fluent: Sized {
+    /// Apply `f` only when `cond` holds.
+    fn when(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond { f(self) } else { self }
+    }
+
+    /// Apply `f` with the value when present.
+    fn when_some<T>(self, value: Option<T>, f: impl FnOnce(Self, T) -> Self) -> Self {
+        match value {
+            Some(v) => f(self, v),
+            None => self,
+        }
+    }
+}
+
+impl<T> Fluent for T {}
+
+/// An element offset by padding. Produced by [`ElementExt::pad_left`] /
+/// [`ElementExt::pad_top`]; stack them for both.
+pub struct Padded<E> {
+    inner: E,
+    left: u16,
+    top: u16,
+}
+
+impl<E: Element> Element for Padded<E> {
+    fn height(&self, width: u16) -> u16 {
+        let inner_width = width.saturating_sub(self.left);
+        if inner_width == 0 {
+            return self.top;
+        }
+        self.top.saturating_add(self.inner.height(inner_width))
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let inner = Rect::new(
+            area.x.saturating_add(self.left),
+            area.y.saturating_add(self.top),
+            area.width.saturating_sub(self.left),
+            area.height.saturating_sub(self.top),
+        );
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        self.inner.render(inner, buf);
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        self.inner.animated()
+    }
+
+    fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+        let inner = Rect::new(
+            area.x.saturating_add(self.left),
+            area.y.saturating_add(self.top),
+            area.width.saturating_sub(self.left),
+            area.height.saturating_sub(self.top),
+        );
+        self.inner
+            .cursor(inner)
+            .map(|(col, row)| (col.saturating_add(self.left), row.saturating_add(self.top)))
+    }
+}
+
+/// The nothing element: zero height, renders nothing. For match arms and
+/// conditionals with no output.
+pub struct Empty;
+
+pub fn empty() -> Empty {
+    Empty
+}
+
+impl Element for Empty {
+    fn height(&self, _width: u16) -> u16 {
+        0
+    }
+
+    fn render(&self, _area: Rect, _buf: &mut Buffer) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::text::text;
+
+    #[test]
+    fn empty_is_zero_height() {
+        assert_eq!(Element::height(&empty(), 80), 0);
+    }
+
+    #[test]
+    fn padded_adds_top_rows_and_left_cols() {
+        let el = text("hi").pad_left(2).pad_top(1);
+        assert_eq!(el.height(10), 2); // 1 top pad + 1 text row
+
+        let area = Rect::new(0, 0, 10, 2);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        assert_eq!(buf[(2, 1)].symbol(), "h");
+        assert_eq!(buf[(3, 1)].symbol(), "i");
+        assert_eq!(buf[(0, 0)].symbol(), " ");
+    }
+
+    #[test]
+    fn padded_narrows_wrap_width() {
+        // "hello world" wraps at width 6; with pad_left(4) the inner
+        // width at outer width 10 is 6 → 2 rows.
+        let el = text("hello world").pad_left(4);
+        assert_eq!(el.height(10), 2);
+    }
+
+    #[test]
+    fn any_erases_heterogeneous_branches() {
+        let branch =
+            |b: bool| -> AnyElement<'static> { if b { text("yes").any() } else { empty().any() } };
+        assert_eq!(branch(true).height(80), 1);
+        assert_eq!(branch(false).height(80), 0);
+    }
+}

--- a/crates/eye_declare_next/src/lib.rs
+++ b/crates/eye_declare_next/src/lib.rs
@@ -23,8 +23,10 @@ pub mod element;
 pub mod spinner;
 pub mod stack;
 pub mod text;
+pub mod timeline;
 
 pub use element::{AnyElement, Element, ElementExt, Empty, Fluent, Padded, empty};
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
 pub use text::{Text, text};
+pub use timeline::Timeline;

--- a/crates/eye_declare_next/src/lib.rs
+++ b/crates/eye_declare_next/src/lib.rs
@@ -1,0 +1,30 @@
+//! The v2 timeline/Elm layer (working name; spec question O4).
+//!
+//! Built on `eye_declare_engine` per `.planning/REDESIGN.md` and validated
+//! by the `spike` crate's bake-off. Core commitments:
+//!
+//! - **Committed output is an effect; the live tail is a view.** Blocks are
+//!   pushed once from `update` and flow into scrollback; only the small
+//!   tail re-renders, every frame, with no dirty tracking.
+//! - **Strict-Elm state** (bake-off O1): widget state lives in the app
+//!   model as plain values; views borrow it.
+//! - **`Msg`-free elements** (bake-off O7): elements describe structure and
+//!   pixels only. All message emission happens in the keymap layer, so the
+//!   element tree carries no message type parameter.
+//! - **Honest measurement:** `Element::height(width)` is required, exact,
+//!   and cheap. No probe rendering.
+//!
+//! Build order (thin slices): element layer + layout + text ✅ → runtime
+//! core (tail present loop) → blocks/commit → keymap/focus/events → async
+//! driver (spawn/Task/subscriptions) → widgets (text area, markdown,
+//! viewport).
+
+pub mod element;
+pub mod spinner;
+pub mod stack;
+pub mod text;
+
+pub use element::{AnyElement, Element, ElementExt, Empty, Fluent, Padded, empty};
+pub use spinner::{Spinner, spinner};
+pub use stack::{Col, Row, Width, col, row};
+pub use text::{Text, text};

--- a/crates/eye_declare_next/src/spinner.rs
+++ b/crates/eye_declare_next/src/spinner.rs
@@ -1,0 +1,131 @@
+//! Animated spinner. Stateless by design: the frame index derives from the
+//! wall clock, because the runtime re-presents the tail continuously while
+//! any element reports [`animated`](crate::Element::animated). No effect
+//! system, no per-widget tick state — the v1 `use_interval` machinery has
+//! no v2 equivalent because nothing needs it.
+
+use std::time::Duration;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+
+use crate::element::Element;
+
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const FRAME_MS: u64 = 80;
+
+pub struct Spinner {
+    label: String,
+    done: bool,
+    hide_checkmark: bool,
+    label_style: Style,
+    spinner_style: Style,
+}
+
+pub fn spinner(label: impl Into<String>) -> Spinner {
+    Spinner {
+        label: label.into(),
+        done: false,
+        hide_checkmark: false,
+        label_style: Style::default(),
+        spinner_style: Style::default(),
+    }
+}
+
+impl Spinner {
+    pub fn done(mut self, done: bool) -> Self {
+        self.done = done;
+        self
+    }
+
+    /// When done, show only the label (no leading checkmark).
+    pub fn hide_checkmark(mut self) -> Self {
+        self.hide_checkmark = true;
+        self
+    }
+
+    pub fn label_style(mut self, style: Style) -> Self {
+        self.label_style = style;
+        self
+    }
+
+    pub fn spinner_style(mut self, style: Style) -> Self {
+        self.spinner_style = style;
+        self
+    }
+
+    fn marker(&self) -> Option<&'static str> {
+        if self.done {
+            if self.hide_checkmark {
+                None
+            } else {
+                Some("✓")
+            }
+        } else {
+            let millis = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            Some(FRAMES[((millis / FRAME_MS) % FRAMES.len() as u64) as usize])
+        }
+    }
+}
+
+impl Element for Spinner {
+    fn height(&self, width: u16) -> u16 {
+        if width == 0 { 0 } else { 1 }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let mut x = area.x;
+        if let Some(marker) = self.marker() {
+            buf.set_stringn(x, area.y, marker, area.width as usize, self.spinner_style);
+            x = x.saturating_add(2); // marker + space
+        }
+        if !self.label.is_empty() && x < area.right() {
+            let max = (area.right() - x) as usize;
+            buf.set_stringn(x, area.y, &self.label, max, self.label_style);
+        }
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        (!self.done).then(|| Duration::from_millis(FRAME_MS))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_spinner_is_animated() {
+        assert_eq!(
+            spinner("working").animated(),
+            Some(Duration::from_millis(80))
+        );
+        assert_eq!(spinner("done").done(true).animated(), None);
+    }
+
+    #[test]
+    fn done_renders_checkmark_and_label() {
+        let el = spinner("built").done(true);
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        assert_eq!(buf[(0, 0)].symbol(), "✓");
+        assert_eq!(buf[(2, 0)].symbol(), "b");
+    }
+
+    #[test]
+    fn hide_checkmark_starts_at_label() {
+        let el = spinner("ran").done(true).hide_checkmark();
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        assert_eq!(buf[(0, 0)].symbol(), "r");
+    }
+}

--- a/crates/eye_declare_next/src/stack.rs
+++ b/crates/eye_declare_next/src/stack.rs
@@ -85,14 +85,24 @@ impl Element for Col<'_> {
 
     fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
         // First child that wants the cursor wins; offset by its position.
+        // Mirrors render's clipping: a child (or cursor row) below the
+        // given height must not place the hardware cursor on a row that
+        // was never painted.
         let mut y_offset: u16 = 0;
         for (i, child) in self.children.iter().enumerate() {
             if i > 0 {
                 y_offset = y_offset.saturating_add(self.gap);
             }
-            let h = child.height(area.width);
+            if y_offset >= area.height {
+                break;
+            }
+            let h = child
+                .height(area.width)
+                .min(area.height.saturating_sub(y_offset));
             let child_area = Rect::new(area.x, area.y.saturating_add(y_offset), area.width, h);
-            if let Some((col, row)) = child.cursor(child_area) {
+            if let Some((col, row)) = child.cursor(child_area)
+                && row < h
+            {
                 return Some((col, row.saturating_add(y_offset)));
             }
             y_offset = y_offset.saturating_add(h);
@@ -296,5 +306,29 @@ mod tests {
         let el = col().child(text("above")).child(CursorAt(3, 0).pad_left(2));
         let area = Rect::new(0, 0, 10, 2);
         assert_eq!(el.cursor(area), Some((5, 1)));
+    }
+
+    #[test]
+    fn cursor_of_clipped_child_is_suppressed() {
+        struct CursorAt(u16, u16);
+        impl Element for CursorAt {
+            fn height(&self, _w: u16) -> u16 {
+                1
+            }
+            fn render(&self, _a: Rect, _b: &mut Buffer) {}
+            fn cursor(&self, _a: Rect) -> Option<(u16, u16)> {
+                Some((self.0, self.1))
+            }
+        }
+
+        // The cursor-bearing child sits on row 2, but only 2 rows are
+        // rendered — the hardware cursor must not land on a hidden row.
+        let el = col()
+            .child(text("a"))
+            .child(text("b"))
+            .child(CursorAt(0, 0));
+        assert_eq!(el.cursor(Rect::new(0, 0, 10, 2)), None);
+        // With enough height it comes back.
+        assert_eq!(el.cursor(Rect::new(0, 0, 10, 3)), Some((0, 2)));
     }
 }

--- a/crates/eye_declare_next/src/stack.rs
+++ b/crates/eye_declare_next/src/stack.rs
@@ -1,0 +1,300 @@
+//! Layout containers: vertical [`Col`] and horizontal [`Row`].
+//!
+//! Layout is content-driven (heights come from children; no vertical flex),
+//! matching v1's model: correct for inline UIs where height is unbounded
+//! scrollback. `Row` allocates widths by `Fixed`/`Fill`, semantics ported
+//! from v1's `allocate_widths`.
+
+use std::time::Duration;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+use crate::element::{AnyElement, Element};
+
+/// Vertical stack. Children get the full width; heights are summed.
+pub struct Col<'a> {
+    children: Vec<AnyElement<'a>>,
+    gap: u16,
+}
+
+pub fn col<'a>() -> Col<'a> {
+    Col {
+        children: Vec::new(),
+        gap: 0,
+    }
+}
+
+impl<'a> Col<'a> {
+    /// Blank rows between children.
+    pub fn gap(mut self, rows: u16) -> Self {
+        self.gap = rows;
+        self
+    }
+
+    pub fn child(mut self, child: impl Element + 'a) -> Self {
+        self.children.push(Box::new(child));
+        self
+    }
+
+    pub fn children<I>(mut self, children: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Element + 'a,
+    {
+        self.children
+            .extend(children.into_iter().map(|c| Box::new(c) as AnyElement<'a>));
+        self
+    }
+}
+
+impl Element for Col<'_> {
+    fn height(&self, width: u16) -> u16 {
+        let content: u16 = self
+            .children
+            .iter()
+            .map(|c| c.height(width))
+            .fold(0, u16::saturating_add);
+        let gaps = self
+            .gap
+            .saturating_mul(self.children.len().saturating_sub(1) as u16);
+        content.saturating_add(gaps)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let mut y = area.y;
+        let bottom = area.bottom();
+        for (i, child) in self.children.iter().enumerate() {
+            if i > 0 {
+                y = y.saturating_add(self.gap);
+            }
+            if y >= bottom {
+                break;
+            }
+            let h = child.height(area.width).min(bottom - y);
+            if h > 0 {
+                child.render(Rect::new(area.x, y, area.width, h), buf);
+            }
+            y = y.saturating_add(h);
+        }
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        self.children.iter().filter_map(|c| c.animated()).min()
+    }
+
+    fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+        // First child that wants the cursor wins; offset by its position.
+        let mut y_offset: u16 = 0;
+        for (i, child) in self.children.iter().enumerate() {
+            if i > 0 {
+                y_offset = y_offset.saturating_add(self.gap);
+            }
+            let h = child.height(area.width);
+            let child_area = Rect::new(area.x, area.y.saturating_add(y_offset), area.width, h);
+            if let Some((col, row)) = child.cursor(child_area) {
+                return Some((col, row.saturating_add(y_offset)));
+            }
+            y_offset = y_offset.saturating_add(h);
+        }
+        None
+    }
+}
+
+/// Cell width within a [`Row`].
+#[derive(Clone, Copy)]
+pub enum Width {
+    Fixed(u16),
+    /// Remaining space, split equally among `Fill` cells (leftover columns
+    /// go one each to the leftmost fills).
+    Fill,
+}
+
+/// Horizontal layout. Row height is the max of cell heights at their
+/// allocated widths; cells are top-aligned.
+pub struct Row<'a> {
+    cells: Vec<(Width, AnyElement<'a>)>,
+}
+
+pub fn row<'a>() -> Row<'a> {
+    Row { cells: Vec::new() }
+}
+
+impl<'a> Row<'a> {
+    pub fn fixed(mut self, cols: u16, child: impl Element + 'a) -> Self {
+        self.cells.push((Width::Fixed(cols), Box::new(child)));
+        self
+    }
+
+    pub fn fill(mut self, child: impl Element + 'a) -> Self {
+        self.cells.push((Width::Fill, Box::new(child)));
+        self
+    }
+
+    /// v1 `allocate_widths` semantics: fixed cells reserve their width in
+    /// order (clamped to what remains); fills split the remainder equally,
+    /// with leftover columns distributed one each from the left.
+    fn allocate(&self, total: u16) -> Vec<u16> {
+        let mut widths = vec![0u16; self.cells.len()];
+        let mut remaining = total;
+        let mut fills = Vec::new();
+
+        for (i, (w, _)) in self.cells.iter().enumerate() {
+            match w {
+                Width::Fixed(n) => {
+                    let take = (*n).min(remaining);
+                    widths[i] = take;
+                    remaining -= take;
+                }
+                Width::Fill => fills.push(i),
+            }
+        }
+
+        if !fills.is_empty() {
+            let each = remaining / fills.len() as u16;
+            let extra = remaining % fills.len() as u16;
+            for (j, &i) in fills.iter().enumerate() {
+                widths[i] = each + u16::from((j as u16) < extra);
+            }
+        }
+
+        widths
+    }
+}
+
+impl Element for Row<'_> {
+    fn height(&self, width: u16) -> u16 {
+        let widths = self.allocate(width);
+        self.cells
+            .iter()
+            .zip(&widths)
+            .map(|((_, c), &w)| if w == 0 { 0 } else { c.height(w) })
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let widths = self.allocate(area.width);
+        let mut x = area.x;
+        for ((_, child), &w) in self.cells.iter().zip(&widths) {
+            if w > 0 {
+                child.render(Rect::new(x, area.y, w, area.height), buf);
+            }
+            x = x.saturating_add(w);
+        }
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        self.cells.iter().filter_map(|(_, c)| c.animated()).min()
+    }
+
+    fn cursor(&self, area: Rect) -> Option<(u16, u16)> {
+        let widths = self.allocate(area.width);
+        let mut x_offset: u16 = 0;
+        for ((_, child), &w) in self.cells.iter().zip(&widths) {
+            let cell_area = Rect::new(area.x.saturating_add(x_offset), area.y, w, area.height);
+            if w > 0
+                && let Some((col, row)) = child.cursor(cell_area)
+            {
+                return Some((col.saturating_add(x_offset), row));
+            }
+            x_offset = x_offset.saturating_add(w);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::element::ElementExt;
+    use crate::text::text;
+
+    fn rendered(el: &impl Element, width: u16) -> Vec<String> {
+        let height = el.height(width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        (0..height)
+            .map(|y| {
+                let mut line: String = (0..width).map(|x| buf[(x, y)].symbol()).collect();
+                while line.ends_with(' ') {
+                    line.pop();
+                }
+                line
+            })
+            .collect()
+    }
+
+    #[test]
+    fn col_stacks_children() {
+        let el = col().child(text("one")).child(text("two"));
+        assert_eq!(el.height(10), 2);
+        assert_eq!(rendered(&el, 10), vec!["one", "two"]);
+    }
+
+    #[test]
+    fn col_gap_inserts_blank_rows() {
+        let el = col().gap(1).child(text("a")).child(text("b"));
+        assert_eq!(el.height(10), 3);
+        assert_eq!(rendered(&el, 10), vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn col_sums_wrapped_heights() {
+        let el = col().child(text("hello world")).child(text("x"));
+        assert_eq!(el.height(6), 3); // 2 wrapped + 1
+    }
+
+    #[test]
+    fn row_fixed_and_fill() {
+        let el = row().fixed(2, text("> ")).fill(text("hello"));
+        assert_eq!(el.height(10), 1);
+        assert_eq!(rendered(&el, 10), vec!["> hello"]);
+    }
+
+    #[test]
+    fn row_fill_gets_remaining_width_for_wrapping() {
+        // Fill cell gets 10 - 4 = 6 cols: "hello world" wraps to 2 rows.
+        let el = row().fixed(4, text("gut ")).fill(text("hello world"));
+        assert_eq!(el.height(10), 2);
+        assert_eq!(rendered(&el, 10), vec!["gut hello", "    world"]);
+    }
+
+    #[test]
+    fn row_splits_fill_equally_with_leftmost_remainder() {
+        let el = row()
+            .fill(empty_cell())
+            .fill(empty_cell())
+            .fill(empty_cell());
+        assert_eq!(el.allocate(10), vec![4, 3, 3]);
+    }
+
+    fn empty_cell() -> crate::element::Empty {
+        crate::element::Empty
+    }
+
+    #[test]
+    fn row_fixed_clamps_to_available() {
+        let el = row().fixed(8, text("aaaaaaaa")).fixed(8, text("b"));
+        assert_eq!(el.allocate(10), vec![8, 2]);
+    }
+
+    #[test]
+    fn col_cursor_offsets_by_child_position() {
+        struct CursorAt(u16, u16);
+        impl Element for CursorAt {
+            fn height(&self, _w: u16) -> u16 {
+                1
+            }
+            fn render(&self, _a: Rect, _b: &mut Buffer) {}
+            fn cursor(&self, _a: Rect) -> Option<(u16, u16)> {
+                Some((self.0, self.1))
+            }
+        }
+
+        let el = col().child(text("above")).child(CursorAt(3, 0).pad_left(2));
+        let area = Rect::new(0, 0, 10, 2);
+        assert_eq!(el.cursor(area), Some((5, 1)));
+    }
+}

--- a/crates/eye_declare_next/src/text.rs
+++ b/crates/eye_declare_next/src/text.rs
@@ -1,0 +1,129 @@
+//! Word-wrapped styled text, the workhorse leaf element.
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span, Text as RText};
+use ratatui_core::widgets::Widget;
+
+use crate::element::Element;
+
+/// A run of styled spans, word-wrapped at the render width. Newlines inside
+/// span content start new lines.
+pub struct Text {
+    spans: Vec<(String, Style)>,
+}
+
+/// Single-span text. `.style()` styles it; `.span()` appends further
+/// styled spans.
+pub fn text(content: impl Into<String>) -> Text {
+    Text {
+        spans: vec![(content.into(), Style::default())],
+    }
+}
+
+impl Text {
+    /// Style the most recently added span (the initial one if none added).
+    pub fn style(mut self, style: Style) -> Self {
+        if let Some(last) = self.spans.last_mut() {
+            last.1 = style;
+        }
+        self
+    }
+
+    /// Append a styled span.
+    pub fn span(mut self, content: impl Into<String>, style: Style) -> Self {
+        self.spans.push((content.into(), style));
+        self
+    }
+
+    /// Build the ratatui text, splitting span content on newlines so `\n`
+    /// starts a new line (a `Span` must not contain newlines).
+    fn to_ratatui(&self) -> RText<'_> {
+        let mut lines: Vec<Line<'_>> = vec![Line::default()];
+        for (content, style) in &self.spans {
+            for (i, part) in content.split('\n').enumerate() {
+                if i > 0 {
+                    lines.push(Line::default());
+                }
+                if !part.is_empty() {
+                    let line = lines.last_mut().expect("lines starts non-empty");
+                    line.spans.push(Span::styled(part, *style));
+                }
+            }
+        }
+        RText::from(lines)
+    }
+}
+
+impl Element for Text {
+    fn height(&self, width: u16) -> u16 {
+        eye_declare_engine::wrap::wrapped_line_count(&self.to_ratatui(), width)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        eye_declare_engine::wrap::wrapping_paragraph(self.to_ratatui()).render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui_core::style::Color;
+
+    fn rendered(el: &impl Element, width: u16) -> Vec<String> {
+        let height = el.height(width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        (0..height)
+            .map(|y| {
+                let mut line: String = (0..width).map(|x| buf[(x, y)].symbol()).collect();
+                while line.ends_with(' ') {
+                    line.pop();
+                }
+                line
+            })
+            .collect()
+    }
+
+    #[test]
+    fn single_line() {
+        assert_eq!(rendered(&text("hello"), 10), vec!["hello"]);
+    }
+
+    #[test]
+    fn wraps_words_at_width() {
+        assert_eq!(rendered(&text("hello world"), 6), vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn newlines_split_lines() {
+        assert_eq!(rendered(&text("a\nb"), 10), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn spans_concatenate_and_carry_style() {
+        let el = text("ab").span("cd", Style::default().fg(Color::Red));
+        assert_eq!(rendered(&el, 10), vec!["abcd"]);
+
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        assert_eq!(buf[(2, 0)].style().fg, Some(Color::Red));
+        assert_ne!(buf[(0, 0)].style().fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn newline_inside_later_span() {
+        let el = text("a").span("b\nc", Style::default());
+        assert_eq!(rendered(&el, 10), vec!["ab", "c"]);
+    }
+
+    #[test]
+    fn empty_text_is_one_blank_row() {
+        // Matches v1 Text: an empty text still occupies a row (a blank
+        // line is content). Use `empty()` for true zero-height.
+        assert_eq!(text("").height(10), 1);
+    }
+}

--- a/crates/eye_declare_next/src/timeline.rs
+++ b/crates/eye_declare_next/src/timeline.rs
@@ -1,0 +1,81 @@
+//! The synchronous runtime core: a timeline of committed blocks plus a
+//! live tail, speaking [`Element`]s on one side and escape bytes on the
+//! other.
+//!
+//! This is both the imperative escape hatch (sync loops, embedding) and
+//! the layer the Elm runtime drives: `ctx.push` lands on [`Timeline::push`],
+//! each frame ends in [`Timeline::present`].
+
+use eye_declare_engine::Engine;
+use eye_declare_engine::frame::Frame;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+use crate::element::Element;
+
+/// A terminal-backed timeline. Blocks pushed become permanent output;
+/// the tail is replaced wholesale on every [`present`](Timeline::present).
+pub struct Timeline {
+    engine: Engine,
+}
+
+impl Timeline {
+    /// Create a timeline for the given content width and terminal height.
+    /// Pass `u16::MAX` as `terminal_height` when no terminal is attached.
+    pub fn new(width: u16, terminal_height: u16) -> Self {
+        Self {
+            engine: Engine::new(width, terminal_height),
+        }
+    }
+
+    pub fn width(&self) -> u16 {
+        self.engine.width()
+    }
+
+    pub fn set_terminal_height(&mut self, height: u16) {
+        self.engine.set_terminal_height(height);
+    }
+
+    /// Commit a finished block above the live tail. The block is rendered
+    /// once at the current width, becomes permanent terminal output, and
+    /// never costs anything again. Irreversible, like `println!`.
+    ///
+    /// Consumes the element: a block is used exactly once.
+    pub fn push(&mut self, block: impl Element) -> Vec<u8> {
+        let buf = render_to_buffer(&block, self.engine.width());
+        self.engine.commit(&buf)
+    }
+
+    /// Replace the live tail. Diffs against the previous tail; identical
+    /// tails produce (nearly) no bytes, which is what makes re-presenting
+    /// every frame the intended usage rather than a cost to avoid.
+    ///
+    /// The tail's [`cursor`](Element::cursor) hint positions the hardware
+    /// cursor; `None` hides it.
+    pub fn present(&mut self, tail: &impl Element) -> Vec<u8> {
+        let width = self.engine.width();
+        let height = tail.height(width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        tail.render(area, &mut buf);
+        let cursor = tail.cursor(area);
+        self.engine.present(Frame::new(buf), cursor)
+    }
+
+    /// Reclaim trailing blank rows for shell handoff (call after a final
+    /// `present` of a shrunken or empty tail).
+    pub fn finalize(&mut self) -> Vec<u8> {
+        self.engine.finalize()
+    }
+}
+
+/// Render an element to an owned buffer at exactly its measured height.
+fn render_to_buffer(el: &impl Element, width: u16) -> Buffer {
+    let height = el.height(width);
+    let area = Rect::new(0, 0, width, height);
+    let mut buf = Buffer::empty(area);
+    if height > 0 {
+        el.render(area, &mut buf);
+    }
+    buf
+}

--- a/crates/eye_declare_next/tests/engine_compose.rs
+++ b/crates/eye_declare_next/tests/engine_compose.rs
@@ -1,0 +1,100 @@
+//! End-to-end: elements → Buffer → Engine → real escape bytes → VTE
+//! terminal. Proves the new layer composes with the extracted engine, and
+//! exercises the timeline shape (present a tail, commit rows above it)
+//! ahead of the runtime existing.
+
+use eye_declare_engine::Engine;
+use eye_declare_engine::frame::Frame;
+use eye_declare_engine::test_terminal::TestTerminal;
+use eye_declare_next::{Element, Fluent, col, text};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+/// Render an element to an owned buffer at the given width.
+fn to_frame(el: &impl Element, width: u16) -> Frame {
+    let height = el.height(width);
+    let area = Rect::new(0, 0, width, height);
+    let mut buf = Buffer::empty(area);
+    el.render(area, &mut buf);
+    Frame::new(buf)
+}
+
+#[test]
+fn tail_reaches_the_terminal() {
+    let tail = col().child(text("hello")).child(text("world"));
+
+    let mut engine = Engine::new(10, 24);
+    let mut term = TestTerminal::new(10, 24);
+    term.feed(&engine.present(to_frame(&tail, 10), None));
+
+    assert_eq!(term.viewport_lines()[0], "hello");
+    assert_eq!(term.viewport_lines()[1], "world");
+}
+
+#[test]
+fn tail_rerender_diffs_to_minimal_output() {
+    let mut engine = Engine::new(10, 24);
+    let mut term = TestTerminal::new(10, 24);
+
+    let tail = |busy: bool| {
+        col()
+            .child(text("status"))
+            .when(busy, |c| c.child(text("busy")))
+    };
+
+    term.feed(&engine.present(to_frame(&tail(true), 10), None));
+    assert_eq!(term.viewport_lines()[1], "busy");
+
+    // Identical frame → no bytes beyond cursor bookkeeping.
+    let bytes = engine.present(to_frame(&tail(true), 10), None);
+    assert!(bytes.len() <= 8, "identical tail should be near-empty diff");
+
+    term.feed(&engine.present(to_frame(&tail(false), 10), None));
+    assert_eq!(term.viewport_lines()[1], "");
+}
+
+#[test]
+fn wrapped_text_measures_and_renders_consistently() {
+    let tail = col().child(text("hello world, this wraps"));
+    let width = 8;
+    let frame = to_frame(&tail, width);
+    assert!(frame.area().height >= 3);
+
+    let mut engine = Engine::new(width, 24);
+    let mut term = TestTerminal::new(8, 24);
+    term.feed(&engine.present(frame, None));
+    assert_eq!(term.viewport_lines()[0], "hello");
+}
+
+/// The v2 timeline shape, hand-driven: commit a block above a live tail by
+/// presenting (block ++ tail) and slicing the block off tracking. This is
+/// the mechanism the runtime's `ctx.push` will use.
+#[test]
+fn commit_block_above_live_tail() {
+    let width = 12;
+    let mut engine = Engine::new(width, 24);
+    let mut term = TestTerminal::new(12, 24);
+
+    // Frame 1: just the tail (an input placeholder).
+    let tail = col().child(text("> input"));
+    term.feed(&engine.present(to_frame(&tail, width), None));
+    assert_eq!(term.viewport_lines()[0], "> input");
+
+    // Commit a block: present block ++ tail, then slice the block rows.
+    let block = col().child(text("you: hi"));
+    let block_height = block.height(width);
+    let stacked = col().child(block).child(text("> input"));
+    term.feed(&engine.present(to_frame(&stacked, width), None));
+    engine.commit_scrolled(block_height);
+
+    assert_eq!(term.viewport_lines()[0], "you: hi");
+    assert_eq!(term.viewport_lines()[1], "> input");
+
+    // The tail keeps updating below the committed block.
+    let tail2 = col().child(text("> inputx"));
+    // After commit_scrolled the engine's frame origin moved up by
+    // block_height; present the tail alone.
+    term.feed(&engine.present(to_frame(&tail2, width), None));
+    assert_eq!(term.viewport_lines()[0], "you: hi");
+    assert_eq!(term.viewport_lines()[1], "> inputx");
+}

--- a/crates/eye_declare_next/tests/engine_compose.rs
+++ b/crates/eye_declare_next/tests/engine_compose.rs
@@ -85,7 +85,7 @@ fn commit_block_above_live_tail() {
     let block_height = block.height(width);
     let stacked = col().child(block).child(text("> input"));
     term.feed(&engine.present(to_frame(&stacked, width), None));
-    engine.commit_scrolled(block_height);
+    term.feed(&engine.commit_scrolled(block_height));
 
     assert_eq!(term.viewport_lines()[0], "you: hi");
     assert_eq!(term.viewport_lines()[1], "> input");

--- a/crates/eye_declare_next/tests/timeline.rs
+++ b/crates/eye_declare_next/tests/timeline.rs
@@ -112,3 +112,54 @@ fn empty_tail_and_finalize_hand_back_to_shell() {
     // shell prompt will land.
     assert_eq!(term.cursor(), (1, 0));
 }
+
+/// The streaming-agent seal shape with a turn taller than the terminal:
+/// the tail grows past the screen (rows burst-stream into scrollback),
+/// then the same content is pushed as a block when the turn completes.
+/// Every line must land in the terminal exactly once — a stale seal path
+/// that re-streams the overlap duplicates the transcript and jumps the
+/// screen by the block height.
+#[test]
+fn sealing_a_tail_taller_than_the_terminal_does_not_duplicate() {
+    let mut tl = Timeline::new(20, 6);
+    let mut term = TestTerminal::new(20, 6);
+
+    let lines: Vec<String> = (0..12).map(|i| format!("reply-line-{i:02}")).collect();
+
+    // Stream: the turn grows row by row, input tail below.
+    term.feed(&tl.present(&text("> ")));
+    for shown in 1..=lines.len() {
+        let turn = lines[..shown].join("\n");
+        term.feed(&tl.present(&col().child(text(turn)).child(text("> "))));
+    }
+
+    // Seal: the finished turn becomes a committed block; tail returns
+    // to just the input.
+    term.feed(&tl.push(text(lines.join("\n"))));
+    term.feed(&tl.present(&text("> ")));
+
+    let all = [term.scrollback_lines(), term.viewport_lines()].concat();
+    for line in &lines {
+        let count = all.iter().filter(|l| *l == line).count();
+        assert_eq!(
+            count, 1,
+            "{line} should appear exactly once, appears {count}×:\n{all:#?}"
+        );
+    }
+
+    // The transcript ends with the tail directly under the last reply
+    // line — no newline burst in between.
+    let last_content = all
+        .iter()
+        .rposition(|l| l == "reply-line-11")
+        .expect("last reply line missing");
+    let tail_row = all
+        .iter()
+        .rposition(|l| l.starts_with('>'))
+        .expect("tail missing");
+    assert_eq!(
+        tail_row,
+        last_content + 1,
+        "tail should sit right below the sealed turn:\n{all:#?}"
+    );
+}

--- a/crates/eye_declare_next/tests/timeline.rs
+++ b/crates/eye_declare_next/tests/timeline.rs
@@ -1,0 +1,114 @@
+//! Behavioral tests for the sync Timeline runtime: a conversation-shaped
+//! push/present flow observed through the VTE test terminal.
+
+use eye_declare_engine::test_terminal::TestTerminal;
+use eye_declare_next::{Element, Timeline, col, spinner, text};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+#[test]
+fn conversation_flow() {
+    let mut tl = Timeline::new(20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    // Idle: just the input placeholder in the tail.
+    term.feed(&tl.present(&text("> ")));
+    assert_eq!(term.viewport_lines()[0], ">");
+
+    // User submits: the turn becomes a block; tail shows the working state.
+    term.feed(&tl.push(text("you: hello")));
+    term.feed(
+        &tl.present(
+            &col()
+                .child(spinner("thinking").done(true))
+                .child(text("> ")),
+        ),
+    );
+    assert_eq!(term.viewport_lines()[0], "you: hello");
+    assert_eq!(term.viewport_lines()[1], "✓ thinking");
+    assert_eq!(term.viewport_lines()[2], ">");
+
+    // Agent turn completes: sealed above the tail, tail returns to idle.
+    term.feed(&tl.push(text("ai: hi there!")));
+    term.feed(&tl.present(&text("> ")));
+    assert_eq!(term.viewport_lines()[0], "you: hello");
+    assert_eq!(term.viewport_lines()[1], "ai: hi there!");
+    assert_eq!(term.viewport_lines()[2], ">");
+
+    // The tail keeps editing below the committed history.
+    term.feed(&tl.present(&text("> more")));
+    assert_eq!(term.viewport_lines()[2], "> more");
+    assert_eq!(term.viewport_lines()[0], "you: hello");
+}
+
+#[test]
+fn history_outgrows_terminal_into_scrollback() {
+    // A tiny 4-row terminal: pushed blocks must flow into scrollback
+    // intact (the burst-streaming path) while the tail stays live.
+    let mut tl = Timeline::new(10, 4);
+    let mut term = TestTerminal::new(10, 4);
+
+    term.feed(&tl.present(&text("> ")));
+    for i in 0..5 {
+        term.feed(&tl.push(text(format!("block {i}"))));
+        term.feed(&tl.present(&text("> ")));
+    }
+
+    let scrollback = term.scrollback_lines();
+    assert!(scrollback.contains(&"block 0".to_string()));
+    assert!(scrollback.contains(&"block 1".to_string()));
+    // The most recent content and the tail are still in the viewport.
+    let viewport = term.viewport_lines();
+    assert!(viewport.contains(&"block 4".to_string()));
+    assert!(viewport.contains(&"> ".trim().to_string()) || viewport.contains(&">".to_string()));
+}
+
+#[test]
+fn tail_cursor_hint_reaches_terminal() {
+    struct CursorAfter(String);
+    impl Element for CursorAfter {
+        fn height(&self, _w: u16) -> u16 {
+            1
+        }
+        fn render(&self, area: Rect, buf: &mut Buffer) {
+            buf.set_stringn(
+                area.x,
+                area.y,
+                &self.0,
+                area.width as usize,
+                ratatui_core::style::Style::default(),
+            );
+        }
+        fn cursor(&self, _area: Rect) -> Option<(u16, u16)> {
+            Some((self.0.len() as u16, 0))
+        }
+    }
+
+    let mut tl = Timeline::new(20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    term.feed(&tl.push(text("history line")));
+    term.feed(&tl.present(&CursorAfter("> hi".into())));
+
+    // Cursor sits after the typed text, on the tail row (row 1: below the
+    // committed block).
+    assert_eq!(term.cursor(), (1, 4));
+}
+
+#[test]
+fn empty_tail_and_finalize_hand_back_to_shell() {
+    let mut tl = Timeline::new(10, 24);
+    let mut term = TestTerminal::new(10, 24);
+
+    term.feed(&tl.push(text("done: ok")));
+    term.feed(&tl.present(&text("> ")));
+    // Exit: clear the tail, reclaim its rows.
+    term.feed(&tl.present(&eye_declare_next::empty()));
+    term.feed(&tl.finalize());
+
+    assert_eq!(term.viewport_lines()[0], "done: ok");
+    assert_eq!(term.viewport_lines()[1], "");
+    // Cursor parked at the row right after content, column 0 — where the
+    // shell prompt will land.
+    assert_eq!(term.cursor(), (1, 0));
+}


### PR DESCRIPTION
The first layer of `eye_declare_next`: a `Msg`-free `Element` trait with required `height(width)` (honest measurement — no probe rendering), `AnyElement<'a>` so views borrow the model, and `Col`/`Row`/`Text`/wall-clock `Spinner`.

On the engine side, `Engine::commit(rows)` appends finished blocks above the live tail, built on `present` plus a hardened `commit_scrolled` that now owns the parked-cursor invariant (returns repositioning bytes instead of leaving the caller to know). The sync `Timeline` runtime (`push`/`present`/`finalize`) proves the conversation flow end-to-end through the VTE terminal.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
