### PR TITLE
v2 redesign: measured perf pass — 3× frames, 61× stream bursts

### DIFF
--- a/.planning/PERF.md
+++ b/.planning/PERF.md
@@ -1,0 +1,71 @@
+# Performance pass (2026-07-20, stack layer mkt/v2-8-perf)
+
+Measured with `cargo run --release -p eye_declare_next --example perf_report`
+(deterministic: exact allocation counts via a wrapping global allocator) and
+`benches/frame.rs` (criterion). Scenario: an atuin-shaped chat app — one
+streaming markdown response of N bytes in the tail + panel/text-area input —
+on a 100×40 terminal, driven headlessly.
+
+## Results (per frame, 10KB markdown in the tail)
+
+| scenario              | before            | after            |
+|-----------------------|-------------------|------------------|
+| steady present        | 2276µs / 10.1K allocs | 784µs / 2.3K allocs |
+| streaming chunk       | 2560µs / 10.8K    | 901µs / 2.6K     |
+| typing keystroke      | 2278µs / 10.1K    | 790µs / 2.3K     |
+| 64-chunk burst        | 99ms (64 frames)  | 1.7ms (1 frame)  |
+
+At 50KB the frame cost is ~3.7ms (was 11.3ms). Scaling with content size
+remains linear — see "what we didn't do."
+
+## What changed
+
+1. **Markdown same-frame caches** (`markdown.rs`): parse once per element
+   lifetime (= per frame) instead of once in `height` and again in
+   `render`; wrapped row count memoized per width — containers re-ask
+   `height()` at every layer, so this fired 3-4× per frame. Render uses a
+   borrowed view of the cached parse (no per-span string clones). No
+   cross-frame invalidation story needed: elements are rebuilt per frame.
+2. **Diff clamped to reachable rows** (`Frame::diff_from`): rows past the
+   scrollback boundary are physically immutable; the engine now skips
+   comparing them instead of filtering them out afterward. With a tail
+   much taller than the terminal this is diffing one screenful instead of
+   the whole virtual frame.
+3. **Message coalescing** (`Runtime::process_batch` + driver drain): the
+   tokio driver drains everything queued (≤256) into one batch and
+   presents once. A stream burst of 64 chunks costs one frame, not 64 —
+   the 61× number above. This is the fix for streams being O(n²) in
+   practice: per-chunk frames were the multiplier on the per-frame cost.
+
+## The arena question: answered no
+
+Building the element tree — the thing an arena allocator would optimize —
+costs 0.5µs and 16 allocations per frame. It was never the problem; the
+allocations were markdown span strings (fixed by caching/borrowing) and
+per-frame re-parsing (fixed by memoization). An arena would complicate
+`AnyElement`'s boxing story for a stage that is 0.06% of the frame.
+
+## What we deliberately didn't do
+
+- **O(visible) rendering.** `render` still paints the full virtual frame
+  and `height` still wraps all content, so per-frame cost stays O(tail
+  content). Fixing that means cooperative render clipping through the
+  element tree, and it wouldn't help the dominant case anyway (a single
+  tall markdown block has no children to cull). The architectural answer
+  is the one the spec already gives: **keep tails bounded** — push content
+  that can no longer change (the frontier pattern), and the per-frame cost
+  follows the live content, not the conversation. 780µs at 10KB /
+  12.5fps animation ≈ 1% CPU, which is acceptable for the unbounded case;
+  apps that stream 100KB+ responses should seal at safe markdown
+  boundaries.
+- **Buffer recycling.** The engine retains each presented frame as `prev`,
+  so reuse needs a swap API for ~10% of one stage. Not worth it today.
+- **`Text` same-frame caches.** Leaf text is label-sized in practice;
+  tree-build measurements say it's noise. The `Markdown` pattern applies
+  directly if a profile ever disagrees.
+
+## Regression harness
+
+`benches/frame.rs` (criterion) and `examples/perf_report.rs` stay in the
+tree. The report prints exact alloc counts — run it before and after
+render-path changes; the numbers are deterministic.

--- a/.planning/REDESIGN.md
+++ b/.planning/REDESIGN.md
@@ -493,6 +493,15 @@ Docs backlog (for the ship phase): the component *convention* (state struct
 framework interface), including the history: Elm's components-are-a-trap
 guidance post-0.17 and iced's deprecated Component trait; when to reach for
 `Keymap::map`/enum embedding; parent-claims-policy composition.
+Perf chapter (from the 2026-07-20 pass, numbers in `.planning/PERF.md`):
+the same-frame `RefCell` cache pattern for expensive custom elements
+(elements are rebuilt per frame, so height/render can share work with no
+invalidation story — and note `height()` runs more than once per frame via
+container placement); keep tails bounded (frontier pattern) because
+per-frame cost is O(tail content); message coalescing is automatic in the
+tokio driver, so apps need not debounce streams themselves. Plus the
+Phase 5 verdict's patterns (persist actor, frontier-shrink hazard,
+interrupt ≠ cancel, keymap-arms-are-model-policy).
 
 ## Non-goals
 

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -84,10 +84,10 @@ impl Engine {
             let empty = Frame::new(ratatui_core::buffer::Buffer::empty(
                 ratatui_core::layout::Rect::new(0, 0, self.width, 0),
             ));
-            let mut diff = new_frame.diff(&empty);
+            let stream_until = new_height.saturating_sub(self.terminal_height);
+            let mut diff = new_frame.diff_from(&empty, stream_until);
 
             let mut output = Vec::new();
-            let stream_until = new_height.saturating_sub(self.terminal_height);
             self.stream_rows_into_scrollback(&new_frame, 0, stream_until, &mut output);
 
             // Emit newlines to claim rows (minus 1 because the cursor
@@ -121,9 +121,12 @@ impl Engine {
             return output;
         }
 
-        // Subsequent renders
+        // Subsequent renders. Rows already past the scrollback boundary
+        // are immutable; skip them at diff time instead of filtering
+        // afterward.
         let prev = self.prev_frame.as_ref().unwrap();
-        let mut diff = new_frame.diff(prev);
+        let already_scrolled = self.emitted_rows.saturating_sub(self.terminal_height);
+        let mut diff = new_frame.diff_from(prev, already_scrolled);
 
         if diff.is_empty() && !diff.grew() {
             // Even if content didn't change, cursor position might have

--- a/crates/eye_declare_engine/src/frame.rs
+++ b/crates/eye_declare_engine/src/frame.rs
@@ -45,11 +45,22 @@ impl Frame {
     /// the shorter one is logically padded with empty cells so that
     /// `Buffer::diff` can operate on matching dimensions.
     pub fn diff(&self, previous: &Frame) -> Diff {
+        self.diff_from(previous, 0)
+    }
+
+    /// [`diff`](Frame::diff), skipping rows above `start_row`.
+    ///
+    /// Rows that have scrolled into terminal scrollback can never be
+    /// repainted, so comparing them is pure waste — the engine passes its
+    /// scrollback boundary here. With a tail much taller than the
+    /// terminal, this is the difference between diffing the whole virtual
+    /// frame and diffing one screenful.
+    pub fn diff_from(&self, previous: &Frame, start_row: u16) -> Diff {
         let new_area = self.buffer.area;
         let prev_area = previous.buffer.area;
 
         // Fast path: same dimensions, use Buffer::diff directly
-        if new_area == prev_area {
+        if new_area == prev_area && start_row == 0 {
             let changes = previous
                 .buffer
                 .diff(&self.buffer)
@@ -71,7 +82,7 @@ impl Frame {
         let default_cell = Cell::default();
         let mut changes = Vec::new();
 
-        for y in 0..max_height {
+        for y in start_row..max_height {
             for x in 0..max_width {
                 let in_prev = x < prev_area.width && y < prev_area.height;
                 let in_new = x < new_area.width && y < new_area.height;

--- a/crates/eye_declare_next/Cargo.toml
+++ b/crates/eye_declare_next/Cargo.toml
@@ -27,6 +27,11 @@ markdown = ["dep:pulldown-cmark"]
 tokio = ["dep:tokio", "crossterm/event-stream"]
 
 [dev-dependencies]
+criterion = "0.5"
 eye_declare_engine = { path = "../eye_declare_engine", features = ["test-util"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+
+[[bench]]
+name = "frame"
+harness = false

--- a/crates/eye_declare_next/Cargo.toml
+++ b/crates/eye_declare_next/Cargo.toml
@@ -32,6 +32,25 @@ eye_declare_engine = { path = "../eye_declare_engine", features = ["test-util"] 
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 
+# Targets that need non-default feature combinations declare them, so
+# `--all-targets --no-default-features` builds cleanly.
 [[bench]]
 name = "frame"
 harness = false
+required-features = ["markdown", "tokio"]
+
+[[example]]
+name = "perf_report"
+required-features = ["markdown", "tokio"]
+
+[[example]]
+name = "stream"
+required-features = ["tokio"]
+
+[[test]]
+name = "async_driver"
+required-features = ["tokio"]
+
+[[test]]
+name = "subscriptions"
+required-features = ["tokio"]

--- a/crates/eye_declare_next/benches/frame.rs
+++ b/crates/eye_declare_next/benches/frame.rs
@@ -1,0 +1,130 @@
+//! Per-frame cost of the timeline pipeline, by scenario and by stage.
+//!
+//! Scenario benches run the full path (tree build → height → render →
+//! diff → escape bytes) through `Runtime`; stage benches isolate the
+//! phases so a regression is attributable from the numbers alone.
+
+#[path = "support/scenario.rs"]
+mod scenario;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use eye_declare_next::{Element, Runtime};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use scenario::{ChatApp, HEIGHT, Msg, WIDTH, markdown_response};
+use std::hint::black_box;
+
+const SIZES: &[usize] = &[1_000, 10_000, 50_000];
+
+/// Steady tail: nothing changed — the diff-to-zero path the design
+/// promises is "unconditionally cheap". Includes full tree rebuild.
+fn steady_present(c: &mut Criterion) {
+    let mut g = c.benchmark_group("steady_present");
+    for &size in SIZES {
+        let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+        let _ = rt.present();
+        g.bench_function(format!("{size}B"), |b| {
+            b.iter(|| black_box(rt.present()));
+        });
+    }
+    g.finish();
+}
+
+/// One streamed chunk lands: update + full re-present of a tail carrying
+/// `size` bytes of markdown. The streaming hot path.
+fn streaming_chunk(c: &mut Criterion) {
+    let mut g = c.benchmark_group("streaming_chunk");
+    for &size in SIZES {
+        let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+        let _ = rt.present();
+        g.bench_function(format!("{size}B"), |b| {
+            b.iter(|| black_box(rt.process(Msg::Chunk("lorem ipsum dolor ".into()))));
+        });
+    }
+    g.finish();
+}
+
+/// Sealing the streamed turn into scrollback (push + re-present).
+fn seal(c: &mut Criterion) {
+    let mut g = c.benchmark_group("seal");
+    for &size in SIZES {
+        g.bench_function(format!("{size}B"), |b| {
+            b.iter_batched(
+                || {
+                    let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+                    let _ = rt.present();
+                    rt
+                },
+                |mut rt| black_box(rt.process(Msg::Seal)),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    g.finish();
+}
+
+/// One keystroke into the text area with a mid-size response on screen.
+fn typing(c: &mut Criterion) {
+    let mut rt = Runtime::new(ChatApp::mid_stream(10_000), WIDTH, HEIGHT);
+    let _ = rt.present();
+    let key = crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Char('x'),
+        crossterm::event::KeyModifiers::NONE,
+    );
+    c.bench_function("typing_keystroke", |b| {
+        b.iter(|| {
+            black_box(rt.process(Msg::Input(eye_declare_next::InputEvent::Key(key))));
+        });
+    });
+}
+
+/// Stage isolation: tree build, height, render, at 10KB.
+fn stages(c: &mut Criterion) {
+    let app = ChatApp::mid_stream(10_000);
+
+    c.bench_function("stage_tree_build", |b| {
+        b.iter(|| black_box(app.tail_element()));
+    });
+
+    c.bench_function("stage_height", |b| {
+        let tail = app.tail_element();
+        b.iter(|| black_box(tail.height(WIDTH)));
+    });
+
+    c.bench_function("stage_render", |b| {
+        let tail = app.tail_element();
+        let h = tail.height(WIDTH);
+        b.iter(|| {
+            let mut buf = Buffer::empty(Rect::new(0, 0, WIDTH, h));
+            tail.render(buf.area, &mut buf);
+            black_box(&buf);
+        });
+    });
+
+    c.bench_function("stage_markdown_parse", |b| {
+        let source = markdown_response(10_000);
+        b.iter(|| {
+            let el = eye_declare_next::markdown(source.clone());
+            black_box(el.height(WIDTH))
+        });
+    });
+}
+
+trait TailExt {
+    fn tail_element(&self) -> Box<dyn Element + '_>;
+}
+impl TailExt for ChatApp {
+    fn tail_element(&self) -> Box<dyn Element + '_> {
+        Box::new(eye_declare_next::App::tail(self))
+    }
+}
+
+criterion_group!(
+    benches,
+    steady_present,
+    streaming_chunk,
+    seal,
+    typing,
+    stages
+);
+criterion_main!(benches);

--- a/crates/eye_declare_next/benches/support/scenario.rs
+++ b/crates/eye_declare_next/benches/support/scenario.rs
@@ -1,0 +1,170 @@
+//! The deterministic benchmark app: an atuin-shaped chat TUI (markdown
+//! turns, streaming assistant response, panel + text-area input) driven
+//! headlessly. Shared by the criterion bench and the alloc-report example
+//! via `#[path]` include.
+
+use eye_declare_next::{
+    App, Ctx, Element, ElementExt, Fluent, Focus, FocusHandle, InputEvent, Keymap, TextAreaState,
+    col, key, keymap, markdown, panel, text, text_area,
+};
+use ratatui_core::style::{Color, Modifier, Style};
+
+pub const WIDTH: u16 = 100;
+pub const HEIGHT: u16 = 40;
+
+/// Deterministic markdown "prose": headers, lists, inline styles, and a
+/// code fence, cycled from a fixed word list. `bytes` is approximate.
+pub fn markdown_response(bytes: usize) -> String {
+    const WORDS: &[&str] = &[
+        "terminal",
+        "renders",
+        "inline",
+        "content",
+        "with",
+        "diffed",
+        "escape",
+        "sequences",
+        "while",
+        "the",
+        "timeline",
+        "commits",
+        "finished",
+        "blocks",
+        "into",
+        "scrollback",
+    ];
+    let mut out = String::with_capacity(bytes + 64);
+    out.push_str("## Summary\n\n");
+    let mut w = 0usize;
+    let mut sentence = 0usize;
+    while out.len() < bytes {
+        match sentence % 7 {
+            3 => {
+                out.push_str("\n- ");
+                out.push_str(WORDS[w % WORDS.len()]);
+                out.push(' ');
+                out.push_str(WORDS[(w + 3) % WORDS.len()]);
+                out.push('\n');
+            }
+            5 => {
+                out.push_str("\n```rust\nlet frame = engine.present(tail)?;\n```\n\n");
+            }
+            _ => {
+                for i in 0..9 {
+                    if i == 4 {
+                        out.push_str("**");
+                        out.push_str(WORDS[w % WORDS.len()]);
+                        out.push_str("** ");
+                    } else if i == 7 {
+                        out.push('`');
+                        out.push_str(WORDS[w % WORDS.len()]);
+                        out.push_str("` ");
+                    } else {
+                        out.push_str(WORDS[w % WORDS.len()]);
+                        out.push(' ');
+                    }
+                    w += 1;
+                }
+                out.push_str("of the\n");
+            }
+        }
+        sentence += 1;
+    }
+    out
+}
+
+#[derive(Clone)]
+pub enum Msg {
+    /// Append one streamed chunk to the live response.
+    Chunk(String),
+    /// Seal the live response into scrollback.
+    Seal,
+    /// A key for the input editor.
+    Input(InputEvent),
+}
+
+pub struct ChatApp {
+    pub streaming: String,
+    pub input: TextAreaState,
+    pub input_focus: FocusHandle,
+}
+
+impl Default for ChatApp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChatApp {
+    pub fn new() -> Self {
+        let input_focus = Focus::new().handle();
+        input_focus.focus();
+        Self {
+            streaming: String::new(),
+            input: TextAreaState::new(),
+            input_focus,
+        }
+    }
+
+    /// An app mid-stream with ~`bytes` of markdown already received.
+    pub fn mid_stream(bytes: usize) -> Self {
+        let mut app = Self::new();
+        app.streaming = markdown_response(bytes);
+        app
+    }
+}
+
+impl App for ChatApp {
+    type Msg = Msg;
+    type Output = ();
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            Msg::Chunk(chunk) => self.streaming.push_str(&chunk),
+            Msg::Seal => {
+                let turn = std::mem::take(&mut self.streaming);
+                ctx.push(turn_view(&turn));
+            }
+            Msg::Input(ev) => self.input.handle(&ev),
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        col()
+            .when(!self.streaming.is_empty(), |c| {
+                c.child(turn_view(&self.streaming))
+            })
+            .child(
+                panel(
+                    text_area(&self.input)
+                        .placeholder("Type a message...")
+                        .track_focus(&self.input_focus)
+                        .max_height(5),
+                )
+                .title("Ask")
+                .footer("[Enter] Send")
+                .border_style(Style::default().fg(Color::DarkGray))
+                .pad_x(1),
+            )
+            .child(text(" Model: bench").style(Style::default().fg(Color::DarkGray)))
+    }
+
+    fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on(key(crossterm::event::KeyCode::Enter), Msg::Seal)
+            .fallthrough(&self.input_focus, Msg::Input)
+    }
+}
+
+pub fn turn_view(source: &str) -> impl Element + use<> {
+    col()
+        .child(
+            text(" Assistant ").style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::REVERSED),
+            ),
+        )
+        .child(markdown(source.to_string()).pad_left(2))
+}

--- a/crates/eye_declare_next/examples/perf_report.rs
+++ b/crates/eye_declare_next/examples/perf_report.rs
@@ -1,0 +1,145 @@
+//! Deterministic allocation + byte-output report for the frame pipeline.
+//!
+//! Run with `cargo run --release -p eye_declare_next --example perf_report`.
+//! Counts every heap allocation through a wrapping global allocator, so
+//! the numbers are exact and reproducible — the arena-allocator question
+//! gets answered with data, not vibes.
+
+#[path = "../benches/support/scenario.rs"]
+mod scenario;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use eye_declare_next::Runtime;
+use scenario::{ChatApp, HEIGHT, Msg, WIDTH};
+
+struct Counting;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+fn measure<R>(label: &str, iters: u64, mut f: impl FnMut() -> R) {
+    // Warm once so one-time setup doesn't pollute the steady state.
+    let _ = f();
+    let a0 = ALLOCS.load(Ordering::Relaxed);
+    let b0 = BYTES.load(Ordering::Relaxed);
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let _ = std::hint::black_box(f());
+    }
+    let dt = t0.elapsed();
+    let allocs = (ALLOCS.load(Ordering::Relaxed) - a0) / iters;
+    let bytes = (BYTES.load(Ordering::Relaxed) - b0) / iters;
+    println!(
+        "{label:<38} {:>9.1}µs {:>7} allocs {:>10} bytes",
+        dt.as_secs_f64() * 1e6 / iters as f64,
+        allocs,
+        bytes,
+    );
+}
+
+fn main() {
+    println!(
+        "{:<38} {:>11} {:>14} {:>16}",
+        "scenario (per frame)", "time", "allocs", "alloc'd"
+    );
+
+    for size in [1_000usize, 10_000, 50_000] {
+        let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+        let _ = rt.present();
+        measure(&format!("steady_present {size}B"), 200, || rt.present());
+    }
+
+    for size in [1_000usize, 10_000, 50_000] {
+        let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+        let _ = rt.present();
+        measure(&format!("streaming_chunk {size}B"), 200, || {
+            rt.process(Msg::Chunk("lorem ipsum dolor ".into()))
+        });
+    }
+
+    {
+        let mut rt = Runtime::new(ChatApp::mid_stream(10_000), WIDTH, HEIGHT);
+        let _ = rt.present();
+        let key = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('x'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        measure("typing_keystroke (10KB on screen)", 200, || {
+            rt.process(Msg::Input(eye_declare_next::InputEvent::Key(key)))
+        });
+    }
+
+    // Coalescing: 64 stream chunks as one batch vs 64 frames.
+    for &(label, batch) in &[("sequential", 1usize), ("batch=64", 64)] {
+        let mut rt = Runtime::new(ChatApp::mid_stream(10_000), WIDTH, HEIGHT);
+        let _ = rt.present();
+        measure(&format!("64 chunks, {label} (10KB)"), 20, || {
+            for _ in 0..(64 / batch) {
+                let msgs = (0..batch).map(|_| Msg::Chunk("lorem ipsum dolor ".into()));
+                let _ = std::hint::black_box(rt.process_batch(msgs));
+            }
+        });
+    }
+
+    // Stage isolation at 10KB: where does the frame go?
+    {
+        use eye_declare_next::{App, Element};
+        let app = ChatApp::mid_stream(10_000);
+        measure("stage: tree build only", 200, || {
+            std::hint::black_box(app.tail()).animated()
+        });
+        let tail = app.tail();
+        measure("stage: height only", 200, || tail.height(WIDTH));
+        let h = tail.height(WIDTH);
+        measure("stage: render only", 200, || {
+            let area = ratatui_core::layout::Rect::new(0, 0, WIDTH, h);
+            let mut buf = ratatui_core::buffer::Buffer::empty(area);
+            tail.render(area, &mut buf);
+            buf.area.height
+        });
+        let src = scenario::markdown_response(10_000);
+        measure("stage: markdown height (1 parse)", 200, || {
+            eye_declare_next::markdown(src.clone()).height(WIDTH)
+        });
+    }
+
+    // Seal is not steady-state (each seal consumes the turn); report the
+    // one-shot cost at each size.
+    for size in [1_000usize, 10_000, 50_000] {
+        let label = format!("seal {size}B (one-shot)");
+        let mut rt = Runtime::new(ChatApp::mid_stream(size), WIDTH, HEIGHT);
+        let _ = rt.present();
+        let a0 = ALLOCS.load(Ordering::Relaxed);
+        let t0 = Instant::now();
+        let (bytes_out, _) = rt.process(Msg::Seal);
+        let dt = t0.elapsed();
+        let allocs = ALLOCS.load(Ordering::Relaxed) - a0;
+        println!(
+            "{label:<38} {:>9.1}µs {allocs:>7} allocs {:>10} bytes-out",
+            dt.as_secs_f64() * 1e6,
+            bytes_out.len(),
+        );
+    }
+}

--- a/crates/eye_declare_next/src/driver_tokio.rs
+++ b/crates/eye_declare_next/src/driver_tokio.rs
@@ -86,7 +86,18 @@ where
                 }
             }
 
-            Some(msg) = rx.recv() => runtime.process(msg),
+            Some(msg) = rx.recv() => {
+                // Drain whatever else is already queued (a stream burst)
+                // into one batch: many chunks, one frame.
+                let mut batch = vec![msg];
+                while batch.len() < 256 {
+                    match rx.try_recv() {
+                        Ok(m) => batch.push(m),
+                        Err(_) => break,
+                    }
+                }
+                runtime.process_batch(batch)
+            }
 
             _ = sleep_opt(anim), if anim.is_some() => (runtime.present(), None),
         };

--- a/crates/eye_declare_next/src/markdown.rs
+++ b/crates/eye_declare_next/src/markdown.rs
@@ -7,6 +7,8 @@
 //! code, fenced code blocks, and (one level of) lists; word-wraps at the
 //! render width with honest height measurement.
 
+use std::cell::RefCell;
+
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 use ratatui_core::style::{Color, Modifier, Style};
@@ -44,19 +46,38 @@ impl Default for MarkdownStyles {
 pub struct Markdown {
     source: String,
     styles: MarkdownStyles,
+    /// Parsed text, shared between `height` and `render` within the
+    /// element's lifetime (one frame). Elements are rebuilt per frame, so
+    /// this halves the per-frame parse cost without any cross-frame
+    /// invalidation story.
+    parsed: RefCell<Option<RText<'static>>>,
+    /// Wrapped row count per width, same lifetime story. `height` runs at
+    /// least twice a frame (the tail measure, then container placement
+    /// during render), and wrap-counting a long document isn't free.
+    measured: RefCell<Option<(u16, u16)>>,
 }
 
 pub fn markdown(source: impl Into<String>) -> Markdown {
     Markdown {
         source: source.into(),
         styles: MarkdownStyles::default(),
+        parsed: RefCell::new(None),
+        measured: RefCell::new(None),
     }
 }
 
 impl Markdown {
     pub fn styles(mut self, styles: MarkdownStyles) -> Self {
         self.styles = styles;
+        self.parsed.take();
+        self.measured.take();
         self
+    }
+
+    fn with_parsed<R>(&self, f: impl FnOnce(&RText<'static>) -> R) -> R {
+        let mut cache = self.parsed.borrow_mut();
+        let parsed = cache.get_or_insert_with(|| parse(&self.source, &self.styles));
+        f(parsed)
     }
 }
 
@@ -65,15 +86,40 @@ impl Element for Markdown {
         if self.source.is_empty() || width == 0 {
             return 0;
         }
-        eye_declare_engine::wrap::wrapped_line_count(&parse(&self.source, &self.styles), width)
+        if let Some((w, rows)) = *self.measured.borrow()
+            && w == width
+        {
+            return rows;
+        }
+        let rows =
+            self.with_parsed(|text| eye_declare_engine::wrap::wrapped_line_count(text, width));
+        *self.measured.borrow_mut() = Some((width, rows));
+        rows
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
         if self.source.is_empty() || area.width == 0 || area.height == 0 {
             return;
         }
-        eye_declare_engine::wrap::wrapping_paragraph(parse(&self.source, &self.styles))
-            .render(area, buf);
+        self.with_parsed(|text| {
+            // A borrowed view of the cached parse: per-line Vecs, but no
+            // string copies (a deep clone would re-allocate every span).
+            let borrowed = RText::from(
+                text.lines
+                    .iter()
+                    .map(|line| {
+                        Line::from(
+                            line.spans
+                                .iter()
+                                .map(|s| Span::styled(s.content.as_ref(), s.style))
+                                .collect::<Vec<_>>(),
+                        )
+                        .style(line.style)
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            eye_declare_engine::wrap::wrapping_paragraph(borrowed).render(area, buf)
+        });
     }
 }
 

--- a/crates/eye_declare_next/src/runtime.rs
+++ b/crates/eye_declare_next/src/runtime.rs
@@ -77,17 +77,37 @@ where
     /// Feed one message (from the keymap, or — in the async driver — from
     /// tasks and subscriptions).
     pub fn process(&mut self, msg: A::Msg) -> (Vec<u8>, Option<A::Output>) {
-        // Undelivered init bytes come first so init's blocks precede this
-        // update's pushes in scrollback.
+        self.process_batch(std::iter::once(msg))
+    }
+
+    /// Feed a batch of messages, presenting once at the end.
+    ///
+    /// Presenting is O(tail) regardless of how many messages arrived, so
+    /// coalescing ready messages (the async driver drains its channel
+    /// into one batch) collapses a burst of stream chunks into a single
+    /// frame. Stops early if a message exits the app; the remainder is
+    /// dropped, matching a terminated run loop.
+    pub fn process_batch(
+        &mut self,
+        msgs: impl IntoIterator<Item = A::Msg>,
+    ) -> (Vec<u8>, Option<A::Output>) {
+        // Undelivered init bytes come first so init's blocks precede
+        // these updates' pushes in scrollback.
         let mut bytes = std::mem::take(&mut self.pending);
-        let mut ctx = Ctx {
-            timeline: &mut self.timeline,
-            output: &mut bytes,
-            effects: &mut self.effects,
-            exit: None,
-        };
-        self.app.update(msg, &mut ctx);
-        let exit = ctx.exit;
+        let mut exit = None;
+        for msg in msgs {
+            let mut ctx = Ctx {
+                timeline: &mut self.timeline,
+                output: &mut bytes,
+                effects: &mut self.effects,
+                exit: None,
+            };
+            self.app.update(msg, &mut ctx);
+            if let Some(output) = ctx.exit {
+                exit = Some(output);
+                break;
+            }
+        }
 
         bytes.extend_from_slice(&self.present());
         if exit.is_some() {


### PR DESCRIPTION
A measured performance pass over the frame pipeline. Adds the harness first — a criterion bench plus an exact allocation-counting report (`examples/perf_report.rs`) over a deterministic atuin-shaped chat scenario — then applies what it found, in measured order: markdown same-frame caches (parse once per frame, height memoized per width, render borrows the cached parse), `Frame::diff_from` (skip diffing rows already immutable in scrollback), and `Runtime::process_batch` with driver channel draining (a stream burst becomes one frame, not one frame per chunk).

At 10KB of streaming markdown: steady present 2276µs → 784µs (10.1K → 2.3K allocs); a 64-chunk burst 99ms → 1.7ms. Tree building measured at 0.5µs / 16 allocs per frame, which settles the arena-allocator question as not worth pursuing. Numbers, non-goals, and the keep-tails-bounded guidance are written up in `.planning/PERF.md`; the harness stays in the tree as a regression check.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
