### PR TITLE
v2 redesign: focus, keymap, App/Ctx, and the sync + tokio runtimes

### DIFF
--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -367,9 +367,20 @@ Still open:
      ticks via poll timeout), `Engine::reset_region` for O3-style resize
      (committed content keeps the terminal's reflow), and the first
      runnable app: `cargo run -p eye_declare_next --example echo`.
-   - Next slices: async driver (tokio, `spawn`/`Task`/subscriptions) →
-     widgets (`TextAreaState`, feature-flagged markdown, viewport, borders/
-     `View`-equivalent chrome) → O3/O4 decisions → atuin-ai port (Phase 5).
+   - Slice 4 ✅ (2026-07-15): async driver. `Ctx::spawn` (message streams)
+     and `Ctx::perform` (one-shot futures) collect `Effect`s; `Task` is
+     cancel-on-drop via a hand-rolled waker future, so the core stays
+     executor-agnostic (verified: compiles `--no-default-features`).
+     `driver_tokio::run` multiplexes terminal events, spawned-work
+     messages, and animation ticks; `spawn_effects` is public for custom
+     drivers/tests. Sync `run()` rejects spawning apps with a clear error.
+     Subscriptions deferred to a later slice (nothing Atuin-shaped needs
+     them). `examples/stream.rs` is the mini-agent demo: streaming turn in
+     the tail, sealed to scrollback on completion, Esc-cancels via Task
+     drop.
+   - Next slices: widgets (`TextAreaState`, feature-flagged markdown,
+     viewport, borders/`View`-equivalent chrome) → subscriptions →
+     O3/O4 decisions → atuin-ai port (Phase 5).
 5. **Atuin AI port** — the validation gate. Success = the four adapters
    (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus
    shadow) delete cleanly and the TUI code shrinks.

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -359,10 +359,17 @@ Still open:
      return cursor-repositioning bytes (the parked-cursor invariant lives in
      the engine now), and the sync `Timeline` runtime (`push`/`present`/
      `finalize`) with conversation-flow tests through the VTE terminal.
-   - Next slices: keymap/focus/events + `App`/`update` loop → async driver
-     (tokio, `spawn`/`Task`/subscriptions, animation self-tick) → widgets
-     (`TextAreaState`, feature-flagged markdown, viewport) → resize story
-     (needs O3 decided).
+   - Slice 3 ✅ (2026-07-15): `Focus`/`FocusHandle` (shared-cell design —
+     single-focus by construction, no runtime registry), `Keymap` with the
+     O2 dispatch order + `map` composition, `App`/`Ctx` (push renders
+     immediately, so blocks may borrow), the headlessly-testable `Runtime`
+     (events in, bytes out) + sync `run()` shell (raw mode guard, animation
+     ticks via poll timeout), `Engine::reset_region` for O3-style resize
+     (committed content keeps the terminal's reflow), and the first
+     runnable app: `cargo run -p eye_declare_next --example echo`.
+   - Next slices: async driver (tokio, `spawn`/`Task`/subscriptions) →
+     widgets (`TextAreaState`, feature-flagged markdown, viewport, borders/
+     `View`-equivalent chrome) → O3/O4 decisions → atuin-ai port (Phase 5).
 5. **Atuin AI port** — the validation gate. Success = the four adapters
    (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus
    shadow) delete cleanly and the TUI code shrinks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
 name = "eye_declare_next"
 version = "0.0.0"
 dependencies = [
+ "crossterm",
  "eye_declare_engine",
  "ratatui-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,10 @@ version = "0.0.0"
 dependencies = [
  "crossterm",
  "eye_declare_engine",
+ "futures",
+ "futures-core",
  "ratatui-core",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -187,13 +187,41 @@ impl Engine {
         output
     }
 
+    /// Reset only the managed region for a width change: erase from the
+    /// region's reachable top downward, then drop tracking state. Content
+    /// above the region — committed blocks, in v2 usage — is untouched,
+    /// matching the committed-is-immutable semantics (spec O3): like any
+    /// printed output, it keeps whatever wrapping the terminal's own
+    /// reflow gave it.
+    ///
+    /// Best-effort by nature: the terminal reflowed existing content when
+    /// the width changed, so pre-reflow row arithmetic may be off by the
+    /// reflow delta; the next [`present`](Engine::present) repaints the
+    /// whole region, which bounds any artifact to one frame.
+    pub fn reset_region(&mut self, new_width: u16) -> Vec<u8> {
+        let mut output = Vec::new();
+        // The reachable top of the region (rows above this are in
+        // scrollback and behave as committed regardless).
+        let top = self.emitted_rows.saturating_sub(self.terminal_height);
+        crate::escape::write_relative_move(&mut output, &mut self.cursor, top, 0);
+        output.extend_from_slice(b"\x1b[J");
+
+        self.width = new_width;
+        self.cursor = CursorState::new();
+        self.prev_frame = None;
+        self.emitted_rows = 0;
+        output
+    }
+
     /// Reset for a width change: clear the visible screen (scrollback is
     /// preserved), home the cursor, and drop all tracking state. The caller
     /// should follow up with a fresh [`present`](Engine::present).
     ///
     /// After a width change the terminal has already reflowed existing
     /// content, making cursor tracking invalid; clear-and-redraw is the
-    /// reliable fallback.
+    /// reliable fallback. (v1 semantics — it repaints its whole retained
+    /// tree afterward. v2 callers use [`reset_region`](Engine::reset_region)
+    /// instead, because committed content can never be repainted.)
     pub fn reset(&mut self, new_width: u16) -> Vec<u8> {
         // \x1b[2J = clear entire screen
         // \x1b[H  = cursor to row 1, col 1 (home)

--- a/crates/eye_declare_next/Cargo.toml
+++ b/crates/eye_declare_next/Cargo.toml
@@ -10,7 +10,17 @@ publish = false
 [dependencies]
 crossterm = "0.29"
 eye_declare_engine = { path = "../eye_declare_engine" }
+futures-core = "0.3"
 ratatui-core = "0.1"
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"], optional = true }
+
+[features]
+default = ["tokio"]
+# The tokio driver (driver_tokio::run). The core stays executor-agnostic;
+# disable for sync-only apps with zero async dependencies.
+tokio = ["dep:tokio", "crossterm/event-stream"]
 
 [dev-dependencies]
 eye_declare_engine = { path = "../eye_declare_engine", features = ["test-util"] }
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }

--- a/crates/eye_declare_next/Cargo.toml
+++ b/crates/eye_declare_next/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 publish = false
 
 [dependencies]
+crossterm = "0.29"
 eye_declare_engine = { path = "../eye_declare_engine" }
 ratatui-core = "0.1"
 

--- a/crates/eye_declare_next/examples/echo.rs
+++ b/crates/eye_declare_next/examples/echo.rs
@@ -29,7 +29,7 @@ impl App for Echo {
     type Msg = Msg;
     type Output = usize;
 
-    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, usize>) {
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
         match msg {
             Msg::Typed(c) => self.typed.push(c),
             Msg::Backspace => {

--- a/crates/eye_declare_next/examples/echo.rs
+++ b/crates/eye_declare_next/examples/echo.rs
@@ -1,0 +1,100 @@
+//! The first runnable v2 app: type a line, Enter commits it to the
+//! timeline, Ctrl+C exits. Watch committed lines scroll into native
+//! scrollback while the prompt stays live.
+//!
+//!     cargo run -p eye_declare_next --example echo
+
+use crossterm::event::KeyCode;
+use eye_declare_next::{
+    App, Ctx, Element, Fluent, Focus, FocusHandle, InputEvent, Keymap, col, key, keymap, run,
+    spinner, text,
+};
+use ratatui_core::style::{Color, Style};
+
+#[derive(Clone)]
+enum Msg {
+    Typed(char),
+    Backspace,
+    Submit,
+    Quit,
+}
+
+struct Echo {
+    input_focus: FocusHandle,
+    typed: String,
+    submitted: usize,
+}
+
+impl App for Echo {
+    type Msg = Msg;
+    type Output = usize;
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, usize>) {
+        match msg {
+            Msg::Typed(c) => self.typed.push(c),
+            Msg::Backspace => {
+                self.typed.pop();
+            }
+            Msg::Submit => {
+                if !self.typed.is_empty() {
+                    let line = std::mem::take(&mut self.typed);
+                    self.submitted += 1;
+                    ctx.push(
+                        text("✓ ")
+                            .style(Style::default().fg(Color::Green))
+                            .span(line, Style::default()),
+                    );
+                }
+            }
+            Msg::Quit => ctx.exit(self.submitted),
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        col()
+            .child(
+                text("> ")
+                    .style(Style::default().fg(Color::Cyan))
+                    .span(&*self.typed, Style::default()),
+            )
+            .when(self.submitted > 0, |c| {
+                c.child(
+                    spinner(format!(
+                        "{} line(s) echoed — Ctrl+C to quit",
+                        self.submitted
+                    ))
+                    .done(false)
+                    .spinner_style(Style::default().fg(Color::Yellow)),
+                )
+            })
+    }
+
+    fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Quit)
+            .in_scope(&self.input_focus, key(KeyCode::Enter), Msg::Submit)
+            .fallthrough(&self.input_focus, |ev| match ev {
+                InputEvent::Key(k) => match k.code {
+                    KeyCode::Char(c) => Msg::Typed(c),
+                    KeyCode::Backspace => Msg::Backspace,
+                    _ => Msg::Typed(' '),
+                },
+                InputEvent::Paste(s) => Msg::Typed(s.chars().next().unwrap_or(' ')),
+            })
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let focus = Focus::new();
+    let input_focus = focus.handle();
+    input_focus.focus();
+
+    let submitted = run(Echo {
+        input_focus,
+        typed: String::new(),
+        submitted: 0,
+    })?;
+
+    println!("echoed {submitted} line(s)");
+    Ok(())
+}

--- a/crates/eye_declare_next/examples/stream.rs
+++ b/crates/eye_declare_next/examples/stream.rs
@@ -1,0 +1,158 @@
+//! A miniature streaming agent — the Atuin AI shape on the v2 stack.
+//!
+//!     cargo run -p eye_declare_next --example stream
+//!
+//! Type a prompt, Enter starts a fake agent turn that streams words back;
+//! the streaming text and spinner live in the tail, and the finished turn
+//! seals into scrollback. Esc cancels a turn mid-stream (dropping the Task
+//! is the entire cancellation mechanism). Ctrl+C exits.
+
+use std::time::Duration;
+
+use crossterm::event::KeyCode;
+use eye_declare_next::{
+    App, Ctx, Element, ElementExt, Fluent, Focus, FocusHandle, InputEvent, Keymap, Task, col,
+    driver_tokio, key, keymap, spinner, text,
+};
+use futures::StreamExt;
+use ratatui_core::style::{Color, Modifier, Style};
+
+#[derive(Clone)]
+enum Msg {
+    Typed(char),
+    Backspace,
+    Submit,
+    Delta(String),
+    Done,
+    CancelTurn,
+    Quit,
+}
+
+struct Agent {
+    input_focus: FocusHandle,
+    typed: String,
+    response: String,
+    streaming: Option<Task>,
+}
+
+impl Agent {
+    fn seal_turn(&mut self, ctx: &mut Ctx<'_, Self>, note: &str) {
+        let response = std::mem::take(&mut self.response);
+        ctx.push(
+            col()
+                .child(text(" agent ").style(Style::default().add_modifier(Modifier::REVERSED)))
+                .child(text(format!("{response}{note}")).pad_left(2)),
+        );
+        self.streaming = None;
+    }
+}
+
+impl App for Agent {
+    type Msg = Msg;
+    type Output = ();
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            Msg::Typed(c) => self.typed.push(c),
+            Msg::Backspace => {
+                self.typed.pop();
+            }
+            Msg::Submit => {
+                if self.typed.trim().is_empty() || self.streaming.is_some() {
+                    return;
+                }
+                let prompt = std::mem::take(&mut self.typed);
+                ctx.push(
+                    col()
+                        .child(
+                            text(" you ").style(Style::default().add_modifier(Modifier::REVERSED)),
+                        )
+                        .child(text(prompt.clone()).pad_left(2)),
+                );
+                self.streaming = Some(ctx.spawn(agent_turn(prompt)));
+            }
+            Msg::Delta(word) => self.response.push_str(&word),
+            Msg::Done => self.seal_turn(ctx, ""),
+            Msg::CancelTurn => {
+                if self.streaming.take().is_some() {
+                    self.seal_turn(ctx, " [cancelled]");
+                }
+            }
+            Msg::Quit => ctx.exit(()),
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        let busy = self.streaming.is_some();
+
+        col()
+            .when(busy, |c| {
+                c.child(
+                    col()
+                        .child(
+                            text(" agent ")
+                                .style(Style::default().add_modifier(Modifier::REVERSED)),
+                        )
+                        .child(text(self.response.as_str()).pad_left(2))
+                        .child(
+                            spinner("streaming — Esc to cancel")
+                                .label_style(Style::default().fg(Color::DarkGray))
+                                .pad_left(2),
+                        ),
+                )
+            })
+            .child(
+                text("> ")
+                    .style(Style::default().fg(Color::Cyan))
+                    .span(&*self.typed, Style::default())
+                    .pad_top(1),
+            )
+    }
+
+    fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Quit)
+            .when(self.streaming.is_some(), |k| {
+                k.on(key(KeyCode::Esc), Msg::CancelTurn)
+            })
+            .in_scope(&self.input_focus, key(KeyCode::Enter), Msg::Submit)
+            .fallthrough(&self.input_focus, |ev| match ev {
+                InputEvent::Key(k) => match k.code {
+                    KeyCode::Char(c) => Msg::Typed(c),
+                    KeyCode::Backspace => Msg::Backspace,
+                    _ => Msg::Typed(' '),
+                },
+                InputEvent::Paste(s) => Msg::Typed(s.chars().next().unwrap_or(' ')),
+            })
+    }
+}
+
+/// The fake turn: stream the prompt back word by word, slowly.
+fn agent_turn(prompt: String) -> impl futures::Stream<Item = Msg> + Send {
+    let words: Vec<String> = format!("you said: {prompt} — and that's all I know about it")
+        .split_whitespace()
+        .map(|w| format!("{w} "))
+        .collect();
+
+    futures::stream::iter(words)
+        .then(|word| async move {
+            tokio::time::sleep(Duration::from_millis(120)).await;
+            Msg::Delta(word)
+        })
+        .chain(futures::stream::iter([Msg::Done]))
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let focus = Focus::new();
+    let input_focus = focus.handle();
+    input_focus.focus();
+
+    driver_tokio::run(Agent {
+        input_focus,
+        typed: String::new(),
+        response: String::new(),
+        streaming: None,
+    })
+    .await
+}

--- a/crates/eye_declare_next/src/app.rs
+++ b/crates/eye_declare_next/src/app.rs
@@ -1,0 +1,54 @@
+//! The application contract: Elm-shaped, with the timeline as the effect
+//! boundary.
+
+use crate::element::Element;
+use crate::input::Keymap;
+use crate::timeline::Timeline;
+
+/// An inline application. The implementing struct IS the model: `update`
+/// takes `&mut self`, `tail` takes `&self` — the borrow checker enforces
+/// the discipline.
+pub trait App: Sized {
+    /// Messages driving the app. Everything that happens becomes one.
+    type Msg;
+    /// What the run loop returns after [`Ctx::exit`].
+    type Output: Default;
+
+    /// Handle a message: mutate the model, emit effects via `ctx`.
+    fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<'_, Self::Output>);
+
+    /// Describe the live tail. Re-run every frame; borrows the model.
+    fn tail(&self) -> impl Element + '_;
+
+    /// Key bindings, rebuilt from the model each update so they can be
+    /// conditional on app state.
+    fn keymap(&self) -> Keymap<Self::Msg> {
+        Keymap::new()
+    }
+}
+
+/// Effect context handed to [`App::update`].
+///
+/// Committed output is an effect: [`push`](Ctx::push) renders the block
+/// immediately (so blocks may freely borrow from locals or the model) and
+/// the bytes join this update's output in order.
+pub struct Ctx<'a, Out> {
+    pub(crate) timeline: &'a mut Timeline,
+    pub(crate) output: &'a mut Vec<u8>,
+    pub(crate) exit: Option<Out>,
+}
+
+impl<Out> Ctx<'_, Out> {
+    /// Commit a finished block above the live tail. Irreversible, like
+    /// `println!`: the block renders once at the current width and leaves
+    /// the program's world.
+    pub fn push(&mut self, block: impl Element) {
+        let bytes = self.timeline.push(block);
+        self.output.extend_from_slice(&bytes);
+    }
+
+    /// End the run loop; it returns this value after teardown.
+    pub fn exit(&mut self, output: Out) {
+        self.exit = Some(output);
+    }
+}

--- a/crates/eye_declare_next/src/app.rs
+++ b/crates/eye_declare_next/src/app.rs
@@ -1,8 +1,11 @@
 //! The application contract: Elm-shaped, with the timeline as the effect
 //! boundary.
 
+use futures_core::Stream;
+
 use crate::element::Element;
 use crate::input::Keymap;
+use crate::task::{Effect, Task, spawn_effect, spawn_once_effect};
 use crate::timeline::Timeline;
 
 /// An inline application. The implementing struct IS the model: `update`
@@ -15,7 +18,7 @@ pub trait App: Sized {
     type Output: Default;
 
     /// Handle a message: mutate the model, emit effects via `ctx`.
-    fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<'_, Self::Output>);
+    fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<'_, Self>);
 
     /// Describe the live tail. Re-run every frame; borrows the model.
     fn tail(&self) -> impl Element + '_;
@@ -31,14 +34,17 @@ pub trait App: Sized {
 ///
 /// Committed output is an effect: [`push`](Ctx::push) renders the block
 /// immediately (so blocks may freely borrow from locals or the model) and
-/// the bytes join this update's output in order.
-pub struct Ctx<'a, Out> {
+/// the bytes join this update's output in order. Async work is an effect
+/// too: [`spawn`](Ctx::spawn) queues the stream for the driver and returns
+/// a cancel-on-drop [`Task`] to hold in the model.
+pub struct Ctx<'a, A: App> {
     pub(crate) timeline: &'a mut Timeline,
     pub(crate) output: &'a mut Vec<u8>,
-    pub(crate) exit: Option<Out>,
+    pub(crate) effects: &'a mut Vec<Effect<A::Msg>>,
+    pub(crate) exit: Option<A::Output>,
 }
 
-impl<Out> Ctx<'_, Out> {
+impl<A: App> Ctx<'_, A> {
     /// Commit a finished block above the live tail. Irreversible, like
     /// `println!`: the block renders once at the current width and leaves
     /// the program's world.
@@ -47,8 +53,32 @@ impl<Out> Ctx<'_, Out> {
         self.output.extend_from_slice(&bytes);
     }
 
+    /// Spawn a stream of messages (the LLM-turn shape): each item feeds
+    /// back into [`App::update`]. The work starts when the driver drains
+    /// effects after this update returns, and stops when the stream ends
+    /// or the returned [`Task`] is dropped — hold it in the model, and
+    /// cancellation is `self.task = None`.
+    ///
+    /// Requires an async driver (the sync [`run`](crate::run) refuses apps
+    /// that spawn).
+    #[must_use]
+    pub fn spawn(&mut self, stream: impl Stream<Item = A::Msg> + Send + 'static) -> Task {
+        let (effect, task) = spawn_effect(stream);
+        self.effects.push(effect);
+        task
+    }
+
+    /// One-shot convenience over [`spawn`](Ctx::spawn): run a future,
+    /// deliver its output as a single message.
+    #[must_use]
+    pub fn perform(&mut self, future: impl Future<Output = A::Msg> + Send + 'static) -> Task {
+        let (effect, task) = spawn_once_effect(future);
+        self.effects.push(effect);
+        task
+    }
+
     /// End the run loop; it returns this value after teardown.
-    pub fn exit(&mut self, output: Out) {
+    pub fn exit(&mut self, output: A::Output) {
         self.exit = Some(output);
     }
 }

--- a/crates/eye_declare_next/src/driver_tokio.rs
+++ b/crates/eye_declare_next/src/driver_tokio.rs
@@ -1,0 +1,121 @@
+//! The tokio driver: wraps [`Runtime`] in an async loop that multiplexes
+//! terminal events, messages from spawned work, and animation ticks.
+//!
+//! The core crate stays executor-agnostic — this module is the only place
+//! tokio appears (feature `tokio`, on by default). A custom driver for
+//! another executor needs exactly what this one uses: `Runtime` (events in,
+//! bytes out), [`Runtime::take_effects`], and [`Effect`]'s stream + cancel
+//! pair.
+
+use std::future::poll_fn;
+use std::io::{self, Write};
+use std::time::Duration;
+
+use futures_core::Stream;
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+
+use crate::app::App;
+use crate::input::InputEvent;
+use crate::runtime::{RawModeGuard, Runtime};
+use crate::task::Effect;
+
+/// Run an app on the attached terminal until it exits, executing spawned
+/// streams on the ambient tokio runtime.
+///
+/// Raw mode + bracketed paste are enabled for the duration and restored on
+/// exit (including panic unwind). If stdin closes, returns
+/// `A::Output::default()`.
+pub async fn run<A>(app: A) -> io::Result<A::Output>
+where
+    A: App,
+    A::Msg: Clone + Send + 'static,
+{
+    let (width, height) = crossterm::terminal::size()?;
+    let mut runtime = Runtime::new(app, width, height);
+    let (tx, mut rx) = unbounded_channel::<A::Msg>();
+    let mut stdout = io::stdout().lock();
+
+    let _guard = RawModeGuard::enable()?;
+
+    let bytes = runtime.present();
+    stdout.write_all(&bytes)?;
+    stdout.flush()?;
+
+    let mut events = crossterm::event::EventStream::new();
+
+    loop {
+        let anim = runtime.animation_interval();
+
+        let (bytes, exit) = tokio::select! {
+            biased;
+
+            maybe_event = poll_fn(|cx| Pin::new(&mut events).poll_next(cx)) => {
+                use crossterm::event::{Event, KeyEventKind};
+                match maybe_event {
+                    Some(Ok(Event::Key(k)))
+                        if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                    {
+                        runtime.handle(InputEvent::Key(k))
+                    }
+                    Some(Ok(Event::Paste(s))) => runtime.handle(InputEvent::Paste(s)),
+                    Some(Ok(Event::Resize(w, h))) => (runtime.resize(w, h), None),
+                    Some(Ok(_)) => (Vec::new(), None),
+                    Some(Err(e)) => return Err(e),
+                    // Terminal input ended (stdin closed): exit cleanly.
+                    None => (Vec::new(), Some(A::Output::default())),
+                }
+            }
+
+            Some(msg) = rx.recv() => runtime.process(msg),
+
+            _ = sleep_opt(anim), if anim.is_some() => (runtime.present(), None),
+        };
+
+        spawn_effects(runtime.take_effects(), &tx);
+
+        if !bytes.is_empty() {
+            stdout.write_all(&bytes)?;
+            stdout.flush()?;
+        }
+        if let Some(output) = exit {
+            return Ok(output);
+        }
+    }
+}
+
+async fn sleep_opt(duration: Option<Duration>) {
+    match duration {
+        Some(d) => tokio::time::sleep(d).await,
+        // The branch is disabled by its `if` guard when None; never polled.
+        None => std::future::pending().await,
+    }
+}
+
+/// Execute effects on the tokio runtime, feeding produced messages into
+/// `tx`. Public so custom loops (tests, embeddings) can drive effects the
+/// same way [`run`] does.
+pub fn spawn_effects<Msg: Send + 'static>(effects: Vec<Effect<Msg>>, tx: &UnboundedSender<Msg>) {
+    for effect in effects {
+        let Effect::Spawn { mut stream, cancel } = effect;
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            loop {
+                if cancel.is_cancelled() {
+                    break;
+                }
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    item = poll_fn(|cx| stream.as_mut().poll_next(cx)) => match item {
+                        Some(msg) => {
+                            if tx.send(msg).is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    },
+                }
+            }
+        });
+    }
+}

--- a/crates/eye_declare_next/src/focus.rs
+++ b/crates/eye_declare_next/src/focus.rs
@@ -1,0 +1,113 @@
+//! Focus as data (GPUI's `FocusHandle` pattern, per the bake-off).
+//!
+//! The app model owns a [`Focus`] system and creates [`FocusHandle`]s from
+//! it. All handles from one system share a single "currently focused" cell,
+//! so exactly one handle is focused at a time *by construction* — there is
+//! no framework focus registry to fall out of sync with, no autofocus
+//! lifecycle, and no Tab cycling unless the app binds Tab to a message.
+//!
+//! - Moving focus is a plain call in `update`: `self.search_focus.focus()`.
+//! - Views read `handle.is_focused()` for focus-dependent visuals.
+//! - [`Keymap`](crate::input::Keymap) scopes bindings to handles.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The focus system for an app. Lives in the app model; hand out handles
+/// via [`handle`](Focus::handle).
+#[derive(Default)]
+pub struct Focus {
+    current: Arc<AtomicU64>,
+    next_id: AtomicU64,
+}
+
+impl Focus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new focusable identity. The first handle created is NOT
+    /// focused automatically — call [`FocusHandle::focus`] to set initial
+    /// focus.
+    pub fn handle(&self) -> FocusHandle {
+        // ids start at 1; 0 means "nothing focused".
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        FocusHandle {
+            id,
+            current: Arc::clone(&self.current),
+        }
+    }
+
+    /// Clear focus entirely (no handle focused).
+    pub fn blur_all(&self) {
+        self.current.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Identity of one focusable thing. Cheap to clone; clones share identity.
+#[derive(Clone)]
+pub struct FocusHandle {
+    id: u64,
+    current: Arc<AtomicU64>,
+}
+
+impl FocusHandle {
+    /// Make this handle the focused one (unfocusing whichever was).
+    pub fn focus(&self) {
+        self.current.store(self.id, Ordering::Relaxed);
+    }
+
+    /// Unfocus, but only if this handle currently has focus.
+    pub fn blur(&self) {
+        let _ = self
+            .current
+            .compare_exchange(self.id, 0, Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    pub fn is_focused(&self) -> bool {
+        self.current.load(Ordering::Relaxed) == self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exactly_one_handle_focused() {
+        let focus = Focus::new();
+        let a = focus.handle();
+        let b = focus.handle();
+
+        assert!(!a.is_focused() && !b.is_focused());
+
+        a.focus();
+        assert!(a.is_focused() && !b.is_focused());
+
+        b.focus();
+        assert!(!a.is_focused() && b.is_focused());
+    }
+
+    #[test]
+    fn blur_only_affects_the_holder() {
+        let focus = Focus::new();
+        let a = focus.handle();
+        let b = focus.handle();
+
+        a.focus();
+        b.blur(); // b doesn't hold focus; no-op
+        assert!(a.is_focused());
+
+        a.blur();
+        assert!(!a.is_focused() && !b.is_focused());
+    }
+
+    #[test]
+    fn clones_share_identity() {
+        let focus = Focus::new();
+        let a = focus.handle();
+        let a2 = a.clone();
+        a.focus();
+        assert!(a2.is_focused());
+    }
+}

--- a/crates/eye_declare_next/src/input.rs
+++ b/crates/eye_declare_next/src/input.rs
@@ -1,0 +1,321 @@
+//! Input events and the keymap: keys resolve to messages as *data*,
+//! rebuilt from the model each update so bindings can be conditional on
+//! app state.
+//!
+//! Dispatch order (bake-off O2, first match in declaration order wins):
+//! 1. [`on_override`](Keymap::on_override) bindings — Ctrl+C-tier chords
+//!    that fire regardless of focus
+//! 2. [`in_scope`](Keymap::in_scope) bindings for the focused handle
+//! 3. [`on`](Keymap::on) global bindings
+//! 4. [`fallthrough`](Keymap::fallthrough) mappers for the focused handle
+//!    (raw events → messages; how a text input receives ordinary typing)
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::focus::FocusHandle;
+
+/// A terminal input event as delivered to the app: key press or paste.
+#[derive(Clone, Debug)]
+pub enum InputEvent {
+    Key(KeyEvent),
+    Paste(String),
+}
+
+/// A key pattern for bindings.
+///
+/// Matching is exact on code + modifiers. Note the usual terminal wart:
+/// shifted characters arrive as the shifted char (`Char('J')` + SHIFT),
+/// so bind the character you expect to receive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Key {
+    pub code: KeyCode,
+    pub mods: KeyModifiers,
+}
+
+pub fn key(code: KeyCode) -> Key {
+    Key {
+        code,
+        mods: KeyModifiers::NONE,
+    }
+}
+
+impl Key {
+    pub fn ctrl(mut self) -> Self {
+        self.mods |= KeyModifiers::CONTROL;
+        self
+    }
+
+    pub fn shift(mut self) -> Self {
+        self.mods |= KeyModifiers::SHIFT;
+        self
+    }
+
+    pub fn alt(mut self) -> Self {
+        self.mods |= KeyModifiers::ALT;
+        self
+    }
+
+    fn matches(&self, event: &KeyEvent) -> bool {
+        self.code == event.code && self.mods == event.modifiers
+    }
+}
+
+enum Scope {
+    /// Fires before focus-scoped and global bindings. For chords that must
+    /// work regardless of what's focused (Ctrl+C-tier).
+    Override,
+    /// Fires while the handle has focus.
+    Focus(FocusHandle),
+    /// Fires if no override or focus-scoped binding matched.
+    Global,
+}
+
+type FallthroughFn<Msg> = Box<dyn Fn(InputEvent) -> Msg + Send>;
+
+/// Key → message bindings. Values, not callbacks: rebuild from the model
+/// each update (see the conditional Tab bindings in the spike's Port 3A —
+/// this is what makes key-policy conflicts impossible by construction).
+pub struct Keymap<Msg> {
+    bindings: Vec<(Scope, Key, Msg)>,
+    fallthrough: Vec<(FocusHandle, FallthroughFn<Msg>)>,
+}
+
+impl<Msg> Default for Keymap<Msg> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn keymap<Msg>() -> Keymap<Msg> {
+    Keymap::new()
+}
+
+impl<Msg> Keymap<Msg> {
+    pub fn new() -> Self {
+        Self {
+            bindings: Vec::new(),
+            fallthrough: Vec::new(),
+        }
+    }
+
+    /// Global binding, checked after focus-scoped bindings.
+    pub fn on(mut self, key: Key, msg: Msg) -> Self {
+        self.bindings.push((Scope::Global, key, msg));
+        self
+    }
+
+    /// Binding that fires before everything else, regardless of focus.
+    pub fn on_override(mut self, key: Key, msg: Msg) -> Self {
+        self.bindings.push((Scope::Override, key, msg));
+        self
+    }
+
+    /// Binding active while `focus` is focused.
+    pub fn in_scope(mut self, focus: &FocusHandle, key: Key, msg: Msg) -> Self {
+        self.bindings.push((Scope::Focus(focus.clone()), key, msg));
+        self
+    }
+
+    /// Route events unclaimed by any binding to a message while `focus` is
+    /// focused. This is how a text input receives ordinary typing (and
+    /// pastes) without the framework owning any editing logic.
+    pub fn fallthrough(
+        mut self,
+        focus: &FocusHandle,
+        map: impl Fn(InputEvent) -> Msg + Send + 'static,
+    ) -> Self {
+        self.fallthrough.push((focus.clone(), Box::new(map)));
+        self
+    }
+
+    /// Re-target to a parent message type (Elm's `Html.map` for keymaps) —
+    /// how a sub-model's keymap embeds into the app's.
+    pub fn map<M2>(self, f: impl Fn(Msg) -> M2 + Clone + Send + 'static) -> Keymap<M2>
+    where
+        Msg: 'static,
+    {
+        Keymap {
+            bindings: self
+                .bindings
+                .into_iter()
+                .map(|(scope, key, msg)| (scope, key, f(msg)))
+                .collect(),
+            fallthrough: self
+                .fallthrough
+                .into_iter()
+                .map(|(focus, g)| {
+                    let f = f.clone();
+                    let mapped: FallthroughFn<M2> = Box::new(move |ev| f(g(ev)));
+                    (focus, mapped)
+                })
+                .collect(),
+        }
+    }
+}
+
+impl<Msg: Clone> Keymap<Msg> {
+    /// Resolve an event to a message, or `None` if nothing claims it.
+    pub fn dispatch(&self, event: &InputEvent) -> Option<Msg> {
+        if let InputEvent::Key(k) = event {
+            for (scope, key, msg) in &self.bindings {
+                if matches!(scope, Scope::Override) && key.matches(k) {
+                    return Some(msg.clone());
+                }
+            }
+            for (scope, key, msg) in &self.bindings {
+                if let Scope::Focus(handle) = scope
+                    && handle.is_focused()
+                    && key.matches(k)
+                {
+                    return Some(msg.clone());
+                }
+            }
+            for (scope, key, msg) in &self.bindings {
+                if matches!(scope, Scope::Global) && key.matches(k) {
+                    return Some(msg.clone());
+                }
+            }
+        }
+
+        // Fallthrough handles both unclaimed keys and pastes.
+        for (handle, map) in &self.fallthrough {
+            if handle.is_focused() {
+                return Some(map(event.clone()));
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::focus::Focus;
+
+    fn press(code: KeyCode) -> InputEvent {
+        InputEvent::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn press_mod(code: KeyCode, mods: KeyModifiers) -> InputEvent {
+        InputEvent::Key(KeyEvent::new(code, mods))
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum Msg {
+        Interrupt,
+        Submit,
+        GlobalHelp,
+        Edit(char),
+    }
+
+    fn edit_msg(ev: InputEvent) -> Msg {
+        match ev {
+            InputEvent::Key(k) => {
+                if let KeyCode::Char(c) = k.code {
+                    Msg::Edit(c)
+                } else {
+                    Msg::Edit('?')
+                }
+            }
+            InputEvent::Paste(_) => Msg::Edit('P'),
+        }
+    }
+
+    #[test]
+    fn dispatch_order_override_scoped_global_fallthrough() {
+        let focus = Focus::new();
+        let input = focus.handle();
+        input.focus();
+
+        let km = keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Interrupt)
+            .in_scope(&input, key(KeyCode::Enter), Msg::Submit)
+            .on(key(KeyCode::Char('h')), Msg::GlobalHelp)
+            .fallthrough(&input, edit_msg);
+
+        assert_eq!(
+            km.dispatch(&press_mod(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            Some(Msg::Interrupt)
+        );
+        assert_eq!(km.dispatch(&press(KeyCode::Enter)), Some(Msg::Submit));
+        // 'h' is claimed by fallthrough? No — scoped/global bindings win
+        // before fallthrough... but 'h' has no scoped binding, so global
+        // fires before the focused fallthrough.
+        assert_eq!(
+            km.dispatch(&press(KeyCode::Char('h'))),
+            Some(Msg::GlobalHelp)
+        );
+        assert_eq!(
+            km.dispatch(&press(KeyCode::Char('x'))),
+            Some(Msg::Edit('x'))
+        );
+        assert_eq!(
+            km.dispatch(&InputEvent::Paste("hi".into())),
+            Some(Msg::Edit('P'))
+        );
+    }
+
+    #[test]
+    fn scoped_bindings_inactive_without_focus() {
+        let focus = Focus::new();
+        let input = focus.handle();
+        // not focused
+
+        let km = keymap()
+            .in_scope(&input, key(KeyCode::Enter), Msg::Submit)
+            .fallthrough(&input, edit_msg);
+
+        assert_eq!(km.dispatch(&press(KeyCode::Enter)), None);
+        assert_eq!(km.dispatch(&press(KeyCode::Char('x'))), None);
+    }
+
+    #[test]
+    fn first_match_in_declaration_order_wins() {
+        let focus = Focus::new();
+        let input = focus.handle();
+        input.focus();
+
+        // Two conditional Tab meanings, declared in priority order.
+        let km = keymap()
+            .in_scope(&input, key(KeyCode::Tab), Msg::Submit)
+            .in_scope(&input, key(KeyCode::Tab), Msg::GlobalHelp);
+
+        assert_eq!(km.dispatch(&press(KeyCode::Tab)), Some(Msg::Submit));
+    }
+
+    #[test]
+    fn map_retargets_bindings_and_fallthrough() {
+        #[derive(Clone, Debug, PartialEq)]
+        enum Outer {
+            Inner(Msg),
+        }
+
+        let focus = Focus::new();
+        let input = focus.handle();
+        input.focus();
+
+        let km = keymap()
+            .in_scope(&input, key(KeyCode::Enter), Msg::Submit)
+            .fallthrough(&input, edit_msg)
+            .map(Outer::Inner);
+
+        assert_eq!(
+            km.dispatch(&press(KeyCode::Enter)),
+            Some(Outer::Inner(Msg::Submit))
+        );
+        assert_eq!(
+            km.dispatch(&press(KeyCode::Char('z'))),
+            Some(Outer::Inner(Msg::Edit('z')))
+        );
+    }
+
+    #[test]
+    fn modifiers_must_match_exactly() {
+        let km: Keymap<Msg> = keymap().on(key(KeyCode::Enter), Msg::Submit);
+        assert_eq!(
+            km.dispatch(&press_mod(KeyCode::Enter, KeyModifiers::SHIFT)),
+            None
+        );
+    }
+}

--- a/crates/eye_declare_next/src/lib.rs
+++ b/crates/eye_declare_next/src/lib.rs
@@ -19,13 +19,21 @@
 //! driver (spawn/Task/subscriptions) → widgets (text area, markdown,
 //! viewport).
 
+pub mod app;
 pub mod element;
+pub mod focus;
+pub mod input;
+pub mod runtime;
 pub mod spinner;
 pub mod stack;
 pub mod text;
 pub mod timeline;
 
+pub use app::{App, Ctx};
 pub use element::{AnyElement, Element, ElementExt, Empty, Fluent, Padded, empty};
+pub use focus::{Focus, FocusHandle};
+pub use input::{InputEvent, Key, Keymap, key, keymap};
+pub use runtime::{Runtime, run};
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
 pub use text::{Text, text};

--- a/crates/eye_declare_next/src/lib.rs
+++ b/crates/eye_declare_next/src/lib.rs
@@ -20,12 +20,15 @@
 //! viewport).
 
 pub mod app;
+#[cfg(feature = "tokio")]
+pub mod driver_tokio;
 pub mod element;
 pub mod focus;
 pub mod input;
 pub mod runtime;
 pub mod spinner;
 pub mod stack;
+pub mod task;
 pub mod text;
 pub mod timeline;
 
@@ -36,5 +39,6 @@ pub use input::{InputEvent, Key, Keymap, key, keymap};
 pub use runtime::{Runtime, run};
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
+pub use task::{Effect, Task};
 pub use text::{Text, text};
 pub use timeline::Timeline;

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -1,0 +1,174 @@
+//! The runtime: a headlessly-testable [`Runtime`] core plus the [`run`]
+//! terminal shell around it.
+//!
+//! `Runtime` speaks [`InputEvent`]s in and escape bytes out, so entire
+//! apps can be driven in tests against the engine's `TestTerminal` — the
+//! same way the framework tests itself.
+
+use std::io::{self, Write};
+use std::time::Duration;
+
+use crate::app::{App, Ctx};
+use crate::element::Element;
+use crate::input::InputEvent;
+use crate::timeline::Timeline;
+
+/// The pure core of the run loop: dispatch → update → flush pushes →
+/// present. No terminal I/O; returns bytes for the caller to write.
+pub struct Runtime<A: App> {
+    app: A,
+    timeline: Timeline,
+    animate: Option<Duration>,
+}
+
+impl<A: App> Runtime<A>
+where
+    A::Msg: Clone,
+{
+    pub fn new(app: A, width: u16, terminal_height: u16) -> Self {
+        Self {
+            app,
+            timeline: Timeline::new(width, terminal_height),
+            animate: None,
+        }
+    }
+
+    /// Feed one input event. Resolves it through the app's keymap; if a
+    /// message results, processes it. Returns the bytes to write and the
+    /// app's output when it exited.
+    pub fn handle(&mut self, event: InputEvent) -> (Vec<u8>, Option<A::Output>) {
+        match self.app.keymap().dispatch(&event) {
+            Some(msg) => self.process(msg),
+            None => (Vec::new(), None),
+        }
+    }
+
+    /// Feed one message (from the keymap, or — in the async driver — from
+    /// tasks and subscriptions).
+    pub fn process(&mut self, msg: A::Msg) -> (Vec<u8>, Option<A::Output>) {
+        let mut bytes = Vec::new();
+        let mut ctx = Ctx {
+            timeline: &mut self.timeline,
+            output: &mut bytes,
+            exit: None,
+        };
+        self.app.update(msg, &mut ctx);
+        let exit = ctx.exit;
+
+        bytes.extend_from_slice(&self.present());
+        if exit.is_some() {
+            bytes.extend_from_slice(&self.timeline.finalize());
+        }
+        (bytes, exit)
+    }
+
+    /// Re-present the live tail (also called on animation ticks).
+    pub fn present(&mut self) -> Vec<u8> {
+        let tail = self.app.tail();
+        self.animate = tail.animated();
+        self.timeline.present(&tail)
+    }
+
+    /// How soon the tail wants re-presenting for animation, if at all.
+    /// Refreshed by every [`present`](Runtime::present).
+    pub fn animation_interval(&self) -> Option<Duration> {
+        self.animate
+    }
+
+    /// Handle a terminal resize. Committed blocks keep the terminal's own
+    /// reflow; the live region is erased and repainted at the new width.
+    pub fn resize(&mut self, width: u16, terminal_height: u16) -> Vec<u8> {
+        self.timeline.set_terminal_height(terminal_height);
+        let mut bytes = self.timeline.resize(width);
+        bytes.extend_from_slice(&self.present());
+        bytes
+    }
+
+    /// The wrapped app, for inspection after exit (tests) or state peeks.
+    pub fn app(&self) -> &A {
+        &self.app
+    }
+}
+
+/// Run an app on the attached terminal until it exits.
+///
+/// Raw mode + bracketed paste are enabled for the duration and restored on
+/// exit (including panic unwind); the cursor is re-shown on teardown.
+pub fn run<A: App>(app: A) -> io::Result<A::Output>
+where
+    A::Msg: Clone,
+{
+    let (width, height) = crossterm::terminal::size()?;
+    let mut runtime = Runtime::new(app, width, height);
+    let mut stdout = io::stdout().lock();
+
+    let _guard = RawModeGuard::enable()?;
+
+    let bytes = runtime.present();
+    stdout.write_all(&bytes)?;
+    stdout.flush()?;
+
+    loop {
+        let timeout = runtime
+            .animation_interval()
+            .unwrap_or(Duration::from_secs(3600));
+
+        let bytes = if crossterm::event::poll(timeout)? {
+            use crossterm::event::{Event, KeyEventKind};
+            match crossterm::event::read()? {
+                Event::Key(k) if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+                    let (bytes, exit) = runtime.handle(InputEvent::Key(k));
+                    if let Some(output) = exit {
+                        stdout.write_all(&bytes)?;
+                        stdout.flush()?;
+                        return Ok(output);
+                    }
+                    bytes
+                }
+                Event::Paste(s) => {
+                    let (bytes, exit) = runtime.handle(InputEvent::Paste(s));
+                    if let Some(output) = exit {
+                        stdout.write_all(&bytes)?;
+                        stdout.flush()?;
+                        return Ok(output);
+                    }
+                    bytes
+                }
+                Event::Resize(w, h) => runtime.resize(w, h),
+                _ => Vec::new(),
+            }
+        } else {
+            // Animation tick.
+            runtime.present()
+        };
+
+        if !bytes.is_empty() {
+            stdout.write_all(&bytes)?;
+            stdout.flush()?;
+        }
+    }
+}
+
+/// Restores the terminal on drop, including panic unwind.
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enable() -> io::Result<Self> {
+        crossterm::terminal::enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        let _ = crossterm::execute!(stdout, crossterm::event::EnableBracketedPaste);
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let mut stdout = io::stdout();
+        let _ = crossterm::execute!(stdout, crossterm::event::DisableBracketedPaste);
+        let _ = crossterm::terminal::disable_raw_mode();
+        // The engine hides the cursor while no element hints one; make
+        // sure the shell gets it back.
+        let _ = stdout.write_all(b"\x1b[?25h");
+        let _ = stdout.flush();
+    }
+}

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use crate::app::{App, Ctx};
 use crate::element::Element;
 use crate::input::InputEvent;
+use crate::task::Effect;
 use crate::timeline::Timeline;
 
 /// The pure core of the run loop: dispatch → update → flush pushes →
@@ -19,6 +20,7 @@ pub struct Runtime<A: App> {
     app: A,
     timeline: Timeline,
     animate: Option<Duration>,
+    effects: Vec<Effect<A::Msg>>,
 }
 
 impl<A: App> Runtime<A>
@@ -30,6 +32,7 @@ where
             app,
             timeline: Timeline::new(width, terminal_height),
             animate: None,
+            effects: Vec::new(),
         }
     }
 
@@ -50,6 +53,7 @@ where
         let mut ctx = Ctx {
             timeline: &mut self.timeline,
             output: &mut bytes,
+            effects: &mut self.effects,
             exit: None,
         };
         self.app.update(msg, &mut ctx);
@@ -60,6 +64,13 @@ where
             bytes.extend_from_slice(&self.timeline.finalize());
         }
         (bytes, exit)
+    }
+
+    /// Effects queued by `update` (spawned streams), for the driver to
+    /// execute. Drain after every [`handle`](Runtime::handle) /
+    /// [`process`](Runtime::process).
+    pub fn take_effects(&mut self) -> Vec<Effect<A::Msg>> {
+        std::mem::take(&mut self.effects)
     }
 
     /// Re-present the live tail (also called on animation ticks).
@@ -118,6 +129,7 @@ where
             match crossterm::event::read()? {
                 Event::Key(k) if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
                     let (bytes, exit) = runtime.handle(InputEvent::Key(k));
+                    reject_effects(&mut runtime)?;
                     if let Some(output) = exit {
                         stdout.write_all(&bytes)?;
                         stdout.flush()?;
@@ -127,6 +139,7 @@ where
                 }
                 Event::Paste(s) => {
                     let (bytes, exit) = runtime.handle(InputEvent::Paste(s));
+                    reject_effects(&mut runtime)?;
                     if let Some(output) = exit {
                         stdout.write_all(&bytes)?;
                         stdout.flush()?;
@@ -149,11 +162,27 @@ where
     }
 }
 
+/// The sync loop can't execute async work — surface the mistake loudly
+/// instead of silently dropping the app's spawned streams.
+fn reject_effects<A: App>(runtime: &mut Runtime<A>) -> io::Result<()>
+where
+    A::Msg: Clone,
+{
+    if runtime.take_effects().is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::other(
+            "app spawned async work (ctx.spawn/perform); drive it with the tokio runtime \
+             (eye_declare_next::tokio_driver::run) instead of the sync run()",
+        ))
+    }
+}
+
 /// Restores the terminal on drop, including panic unwind.
-struct RawModeGuard;
+pub(crate) struct RawModeGuard;
 
 impl RawModeGuard {
-    fn enable() -> io::Result<Self> {
+    pub(crate) fn enable() -> io::Result<Self> {
         crossterm::terminal::enable_raw_mode()?;
         let mut stdout = io::stdout();
         let _ = crossterm::execute!(stdout, crossterm::event::EnableBracketedPaste);

--- a/crates/eye_declare_next/src/task.rs
+++ b/crates/eye_declare_next/src/task.rs
@@ -1,0 +1,188 @@
+//! Spawned work and its cancellation story.
+//!
+//! [`Ctx::spawn`](crate::Ctx::spawn) collects [`Effect`]s during `update`;
+//! a driver (e.g. the tokio one) drains them via
+//! [`Runtime::take_effects`](crate::Runtime::take_effects) and actually
+//! executes the streams. The returned [`Task`] is the app's lifecycle
+//! handle: **dropping it cancels the work**, so cancellation is a plain
+//! assignment (`self.streaming = None`).
+//!
+//! Everything here is executor-agnostic — cancellation is a hand-rolled
+//! waker future, so the core crate stays free of runtime dependencies.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use futures_core::Stream;
+
+/// Handle to spawned work. Dropping it cancels the work; call
+/// [`detach`](Task::detach) for fire-and-forget.
+pub struct Task {
+    cancel: Option<Arc<Cancel>>,
+}
+
+impl Task {
+    /// Let the work run to completion even after this handle is gone.
+    pub fn detach(mut self) {
+        self.cancel = None;
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
+        if let Some(cancel) = &self.cancel {
+            cancel.cancel();
+        }
+    }
+}
+
+/// Shared cancellation state between a [`Task`] handle and the driver's
+/// execution of the work. Opaque outside the crate; it appears in
+/// [`Effect`]'s public shape so custom drivers can hold it.
+pub struct Cancel {
+    cancelled: AtomicBool,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl Cancel {
+    fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+            waker: Mutex::new(None),
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// A future that resolves when the task is cancelled. Drivers select
+    /// this against the work's next item.
+    pub fn cancelled(self: &Arc<Self>) -> Cancelled {
+        Cancelled {
+            cancel: Arc::clone(self),
+        }
+    }
+}
+
+/// See [`Cancel::cancelled`].
+pub struct Cancelled {
+    cancel: Arc<Cancel>,
+}
+
+impl Future for Cancelled {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.cancel.is_cancelled() {
+            return Poll::Ready(());
+        }
+        *self.cancel.waker.lock().unwrap() = Some(cx.waker().clone());
+        // Re-check after storing the waker to close the race with a
+        // concurrent cancel() that ran between the check and the store.
+        if self.cancel.is_cancelled() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+/// An effect requested during `update`, to be executed by the driver.
+pub enum Effect<Msg> {
+    /// Run a stream, feeding each item back into `update` as a message,
+    /// until it ends or its [`Task`] is dropped.
+    Spawn {
+        stream: Pin<Box<dyn Stream<Item = Msg> + Send>>,
+        cancel: Arc<Cancel>,
+    },
+}
+
+pub(crate) fn spawn_effect<Msg>(
+    stream: impl Stream<Item = Msg> + Send + 'static,
+) -> (Effect<Msg>, Task) {
+    let cancel = Arc::new(Cancel::new());
+    (
+        Effect::Spawn {
+            stream: Box::pin(stream),
+            cancel: Arc::clone(&cancel),
+        },
+        Task {
+            cancel: Some(cancel),
+        },
+    )
+}
+
+pub(crate) fn spawn_once_effect<Msg>(
+    future: impl Future<Output = Msg> + Send + 'static,
+) -> (Effect<Msg>, Task) {
+    spawn_effect(FutureStream {
+        future: Some(Box::pin(future)),
+    })
+}
+
+/// Adapts a future into a one-item stream (futures-core is traits-only,
+/// so the adapter lives here).
+struct FutureStream<F: Future> {
+    future: Option<Pin<Box<F>>>,
+}
+
+impl<F: Future> Stream for FutureStream<F> {
+    type Item = F::Output;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<F::Output>> {
+        let this = self.get_mut();
+        match &mut this.future {
+            Some(future) => match future.as_mut().poll(cx) {
+                Poll::Ready(value) => {
+                    this.future = None;
+                    Poll::Ready(Some(value))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stream that never yields (futures-core is traits-only).
+    struct Pending;
+
+    impl Stream for Pending {
+        type Item = ();
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<()>> {
+            Poll::Pending
+        }
+    }
+
+    #[test]
+    fn drop_cancels() {
+        let (effect, task) = spawn_effect(Pending);
+        let Effect::Spawn { cancel, .. } = effect;
+        assert!(!cancel.is_cancelled());
+        drop(task);
+        assert!(cancel.is_cancelled());
+    }
+
+    #[test]
+    fn detach_does_not_cancel() {
+        let (effect, task) = spawn_effect(Pending);
+        let Effect::Spawn { cancel, .. } = effect;
+        task.detach();
+        assert!(!cancel.is_cancelled());
+    }
+}

--- a/crates/eye_declare_next/src/timeline.rs
+++ b/crates/eye_declare_next/src/timeline.rs
@@ -62,6 +62,15 @@ impl Timeline {
         self.engine.present(Frame::new(buf), cursor)
     }
 
+    /// Handle a terminal width change: erase the live region (committed
+    /// blocks above it are untouched — they keep the terminal's own
+    /// reflow, per the committed-is-immutable semantics) and reset
+    /// tracking. Follow with a [`present`](Timeline::present) to repaint
+    /// the tail at the new width.
+    pub fn resize(&mut self, new_width: u16) -> Vec<u8> {
+        self.engine.reset_region(new_width)
+    }
+
     /// Reclaim trailing blank rows for shell handoff (call after a final
     /// `present` of a shrunken or empty tail).
     pub fn finalize(&mut self) -> Vec<u8> {

--- a/crates/eye_declare_next/tests/app_headless.rs
+++ b/crates/eye_declare_next/tests/app_headless.rs
@@ -48,7 +48,7 @@ impl App for Echo {
     type Msg = Msg;
     type Output = Outcome;
 
-    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Outcome>) {
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
         match msg {
             Msg::Typed(c) => self.typed.push(c),
             Msg::Backspace => {
@@ -201,7 +201,7 @@ fn borrowed_blocks_push_cleanly() {
         type Msg = ();
         type Output = ();
 
-        fn update(&mut self, _msg: (), ctx: &mut Ctx<'_, ()>) {
+        fn update(&mut self, _msg: (), ctx: &mut Ctx<'_, Self>) {
             let events = std::mem::take(&mut self.events);
             ctx.push(col().children(events.iter().map(|e| text(e.as_str()).pad_left(2))));
             self.done = true;

--- a/crates/eye_declare_next/tests/app_headless.rs
+++ b/crates/eye_declare_next/tests/app_headless.rs
@@ -1,0 +1,232 @@
+//! A complete app driven headlessly: synthetic key events in, VTE-verified
+//! terminal contents out. This is the snapshot-testing story downstream
+//! users get — the framework tests itself the same way.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use eye_declare_engine::test_terminal::TestTerminal;
+use eye_declare_next::{
+    App, Ctx, Element, ElementExt, Fluent, Focus, FocusHandle, InputEvent, Keymap, Runtime, col,
+    key, keymap, text,
+};
+
+#[derive(Clone)]
+enum Msg {
+    Submit,
+    Typed(char),
+    Backspace,
+    Quit,
+}
+
+#[derive(Default)]
+enum Outcome {
+    #[default]
+    Cancelled,
+    Finished(usize),
+}
+
+/// Minimal echo app: type a line, Enter commits it as a block, Ctrl+C
+/// exits with the number of submitted lines.
+struct Echo {
+    input_focus: FocusHandle,
+    typed: String,
+    submitted: usize,
+}
+
+impl Echo {
+    fn new(focus: &Focus) -> Self {
+        let input_focus = focus.handle();
+        input_focus.focus();
+        Self {
+            input_focus,
+            typed: String::new(),
+            submitted: 0,
+        }
+    }
+}
+
+impl App for Echo {
+    type Msg = Msg;
+    type Output = Outcome;
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Outcome>) {
+        match msg {
+            Msg::Typed(c) => self.typed.push(c),
+            Msg::Backspace => {
+                self.typed.pop();
+            }
+            Msg::Submit => {
+                if !self.typed.is_empty() {
+                    let line = std::mem::take(&mut self.typed);
+                    ctx.push(text(format!("* {line}")));
+                    self.submitted += 1;
+                }
+            }
+            Msg::Quit => ctx.exit(Outcome::Finished(self.submitted)),
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        col()
+            .child(text(format!("> {}", self.typed)))
+            .when(self.submitted > 0, |c| {
+                c.child(text(format!("({} sent)", self.submitted)))
+            })
+    }
+
+    fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Quit)
+            .in_scope(&self.input_focus, key(KeyCode::Enter), Msg::Submit)
+            .fallthrough(&self.input_focus, |ev| match ev {
+                InputEvent::Key(k) => match k.code {
+                    KeyCode::Char(c) => Msg::Typed(c),
+                    KeyCode::Backspace => Msg::Backspace,
+                    _ => Msg::Typed('?'),
+                },
+                InputEvent::Paste(_) => Msg::Typed('P'),
+            })
+    }
+}
+
+fn press(code: KeyCode) -> InputEvent {
+    InputEvent::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+fn type_str(rt: &mut Runtime<Echo>, term: &mut TestTerminal, s: &str) {
+    for c in s.chars() {
+        let (bytes, exit) = rt.handle(press(KeyCode::Char(c)));
+        assert!(exit.is_none());
+        term.feed(&bytes);
+    }
+}
+
+#[test]
+fn echo_session_end_to_end() {
+    let focus = Focus::new();
+    let mut rt = Runtime::new(Echo::new(&focus), 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    term.feed(&rt.present());
+    assert_eq!(term.viewport_lines()[0], ">");
+
+    // Type and watch the tail echo.
+    type_str(&mut rt, &mut term, "hello");
+    assert_eq!(term.viewport_lines()[0], "> hello");
+
+    // Backspace edits.
+    let (bytes, _) = rt.handle(press(KeyCode::Backspace));
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "> hell");
+
+    // Enter commits the line as a block; tail resets below it.
+    let (bytes, _) = rt.handle(press(KeyCode::Enter));
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "* hell");
+    assert_eq!(term.viewport_lines()[1], ">");
+    assert_eq!(term.viewport_lines()[2], "(1 sent)");
+
+    // Another line stacks below the first block.
+    type_str(&mut rt, &mut term, "again");
+    let (bytes, _) = rt.handle(press(KeyCode::Enter));
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "* hell");
+    assert_eq!(term.viewport_lines()[1], "* again");
+    assert_eq!(term.viewport_lines()[2], ">");
+    assert_eq!(term.viewport_lines()[3], "(2 sent)");
+
+    // Ctrl+C exits with the outcome; committed history survives.
+    let (bytes, exit) = rt.handle(InputEvent::Key(KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::CONTROL,
+    )));
+    term.feed(&bytes);
+    match exit {
+        Some(Outcome::Finished(n)) => assert_eq!(n, 2),
+        _ => panic!("expected Finished exit"),
+    }
+    assert_eq!(term.viewport_lines()[0], "* hell");
+    assert_eq!(term.viewport_lines()[1], "* again");
+}
+
+#[test]
+fn unclaimed_events_produce_no_output() {
+    let focus = Focus::new();
+    let mut rt = Runtime::new(Echo::new(&focus), 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+    term.feed(&rt.present());
+
+    // F5 matches nothing: no bindings, fallthrough maps it to Typed('?')…
+    // actually fallthrough claims everything for the focused input. Blur
+    // first so nothing is focused.
+    focus.blur_all();
+    let (bytes, exit) = rt.handle(press(KeyCode::F(5)));
+    assert!(bytes.is_empty());
+    assert!(exit.is_none());
+}
+
+#[test]
+fn conditional_bindings_rebuild_per_update() {
+    // The "(n sent)" line only appears after a submit — and so could a
+    // binding. Verify keymap() is consulted fresh each event by toggling
+    // focus between events.
+    let focus = Focus::new();
+    let app = Echo::new(&focus);
+    let input_focus = app.input_focus.clone();
+    let mut rt = Runtime::new(app, 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+    term.feed(&rt.present());
+
+    type_str(&mut rt, &mut term, "a");
+    assert_eq!(term.viewport_lines()[0], "> a");
+
+    input_focus.blur();
+    let (bytes, _) = rt.handle(press(KeyCode::Char('b')));
+    assert!(bytes.is_empty(), "typing while blurred does nothing");
+
+    input_focus.focus();
+    type_str(&mut rt, &mut term, "c");
+    assert_eq!(term.viewport_lines()[0], "> ac");
+}
+
+#[test]
+fn borrowed_blocks_push_cleanly() {
+    // Ctx::push renders immediately, so blocks may borrow from update
+    // locals — this is the API shape the driver port needed.
+    struct OneShot {
+        events: Vec<String>,
+        done: bool,
+    }
+
+    impl App for OneShot {
+        type Msg = ();
+        type Output = ();
+
+        fn update(&mut self, _msg: (), ctx: &mut Ctx<'_, ()>) {
+            let events = std::mem::take(&mut self.events);
+            ctx.push(col().children(events.iter().map(|e| text(e.as_str()).pad_left(2))));
+            self.done = true;
+            ctx.exit(());
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            text(if self.done { "" } else { "working" })
+        }
+    }
+
+    let mut rt = Runtime::new(
+        OneShot {
+            events: vec!["one".into(), "two".into()],
+            done: false,
+        },
+        20,
+        24,
+    );
+    let mut term = TestTerminal::new(20, 24);
+    term.feed(&rt.present());
+
+    let (bytes, exit) = rt.process(());
+    term.feed(&bytes);
+    assert!(exit.is_some());
+    assert_eq!(term.viewport_lines()[0], "  one");
+    assert_eq!(term.viewport_lines()[1], "  two");
+}

--- a/crates/eye_declare_next/tests/async_driver.rs
+++ b/crates/eye_declare_next/tests/async_driver.rs
@@ -1,0 +1,197 @@
+//! Async driver behavior, driven headlessly: spawned streams feed
+//! `update`; dropping a `Task` cancels mid-stream; `perform` delivers a
+//! one-shot message.
+
+use std::time::Duration;
+
+use eye_declare_engine::test_terminal::TestTerminal;
+use eye_declare_next::driver_tokio::spawn_effects;
+use eye_declare_next::{App, Ctx, Element, Runtime, Task, col, text};
+use futures::StreamExt;
+
+#[derive(Clone)]
+enum Msg {
+    Start,
+    Delta(String),
+    Done,
+    Cancel,
+}
+
+#[derive(Default)]
+struct Agent {
+    slow: bool,
+    response: String,
+    task: Option<Task>,
+    turns: usize,
+}
+
+impl App for Agent {
+    type Msg = Msg;
+    type Output = ();
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            Msg::Start => {
+                let stream: futures::stream::BoxStream<'static, Msg> = if self.slow {
+                    futures::stream::unfold(0u8, |n| async move {
+                        match n {
+                            0 => Some((Msg::Delta("first".into()), 1)),
+                            1 => {
+                                tokio::time::sleep(Duration::from_millis(50)).await;
+                                Some((Msg::Delta("second".into()), 2))
+                            }
+                            _ => None,
+                        }
+                    })
+                    .boxed()
+                } else {
+                    futures::stream::iter([
+                        Msg::Delta("hel".into()),
+                        Msg::Delta("lo".into()),
+                        Msg::Done,
+                    ])
+                    .boxed()
+                };
+                self.task = Some(ctx.spawn(stream));
+            }
+            Msg::Delta(s) => self.response.push_str(&s),
+            Msg::Done => {
+                let content = std::mem::take(&mut self.response);
+                ctx.push(text(format!("ai: {content}")));
+                self.task = None;
+                self.turns += 1;
+            }
+            Msg::Cancel => {
+                // Cancellation is an assignment: dropping the Task cancels
+                // the spawned stream.
+                self.task = None;
+            }
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        col().child(text(format!("~ {}", self.response)))
+    }
+}
+
+#[tokio::test]
+async fn spawned_stream_drives_updates() {
+    let mut rt = Runtime::new(Agent::default(), 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+    term.feed(&rt.present());
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let (bytes, _) = rt.process(Msg::Start);
+    term.feed(&bytes);
+    spawn_effects(rt.take_effects(), &tx);
+
+    while rt.app().turns == 0 {
+        let msg = rx.recv().await.expect("stream should keep feeding");
+        let (bytes, _) = rt.process(msg);
+        term.feed(&bytes);
+        spawn_effects(rt.take_effects(), &tx);
+    }
+
+    // The completed turn is a committed block; the tail reset below it.
+    assert_eq!(term.viewport_lines()[0], "ai: hello");
+    assert_eq!(term.viewport_lines()[1], "~");
+}
+
+#[tokio::test]
+async fn dropping_task_cancels_stream() {
+    let mut rt = Runtime::new(
+        Agent {
+            slow: true,
+            ..Agent::default()
+        },
+        20,
+        24,
+    );
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let (_, _) = rt.process(Msg::Start);
+    spawn_effects(rt.take_effects(), &tx);
+
+    // First item arrives, then the stream sleeps.
+    let first = rx.recv().await.expect("first item");
+    let (_, _) = rt.process(first);
+    assert_eq!(rt.app().response, "first");
+
+    // Cancel while the stream sleeps; the spawned task must end without
+    // producing "second". Dropping our tx makes rx.recv() return None
+    // exactly when the task's tx clone is gone.
+    let (_, _) = rt.process(Msg::Cancel);
+    drop(tx);
+    let next = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("cancelled task should end promptly");
+    assert!(next.is_none(), "no further items after cancellation");
+    assert_eq!(rt.app().response, "first");
+}
+
+#[tokio::test]
+async fn perform_delivers_one_message() {
+    #[derive(Clone)]
+    enum FetchMsg {
+        Start,
+        Got(&'static str),
+    }
+
+    struct OneShot {
+        got: Option<&'static str>,
+        task: Option<Task>,
+    }
+
+    impl App for OneShot {
+        type Msg = FetchMsg;
+        type Output = ();
+
+        fn update(&mut self, msg: FetchMsg, ctx: &mut Ctx<'_, Self>) {
+            match msg {
+                FetchMsg::Start => {
+                    self.task = Some(ctx.perform(async {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        FetchMsg::Got("data")
+                    }));
+                }
+                FetchMsg::Got(value) => {
+                    self.got = Some(value);
+                    self.task = None;
+                }
+            }
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            text(self.got.unwrap_or("waiting"))
+        }
+    }
+
+    let mut rt = Runtime::new(
+        OneShot {
+            got: None,
+            task: None,
+        },
+        20,
+        24,
+    );
+    let mut term = TestTerminal::new(20, 24);
+    term.feed(&rt.present());
+    assert_eq!(term.viewport_lines()[0], "waiting");
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let (bytes, _) = rt.process(FetchMsg::Start);
+    term.feed(&bytes);
+    spawn_effects(rt.take_effects(), &tx);
+
+    let msg = rx
+        .recv()
+        .await
+        .expect("perform delivers exactly one message");
+    let (bytes, _) = rt.process(msg);
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "data");
+
+    // The future completed; the stream behind it ends.
+    drop(tx);
+    assert!(rx.recv().await.is_none());
+}


### PR DESCRIPTION
The interactive core. Focus is data — `FocusHandle`s share one cell, so single focus holds by construction and the runtime has zero focus knowledge. `Keymap` implements the dispatch order settled in the bake-off (override → focus-scoped → global → fallthrough, first declaration wins). `App`/`Ctx` is the Elm surface: `ctx.push` renders immediately so blocks may borrow the model; `Runtime` is headlessly testable (events in, bytes out).

The tokio driver adds `ctx.spawn`/`ctx.perform` with a cancel-on-drop `Task` built on a hand-rolled waker future, keeping the core executor-agnostic (verified: compiles `--no-default-features`). First runnable examples: `echo` and `stream` (a mini agent — streaming turn in the tail, sealed on completion, Esc cancels by dropping the Task).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
