### PR TITLE
v2 redesign: port-driven additions — keyboard protocol options

### DIFF
--- a/.planning/PHASE5-ATUIN-PORT.md
+++ b/.planning/PHASE5-ATUIN-PORT.md
@@ -25,7 +25,7 @@ thread ⇄ spawned tasks) into one `App`:
 struct AiApp {
     fsm: AgentFsm,                      // unchanged
     io: IoContext,                      // unchanged (persistence goes async, below)
-    input: TextAreaState,               // replaces Arc<Mutex<TextArea>>
+    input: TextArea<'static>,           // tui-textarea as a plain value (no Arc<Mutex>)
     select: Option<SelectState>,        // permission prompt / model picker cursor
     slash: SlashState,                  // registry + live search results
     usage: Option<UsageSnapshot>,
@@ -115,7 +115,7 @@ declarative — the Tab footgun fix falls out structurally:
 | `tui/view/mod.rs` (1103) | `ai_view` → `tail()` + plain `&data -> impl Element + use<>` view fns; `element!` → fluent builders; every `key:` prop deleted; the diff/write/shell/group views port near-1:1 (already proven in the Phase 1 spike) |
 | `tui/view/turn.rs` | unchanged (pure) |
 | `tui/components/atuin_ai.rs` (143) | **deleted** → `keymap()` |
-| `tui/components/input_box.rs` (220) | **deleted** → `TextAreaState` in model + `panel(text_area(..))` in view + keymap arms; drops the `tui-textarea` dependency |
+| `tui/components/input_box.rs` (220) | **deleted** → tui-textarea's `TextArea` as a plain model value (the `Arc<Mutex<..>>` was v1's fault, not tui-textarea's — under strict Elm it's just a field) + a small `Element` interop adapter (measure/render) + `panel(..)` chrome + keymap arms. Decided 2026-07-16: keep tui-textarea for emacs bindings/undo/kill-ring rather than rebuilding them on `TextAreaState`; this also exercises the ratatui-interop design rule. `TextAreaState` stays the zero-dep built-in for simple apps. |
 | `tui/components/select.rs` (95) | → `SelectState` value + view fn (~30 lines); candidate for promotion into the library during Phase 6 |
 | `tui/components/session_continue.rs` (49) | **deleted** → a `String` computed once at startup |
 | `tui/components/markdown.rs` (210) | **deleted** → `eye_declare::markdown` (already ported) |

--- a/.planning/PHASE5-ATUIN-PORT.md
+++ b/.planning/PHASE5-ATUIN-PORT.md
@@ -163,3 +163,36 @@ declarative — the Tab footgun fix falls out structurally:
   `update_tracked` dirty-avoidance tricks, no `exiting` AtomicBool.
 - Esc-cancels-generation is `self.streaming = None`.
 - History renders exactly once (pushed at startup), not every frame.
+
+## Verdict (2026-07-20 — Phase 5 COMPLETE)
+
+All six slices landed on atuin branch `mkt/ai-eye-declare-v2` (6d604c51).
+
+**Success criteria: met.** `DriverEventSender`, `ViewState`/`sync_view_state`,
+the `on_commit` key parsing, and the `active`-prop focus shadow are deleted
+with no successors — along with their support machinery (`UiTurn.id`,
+`TurnBuilder::new_starting_at`, `AppMode`, the `Arc<Mutex<TextArea>>`, the
+blocking driver thread, the watch-channel stream cancellation, and the
+`exiting` AtomicBool).
+
+**Numbers.** v1 TUI layer (tui/ + driver.rs + inline.rs): 4,655 lines with
+~35 lines of tests. v2: 4,649 lines of which ~810 are a headless test suite
+(69 tests driving the full app through the VTE terminal). Production code
+shrank ~780 lines (~17%) while the behavior surface grew (everything v1 did,
+plus regression coverage it never had).
+
+**Library additions the port forced** (all on stack layer
+`mkt/v2-7-port-additions`): `KeyboardProtocol`/`RunOptions`/`run_with`,
+`Keymap::merge`, `App::init` + `Runtime::startup`. Plus one engine fix it
+shook out (on `mkt/v2-3-elements`): `Engine::commit` presents the block
+alone, ending tall-seal transcript duplication.
+
+**Patterns worth documenting** (Phase 7 docs backlog):
+- The persist actor: a single task owning a `&mut`-method resource, fed
+  jobs in channel order — the Elm-shaped answer to serialized IO.
+- The frontier hazard: any app-held index into externally-owned state
+  needs a story for that state shrinking (the /new bug).
+- Interrupt ≠ cancel: detached streams for work whose outcome must
+  survive a user interrupt; `Task` drop for work that shouldn't.
+- Keymap conditionals that grow arms are usually policy the model/FSM
+  already owns (the Esc ladder deletion).

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -429,6 +429,15 @@ Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
    keyboard enhancement flags, `Keymap::merge`). Work happens on an atuin
    branch via Cargo package-rename (`eye_declare = { package =
    "eye_declare_next", .. }`) so code paths never change at release.
+   - Port slice 5 ✅ (2026-07-20): pickers + usage + startup. Library
+     addition `App::init` (runs in `Runtime::new`; pushed bytes precede
+     the first frame via a pending buffer drained by present/process;
+     `Runtime::startup()` delivers init bytes + init exit to drivers).
+     Atuin: initial prompt submits through normal dispatch, stale usage
+     refreshes in the background, /model picker reuses `SelectState`,
+     status bar ported. Design win: the keymap's Esc mode-ladder deleted —
+     `Msg::Cancel` always; the FSM was already the owner of what
+     cancelling means per state. Remaining: slice 6 deletion audit.
    - Port slice 4 ✅ (2026-07-20): tools + permissions. Shell execution =
      detached message stream (previews + outcome from one select loop;
      interrupt ≠ cancel proven by an interrupted-sleep test); file tools

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -424,6 +424,10 @@ Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
 5. **Atuin AI port** — the validation gate. Success = the four adapters
    (`DriverEventSender`, `sync_view_state`, key-parsing `on_commit`, `active`-prop focus
    shadow) delete cleanly and the TUI code shrinks.
+   ✅ **COMPLETE (2026-07-20).** All four adapters gone with no successors;
+   production TUI code −17% (~780 lines) while gaining a 69-test headless
+   suite. Full verdict + patterns for the docs: `.planning/PHASE5-ATUIN-PORT.md`.
+   **← Phase 6 next: the OpenRouter flagship example.**
    **Plan written (2026-07-16):** `.planning/PHASE5-ATUIN-PORT.md` — file-by-file
    mapping, six port slices, expected library additions (startup effects,
    keyboard enhancement flags, `Keymap::merge`). Work happens on an atuin

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -429,6 +429,17 @@ Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
    keyboard enhancement flags, `Keymap::merge`). Work happens on an atuin
    branch via Cargo package-rename (`eye_declare = { package =
    "eye_declare_next", .. }`) so code paths never change at release.
+   - Port slice 4 ✅ (2026-07-20): tools + permissions. Shell execution =
+     detached message stream (previews + outcome from one select loop;
+     interrupt ≠ cancel proven by an interrupted-sleep test); file tools
+     inline with snapshot/tracker/diff wiring; permission fast paths sync,
+     resolver via perform, headless resolves Ask (which is the prompt
+     path tests need). First real sub-model: `SelectState` +
+     `Keymap::merge` (added to the library on the port-additions layer,
+     with the earlier-declarations-win contract). Debug lesson repeated:
+     probe, don't guess — "prompt never appears" was capability gating +
+     a wrong field name (`path` vs `file_path`), both found by printing
+     FSM state. Also rebased onto upstream (DisplayRichExt/typed URLs).
    - Port slice 3 ✅ (2026-07-16): streaming. Bridge = plain
      `Stream<Item = Msg>` via `ctx.spawn`; cancel-on-drop deleted the
      watch-channel protocol *and* the stale-cache-population hazard.

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -429,6 +429,16 @@ Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
    keyboard enhancement flags, `Keymap::merge`). Work happens on an atuin
    branch via Cargo package-rename (`eye_declare = { package =
    "eye_declare_next", .. }`) so code paths never change at release.
+   - Port slice 3 ✅ (2026-07-16): streaming. Bridge = plain
+     `Stream<Item = Msg>` via `ctx.spawn`; cancel-on-drop deleted the
+     watch-channel protocol *and* the stale-cache-population hazard.
+     Persistence = actor owning `SessionManager` (`&mut self` methods +
+     write ordering → single owning task, no locks — better answer than
+     the plan's Arc guess). Streaming text injects into the tail's
+     TurnBuilder; agent turns seal on Idle, stay live through Error
+     (Retry continues the turn); timeouts = detached `ctx.perform`
+     sleeps. Test seam: `AiApp::headless` (io: Option) — stream flows
+     driven as `Msg::Fsm` events. Tools/permissions next (slice 4).
    - Port slice 2 ✅ (2026-07-16): input path. tui-textarea kept as the
      editor — a plain model value + ~50-line Element adapter (RefCell only
      for measure()'s memoization `&mut`); the ratatui-interop design rule

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -429,6 +429,17 @@ Resolved by the bake-off (evidence: `crates/spike/FINDINGS.md`):
    keyboard enhancement flags, `Keymap::merge`). Work happens on an atuin
    branch via Cargo package-rename (`eye_declare = { package =
    "eye_declare_next", .. }`) so code paths never change at release.
+   - Port slice 2 ✅ (2026-07-16): input path. tui-textarea kept as the
+     editor — a plain model value + ~50-line Element adapter (RefCell only
+     for measure()'s memoization `&mut`); the ratatui-interop design rule
+     validated in production shape. Keymap policy table fully declarative
+     (Esc/Ctrl+C/Enter/Tab resolve their mode at keymap build); Tab
+     footgun structurally gone (test: `typing_disarms_command_execution`).
+     Submit → FSM; ExitApp executes (suggest→Execute/Insert works e2e);
+     sealed turns `ctx.push` at submit. Library addition shipped on stack
+     layer `mkt/v2-7-port-additions`: `KeyboardProtocol`/`RunOptions` +
+     `run_with` (Shift+Enter). Test lesson: headless harness must feed
+     `handle()`'s bytes to the VTE terminal, not just `present()`'s.
    - Port slice 1 ✅ (2026-07-16, atuin `mkt/ai-eye-declare-v2`): skeleton.
      Dep swapped (versions unified cleanly: ratatui-core 0.1 / crossterm
      0.29 both sides); component layer + `driver.rs` deleted; `AiApp` with

--- a/crates/eye_declare_next/src/app.rs
+++ b/crates/eye_declare_next/src/app.rs
@@ -18,6 +18,16 @@ pub trait App: Sized {
     /// What the run loop returns after [`Ctx::exit`].
     type Output: Default;
 
+    /// One-time startup effects, run during runtime construction before
+    /// the first frame: push preamble blocks, spawn initial work, feed an
+    /// initial message through the model. Default: nothing.
+    ///
+    /// Async effects spawned here need an async driver, exactly as from
+    /// `update`; the sync [`run`](crate::run) rejects them.
+    fn init(&mut self, ctx: &mut Ctx<'_, Self>) {
+        let _ = ctx;
+    }
+
     /// Handle a message: mutate the model, emit effects via `ctx`.
     fn update(&mut self, msg: Self::Msg, ctx: &mut Ctx<'_, Self>);
 

--- a/crates/eye_declare_next/src/driver_tokio.rs
+++ b/crates/eye_declare_next/src/driver_tokio.rs
@@ -50,9 +50,13 @@ where
 
     let _guard = RawModeGuard::enable(options.keyboard)?;
 
-    let bytes = runtime.present();
+    let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
     stdout.flush()?;
+    if let Some(output) = init_exit {
+        return Ok(output);
+    }
+    spawn_effects(runtime.take_effects(), &tx);
 
     let mut subs = ActiveSubscriptions::new(tx.clone());
     subs.sync(runtime.app().subscriptions());

--- a/crates/eye_declare_next/src/driver_tokio.rs
+++ b/crates/eye_declare_next/src/driver_tokio.rs
@@ -18,12 +18,12 @@ use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 
 use crate::app::App;
 use crate::input::InputEvent;
-use crate::runtime::{RawModeGuard, Runtime};
+use crate::runtime::{RawModeGuard, RunOptions, Runtime};
 use crate::subscription::{SubKind, Subscriptions};
 use crate::task::{Cancel, Effect, MsgStream};
 
 /// Run an app on the attached terminal until it exits, executing spawned
-/// streams on the ambient tokio runtime.
+/// streams on the ambient tokio runtime. Uses default [`RunOptions`].
 ///
 /// Raw mode + bracketed paste are enabled for the duration and restored on
 /// exit (including panic unwind). If stdin closes, returns
@@ -33,12 +33,22 @@ where
     A: App,
     A::Msg: Clone + Send + 'static,
 {
+    run_with(app, RunOptions::default()).await
+}
+
+/// [`run`] with explicit [`RunOptions`] (e.g. the enhanced keyboard
+/// protocol, which apps need to distinguish Shift+Enter from Enter).
+pub async fn run_with<A>(app: A, options: RunOptions) -> io::Result<A::Output>
+where
+    A: App,
+    A::Msg: Clone + Send + 'static,
+{
     let (width, height) = crossterm::terminal::size()?;
     let mut runtime = Runtime::new(app, width, height);
     let (tx, mut rx) = unbounded_channel::<A::Msg>();
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable()?;
+    let _guard = RawModeGuard::enable(options.keyboard)?;
 
     let bytes = runtime.present();
     stdout.write_all(&bytes)?;

--- a/crates/eye_declare_next/src/input.rs
+++ b/crates/eye_declare_next/src/input.rs
@@ -128,6 +128,16 @@ impl<Msg> Keymap<Msg> {
         self
     }
 
+    /// Append another keymap's bindings. Within each scope tier, earlier
+    /// declarations still win, so a parent that merges a child's keymap
+    /// after its own bindings keeps priority on contested keys — the usual
+    /// composition is `parent_bindings.merge(child.keymap().map(Msg::Child))`.
+    pub fn merge(mut self, other: Keymap<Msg>) -> Self {
+        self.bindings.extend(other.bindings);
+        self.fallthrough.extend(other.fallthrough);
+        self
+    }
+
     /// Re-target to a parent message type (Elm's `Html.map` for keymaps) —
     /// how a sub-model's keymap embeds into the app's.
     pub fn map<M2>(self, f: impl Fn(Msg) -> M2 + Clone + Send + 'static) -> Keymap<M2>
@@ -220,6 +230,21 @@ mod tests {
             }
             InputEvent::Paste(_) => Msg::Edit('P'),
         }
+    }
+
+    #[test]
+    fn merge_appends_and_earlier_declarations_win() {
+        // The composition shape: a child sub-model's keymap, mapped and
+        // merged after the parent's own bindings.
+        let child = keymap()
+            .on(key(KeyCode::Up), Msg::Edit('u'))
+            .on(key(KeyCode::Enter), Msg::Edit('!'));
+        let km = keymap().on(key(KeyCode::Enter), Msg::Submit).merge(child);
+
+        // The child's uncontested binding works…
+        assert_eq!(km.dispatch(&press(KeyCode::Up)), Some(Msg::Edit('u')));
+        // …but on a contested key the parent, declared first, wins.
+        assert_eq!(km.dispatch(&press(KeyCode::Enter)), Some(Msg::Submit));
     }
 
     #[test]

--- a/crates/eye_declare_next/src/lib.rs
+++ b/crates/eye_declare_next/src/lib.rs
@@ -45,7 +45,7 @@ pub use input::{InputEvent, Key, Keymap, key, keymap};
 #[cfg(feature = "markdown")]
 pub use markdown::{Markdown, MarkdownStyles, markdown};
 pub use panel::{Panel, panel};
-pub use runtime::{Runtime, run};
+pub use runtime::{KeyboardProtocol, RunOptions, Runtime, run, run_with};
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
 pub use subscription::Subscriptions;

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -21,19 +21,47 @@ pub struct Runtime<A: App> {
     timeline: Timeline,
     animate: Option<Duration>,
     effects: Vec<Effect<A::Msg>>,
+    /// Bytes produced by [`App::init`] pushes, drained by the next
+    /// [`present`](Runtime::present).
+    pending: Vec<u8>,
+    /// An exit requested from [`App::init`], delivered via
+    /// [`startup`](Runtime::startup).
+    init_exit: Option<A::Output>,
 }
 
 impl<A: App> Runtime<A>
 where
     A::Msg: Clone,
 {
-    pub fn new(app: A, width: u16, terminal_height: u16) -> Self {
+    /// Construct the runtime. Runs [`App::init`]; its pushed blocks join
+    /// the next `present`'s bytes and its spawned effects wait in
+    /// [`take_effects`](Runtime::take_effects).
+    pub fn new(mut app: A, width: u16, terminal_height: u16) -> Self {
+        let mut timeline = Timeline::new(width, terminal_height);
+        let mut pending = Vec::new();
+        let mut effects = Vec::new();
+        let mut ctx = Ctx {
+            timeline: &mut timeline,
+            output: &mut pending,
+            effects: &mut effects,
+            exit: None,
+        };
+        app.init(&mut ctx);
+        let init_exit = ctx.exit;
         Self {
             app,
-            timeline: Timeline::new(width, terminal_height),
+            timeline,
             animate: None,
-            effects: Vec::new(),
+            effects,
+            pending,
+            init_exit,
         }
+    }
+
+    /// First bytes to write and any exit [`App::init`] requested — what a
+    /// driver calls once before its loop, instead of a bare `present`.
+    pub fn startup(&mut self) -> (Vec<u8>, Option<A::Output>) {
+        (self.present(), self.init_exit.take())
     }
 
     /// Feed one input event. Resolves it through the app's keymap; if a
@@ -49,7 +77,9 @@ where
     /// Feed one message (from the keymap, or — in the async driver — from
     /// tasks and subscriptions).
     pub fn process(&mut self, msg: A::Msg) -> (Vec<u8>, Option<A::Output>) {
-        let mut bytes = Vec::new();
+        // Undelivered init bytes come first so init's blocks precede this
+        // update's pushes in scrollback.
+        let mut bytes = std::mem::take(&mut self.pending);
         let mut ctx = Ctx {
             timeline: &mut self.timeline,
             output: &mut bytes,
@@ -77,7 +107,9 @@ where
     pub fn present(&mut self) -> Vec<u8> {
         let tail = self.app.tail();
         self.animate = tail.animated();
-        self.timeline.present(&tail)
+        let mut bytes = std::mem::take(&mut self.pending);
+        bytes.extend(self.timeline.present(&tail));
+        bytes
     }
 
     /// How soon the tail wants re-presenting for animation, if at all.
@@ -156,9 +188,13 @@ where
 
     let _guard = RawModeGuard::enable(options.keyboard)?;
 
-    let bytes = runtime.present();
+    let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
     stdout.flush()?;
+    if let Some(output) = init_exit {
+        return Ok(output);
+    }
+    reject_effects(&mut runtime)?;
 
     loop {
         let timeout = runtime

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -101,7 +101,40 @@ where
     }
 }
 
-/// Run an app on the attached terminal until it exits.
+/// Which keyboard protocol interactive drivers request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum KeyboardProtocol {
+    /// Standard terminal key reporting (default). Compatible everywhere,
+    /// but some chords are ambiguous (Shift+Enter vs Enter, Tab vs Ctrl+I).
+    #[default]
+    Legacy,
+    /// The [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/)
+    /// when the terminal supports it, silently falling back to legacy.
+    /// Disambiguates modified keys (Shift+Enter) in supporting terminals
+    /// (kitty, WezTerm, foot, Ghostty, Windows Terminal, …).
+    Enhanced,
+}
+
+/// Terminal options for the interactive drivers ([`run_with`],
+/// [`driver_tokio::run_with`](crate::driver_tokio::run_with)).
+///
+/// Construct with [`Default`] and the fluent setters; new options may be
+/// added without a breaking change.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct RunOptions {
+    pub keyboard: KeyboardProtocol,
+}
+
+impl RunOptions {
+    pub fn keyboard(mut self, protocol: KeyboardProtocol) -> Self {
+        self.keyboard = protocol;
+        self
+    }
+}
+
+/// Run an app on the attached terminal until it exits, with default
+/// [`RunOptions`].
 ///
 /// Raw mode + bracketed paste are enabled for the duration and restored on
 /// exit (including panic unwind); the cursor is re-shown on teardown.
@@ -109,11 +142,19 @@ pub fn run<A: App>(app: A) -> io::Result<A::Output>
 where
     A::Msg: Clone,
 {
+    run_with(app, RunOptions::default())
+}
+
+/// [`run`] with explicit [`RunOptions`].
+pub fn run_with<A: App>(app: A, options: RunOptions) -> io::Result<A::Output>
+where
+    A::Msg: Clone,
+{
     let (width, height) = crossterm::terminal::size()?;
     let mut runtime = Runtime::new(app, width, height);
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable()?;
+    let _guard = RawModeGuard::enable(options.keyboard)?;
 
     let bytes = runtime.present();
     stdout.write_all(&bytes)?;
@@ -184,20 +225,40 @@ where
 }
 
 /// Restores the terminal on drop, including panic unwind.
-pub(crate) struct RawModeGuard;
+pub(crate) struct RawModeGuard {
+    keyboard_enhanced: bool,
+}
 
 impl RawModeGuard {
-    pub(crate) fn enable() -> io::Result<Self> {
+    pub(crate) fn enable(keyboard: KeyboardProtocol) -> io::Result<Self> {
         crossterm::terminal::enable_raw_mode()?;
         let mut stdout = io::stdout();
         let _ = crossterm::execute!(stdout, crossterm::event::EnableBracketedPaste);
-        Ok(Self)
+
+        // Only push if the terminal supports it — the silent-fallback
+        // contract of KeyboardProtocol::Enhanced.
+        let keyboard_enhanced = keyboard == KeyboardProtocol::Enhanced
+            && crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false);
+        if keyboard_enhanced {
+            let _ = crossterm::execute!(
+                stdout,
+                crossterm::event::PushKeyboardEnhancementFlags(
+                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                        | crossterm::event::KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+                )
+            );
+        }
+
+        Ok(Self { keyboard_enhanced })
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         let mut stdout = io::stdout();
+        if self.keyboard_enhanced {
+            let _ = crossterm::execute!(stdout, crossterm::event::PopKeyboardEnhancementFlags);
+        }
         let _ = crossterm::execute!(stdout, crossterm::event::DisableBracketedPaste);
         let _ = crossterm::terminal::disable_raw_mode();
         // The engine hides the cursor while no element hints one; make

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -276,11 +276,14 @@ impl RawModeGuard {
         let keyboard_enhanced = keyboard == KeyboardProtocol::Enhanced
             && crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false);
         if keyboard_enhanced {
+            // Disambiguation only: it's all Shift+Enter detection needs.
+            // REPORT_EVENT_TYPES would add key-release events, which the
+            // built-in drivers filter but a custom driver feeding
+            // Runtime::handle directly could easily double-dispatch.
             let _ = crossterm::execute!(
                 stdout,
                 crossterm::event::PushKeyboardEnhancementFlags(
                     crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                        | crossterm::event::KeyboardEnhancementFlags::REPORT_EVENT_TYPES
                 )
             );
         }

--- a/crates/eye_declare_next/tests/app_headless.rs
+++ b/crates/eye_declare_next/tests/app_headless.rs
@@ -230,3 +230,84 @@ fn borrowed_blocks_push_cleanly() {
     assert_eq!(term.viewport_lines()[0], "  one");
     assert_eq!(term.viewport_lines()[1], "  two");
 }
+
+#[test]
+fn init_pushes_precede_first_frame_and_later_pushes() {
+    struct Banner {
+        submitted: bool,
+    }
+
+    impl App for Banner {
+        type Msg = ();
+        type Output = ();
+
+        fn init(&mut self, ctx: &mut Ctx<'_, Self>) {
+            ctx.push(text("welcome banner"));
+        }
+
+        fn update(&mut self, _msg: (), ctx: &mut Ctx<'_, Self>) {
+            self.submitted = true;
+            ctx.push(text("first message"));
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            text(if self.submitted { "done" } else { "prompt" })
+        }
+    }
+
+    // The driver path: startup() delivers init's block before the tail.
+    let mut rt = Runtime::new(Banner { submitted: false }, 40, 10);
+    let mut term = TestTerminal::new(40, 10);
+    let (bytes, exit) = rt.startup();
+    assert!(exit.is_none());
+    term.feed(&bytes);
+    let screen = term.viewport_lines().join("\n");
+    let banner_row = screen.find("welcome banner").expect("banner missing");
+    let prompt_row = screen.find("prompt").expect("tail missing");
+    assert!(banner_row < prompt_row, "init block must precede the tail");
+
+    // A later push lands below the banner.
+    let (bytes, _) = rt.process(());
+    term.feed(&bytes);
+    let all = [term.scrollback_lines(), term.viewport_lines()]
+        .concat()
+        .join("\n");
+    let banner = all.find("welcome banner").unwrap();
+    let first = all.find("first message").unwrap();
+    assert!(
+        banner < first,
+        "init block stays above later pushes:\n{all}"
+    );
+}
+
+#[test]
+fn init_bytes_survive_process_without_present() {
+    struct P;
+    impl App for P {
+        type Msg = ();
+        type Output = ();
+        fn init(&mut self, ctx: &mut Ctx<'_, Self>) {
+            ctx.push(text("from init"));
+        }
+        fn update(&mut self, _msg: (), ctx: &mut Ctx<'_, Self>) {
+            ctx.push(text("from update"));
+        }
+        fn tail(&self) -> impl Element + '_ {
+            text("tail")
+        }
+    }
+
+    // Skipping startup() and going straight to process(): init's block
+    // must still come out first.
+    let mut rt = Runtime::new(P, 40, 10);
+    let mut term = TestTerminal::new(40, 10);
+    let (bytes, _) = rt.process(());
+    term.feed(&bytes);
+    let all = [term.scrollback_lines(), term.viewport_lines()]
+        .concat()
+        .join("\n");
+    assert!(
+        all.find("from init").unwrap() < all.find("from update").unwrap(),
+        "wrong order:\n{all}"
+    );
+}


### PR DESCRIPTION
Library additions driven by the Atuin AI port (Phase 5), landing as the port's slices discover them. So far: `KeyboardProtocol` (Legacy default / Enhanced = kitty protocol, gated on terminal support with silent fallback — required to tell Shift+Enter from Enter) carried by a `non_exhaustive` `RunOptions`, with `run_with(app, options)` on both the sync and tokio drivers. `run(app)` keeps its zero-config shape.

Expected to grow: startup effects (`App::init`-style, for initial prompts and background fetches) and `Keymap::merge` when the port's picker slice needs them.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
