### PR TITLE
fix: park the cursor below the tail on exit

### DIFF
--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -81,8 +81,9 @@ where
                     Some(Ok(Event::Resize(w, h))) => (runtime.resize(w, h), None),
                     Some(Ok(_)) => (Vec::new(), None),
                     Some(Err(e)) => return Err(e),
-                    // Terminal input ended (stdin closed): exit cleanly.
-                    None => (Vec::new(), Some(A::Output::default())),
+                    // Terminal input ended (stdin closed): exit cleanly,
+                    // with the shell handoff process_batch would have done.
+                    None => (runtime.finalize(), Some(A::Output::default())),
                 }
             }
 

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -60,8 +60,16 @@ where
 
     /// First bytes to write and any exit [`App::init`] requested — what a
     /// driver calls once before its loop, instead of a bare `present`.
+    ///
+    /// An init-requested exit skips the message loop, so the shell
+    /// handoff is appended here rather than by `process_batch`.
     pub fn startup(&mut self) -> (Vec<u8>, Option<A::Output>) {
-        (self.present(), self.init_exit.take())
+        let mut bytes = self.present();
+        let exit = self.init_exit.take();
+        if exit.is_some() {
+            bytes.extend_from_slice(&self.timeline.finalize());
+        }
+        (bytes, exit)
     }
 
     /// Feed one input event. Resolves it through the app's keymap; if a
@@ -145,6 +153,15 @@ where
         let mut bytes = self.timeline.resize(width);
         bytes.extend_from_slice(&self.present());
         bytes
+    }
+
+    /// Shell handoff for exits that bypass the message loop: park the
+    /// cursor at column 0 below the content. Message-driven exits get
+    /// this automatically from [`process_batch`](Runtime::process_batch);
+    /// custom drivers that exit for their own reasons (e.g. stdin
+    /// closing) write these bytes last.
+    pub fn finalize(&mut self) -> Vec<u8> {
+        self.timeline.finalize()
     }
 
     /// The wrapped app, for inspection after exit (tests) or state peeks.

--- a/crates/eye_declare/src/timeline.rs
+++ b/crates/eye_declare/src/timeline.rs
@@ -71,8 +71,9 @@ impl Timeline {
         self.engine.reset_region(new_width)
     }
 
-    /// Reclaim trailing blank rows for shell handoff (call after a final
-    /// `present` of a shrunken or empty tail).
+    /// Hand the terminal back to the shell: park the cursor at column 0
+    /// on the row after the last content row, reclaiming any rows a
+    /// shrunken or empty tail vacated (call after a final `present`).
     pub fn finalize(&mut self) -> Vec<u8> {
         self.engine.finalize()
     }

--- a/crates/eye_declare/tests/app_headless.rs
+++ b/crates/eye_declare/tests/app_headless.rs
@@ -159,6 +159,46 @@ fn echo_session_end_to_end() {
 }
 
 #[test]
+fn init_exit_parks_cursor_below_content() {
+    // An exit requested from App::init bypasses the message loop, so the
+    // shell handoff must come from startup() itself.
+    struct PrintAndQuit;
+
+    impl App for PrintAndQuit {
+        type Msg = ();
+        type Output = ();
+
+        fn init(&mut self, ctx: &mut Ctx<'_, Self>) {
+            ctx.push(text("one-shot output"));
+            ctx.exit(());
+        }
+
+        fn update(&mut self, _msg: (), _ctx: &mut Ctx<'_, Self>) {}
+
+        fn tail(&self) -> impl Element + '_ {
+            text("tail line")
+        }
+
+        fn keymap(&self) -> Keymap<()> {
+            keymap()
+        }
+    }
+
+    let mut rt = Runtime::new(PrintAndQuit, 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    let (bytes, exit) = rt.startup();
+    term.feed(&bytes);
+    assert!(exit.is_some());
+
+    assert_eq!(term.viewport_lines()[0], "one-shot output");
+    assert_eq!(term.viewport_lines()[1], "tail line");
+    assert_eq!(term.cursor(), (2, 0));
+    term.feed(b"$ prompt");
+    assert_eq!(term.viewport_lines()[2], "$ prompt");
+}
+
+#[test]
 fn tail_hidden_before_deferred_exit_leaves_no_gap() {
     // The Atuin AI exit shape: one update hides the tail (the input box
     // disappears in its own frame), a later message actually exits. The

--- a/crates/eye_declare/tests/app_headless.rs
+++ b/crates/eye_declare/tests/app_headless.rs
@@ -146,6 +146,81 @@ fn echo_session_end_to_end() {
     }
     assert_eq!(term.viewport_lines()[0], "* hell");
     assert_eq!(term.viewport_lines()[1], "* again");
+
+    // Exit parks the cursor on a fresh line below the still-visible tail,
+    // so whatever main() prints after run() returns doesn't land on top
+    // of it.
+    assert_eq!(term.viewport_lines()[2], ">");
+    assert_eq!(term.viewport_lines()[3], "(2 sent)");
+    assert_eq!(term.cursor(), (4, 0));
+    term.feed(b"echoed 2 line(s)\r\n");
+    assert_eq!(term.viewport_lines()[3], "(2 sent)");
+    assert_eq!(term.viewport_lines()[4], "echoed 2 line(s)");
+}
+
+#[test]
+fn tail_hidden_before_deferred_exit_leaves_no_gap() {
+    // The Atuin AI exit shape: one update hides the tail (the input box
+    // disappears in its own frame), a later message actually exits. The
+    // vacated rows must be reclaimed with no blank line left between the
+    // committed content and the shell prompt.
+    struct HideThenQuit {
+        exiting: bool,
+    }
+
+    #[derive(Clone)]
+    enum HMsg {
+        Commit,
+        Hide,
+        Quit,
+    }
+
+    impl App for HideThenQuit {
+        type Msg = HMsg;
+        type Output = ();
+
+        fn update(&mut self, msg: HMsg, ctx: &mut Ctx<'_, Self>) {
+            match msg {
+                HMsg::Commit => ctx.push(text("committed line")),
+                HMsg::Hide => self.exiting = true,
+                HMsg::Quit => ctx.exit(()),
+            }
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            if self.exiting {
+                col()
+            } else {
+                col().child(text("| input box |")).child(text("footer"))
+            }
+        }
+
+        fn keymap(&self) -> Keymap<HMsg> {
+            keymap()
+        }
+    }
+
+    let mut rt = Runtime::new(HideThenQuit { exiting: false }, 20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    term.feed(&rt.present());
+    let (bytes, _) = rt.process(HMsg::Commit);
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[1], "| input box |");
+    assert_eq!(term.viewport_lines()[2], "footer");
+
+    let (bytes, exit) = rt.process(HMsg::Hide);
+    term.feed(&bytes);
+    assert!(exit.is_none());
+    let (bytes, exit) = rt.process(HMsg::Quit);
+    term.feed(&bytes);
+    assert!(exit.is_some());
+
+    assert_eq!(term.viewport_lines()[0], "committed line");
+    assert_eq!(term.viewport_lines()[1], "");
+    assert_eq!(term.cursor(), (1, 0));
+    term.feed(b"$ prompt");
+    assert_eq!(term.viewport_lines()[1], "$ prompt");
 }
 
 #[test]

--- a/crates/eye_declare/tests/timeline.rs
+++ b/crates/eye_declare/tests/timeline.rs
@@ -113,6 +113,53 @@ fn empty_tail_and_finalize_hand_back_to_shell() {
     assert_eq!(term.cursor(), (1, 0));
 }
 
+#[test]
+fn finalize_with_visible_tail_opens_a_fresh_line() {
+    let mut tl = Timeline::new(20, 24);
+    let mut term = TestTerminal::new(20, 24);
+
+    term.feed(&tl.push(text("done: ok")));
+    term.feed(&tl.present(&text("> bye")));
+    // Exit without clearing the tail: the tail stays on screen and the
+    // cursor must still land on a fresh line below it.
+    term.feed(&tl.finalize());
+
+    assert_eq!(term.cursor(), (2, 0));
+    // A repeated finalize is a no-op, not another blank line.
+    assert!(tl.finalize().is_empty());
+
+    // What the process prints after run() returns lands below the tail,
+    // not on top of it.
+    term.feed(b"echoed 1 line(s)\r\n");
+    assert_eq!(term.viewport_lines()[0], "done: ok");
+    assert_eq!(term.viewport_lines()[1], "> bye");
+    assert_eq!(term.viewport_lines()[2], "echoed 1 line(s)");
+}
+
+#[test]
+fn finalize_at_terminal_bottom_scrolls_for_the_fresh_line() {
+    // Region bottom flush with the terminal bottom: the fresh handoff
+    // line doesn't exist yet, so finalize must scroll (LF), not clamp.
+    let mut tl = Timeline::new(10, 3);
+    let mut term = TestTerminal::new(10, 3);
+
+    term.feed(&tl.present(&text("> ")));
+    term.feed(&tl.push(text("block 0")));
+    term.feed(&tl.push(text("block 1")));
+    term.feed(&tl.present(&text("> ")));
+    term.feed(&tl.finalize());
+
+    // "block 0" scrolled away to make room for the handoff line.
+    assert_eq!(term.viewport_lines()[0], "block 1");
+    assert_eq!(term.viewport_lines()[1], ">");
+    assert_eq!(term.viewport_lines()[2], "");
+    assert_eq!(term.cursor(), (2, 0));
+    assert!(term.scrollback_lines().contains(&"block 0".to_string()));
+
+    term.feed(b"$ prompt");
+    assert_eq!(term.viewport_lines()[2], "$ prompt");
+}
+
 /// The streaming-agent seal shape with a turn taller than the terminal:
 /// the tail grows past the screen (rows burst-stream into scrollback),
 /// then the same content is pushed as a block when the turn completes.

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -324,25 +324,24 @@ impl Engine {
         output
     }
 
-    /// Reclaim trailing blank rows after the frame has shrunk.
+    /// Park the cursor for shell handoff: column 0 on the row after the
+    /// last content row, trailing blank rows erased.
     ///
-    /// Call after a final [`present`](Engine::present) when content has
-    /// been removed (e.g., clearing a text input before exit). Moves the
-    /// cursor to the last row of actual content, erases everything below,
-    /// and adjusts tracking so the shell prompt appears immediately after
-    /// the content.
-    ///
-    /// Returns an empty Vec if there are no trailing blank rows to reclaim.
+    /// Call after a final [`present`](Engine::present). When the tail
+    /// shrank before exit (e.g., an input box cleared) the vacated rows
+    /// are reclaimed so the shell prompt appears immediately after the
+    /// content; when the tail still has content, a fresh line is opened
+    /// below it so whatever the process prints next (`println!`, the
+    /// shell prompt) never lands on top of the tail. Idempotent.
     pub fn finalize(&mut self) -> Vec<u8> {
+        if self.emitted_rows == 0 {
+            return Vec::new();
+        }
         let current_height = self
             .prev_frame
             .as_ref()
             .map(|f| f.area().height)
             .unwrap_or(0);
-
-        if current_height >= self.emitted_rows || self.emitted_rows == 0 {
-            return Vec::new();
-        }
 
         // Respect the scrollback boundary: rows above `scrolled_past` are
         // in terminal scrollback and unreachable by cursor movement.  If we
@@ -351,33 +350,47 @@ impl Engine {
         let scrolled_past = self.emitted_rows.saturating_sub(self.terminal_height);
         let target_row = current_height.max(scrolled_past);
 
-        if target_row >= self.emitted_rows {
+        let mut output = Vec::new();
+
+        if target_row < self.emitted_rows {
+            // Trailing blank rows below the content: erasing them leaves
+            // the cursor exactly at the handoff position.
+            //
+            // Use CR first to clear any pending-wrap state, then CPL
+            // (Cursor Previous Line) which moves up N lines and to
+            // column 0 atomically — more reliable than CUU + CR for
+            // terminals with edge-case wrap behavior.
+            output.extend_from_slice(b"\r");
+            if self.cursor.row > target_row {
+                let up = self.cursor.row - target_row;
+                output.extend_from_slice(format!("\x1b[{}F", up).as_bytes());
+            } else if self.cursor.row < target_row {
+                let down = target_row - self.cursor.row;
+                output.extend_from_slice(format!("\x1b[{}E", down).as_bytes());
+            }
+
+            // Erase from cursor to end of screen
+            output.extend_from_slice(b"\x1b[J");
+
+            self.emitted_rows = target_row;
+        } else if self.cursor.row < self.emitted_rows {
+            // Content fills the region: open a fresh line below it. LF —
+            // not CNL, which clamps instead of scrolling at the bottom
+            // margin, where the new line may not physically exist yet.
+            output.extend_from_slice(b"\r");
+            let bottom = self.emitted_rows - 1;
+            if self.cursor.row < bottom {
+                let down = bottom - self.cursor.row;
+                output.extend_from_slice(format!("\x1b[{}E", down).as_bytes());
+            }
+            output.extend_from_slice(b"\n");
+        } else {
+            // Already parked below the content (a repeated finalize).
             return Vec::new();
         }
 
-        let mut output = Vec::new();
-
-        // Position cursor at the first erasable blank row.
-        // Use CR first to clear any pending-wrap state, then CPL
-        // (Cursor Previous Line) which moves up N lines and to
-        // column 0 atomically — more reliable than CUU + CR for
-        // terminals with edge-case wrap behavior.
-        output.extend_from_slice(b"\r");
-        if self.cursor.row > target_row {
-            let up = self.cursor.row - target_row;
-            output.extend_from_slice(format!("\x1b[{}F", up).as_bytes());
-        } else if self.cursor.row < target_row {
-            let down = target_row - self.cursor.row;
-            output.extend_from_slice(format!("\x1b[{}E", down).as_bytes());
-        }
-
-        // Erase from cursor to end of screen
-        output.extend_from_slice(b"\x1b[J");
-
-        self.cursor.row = target_row;
+        self.cursor.row = self.emitted_rows;
         self.cursor.col = 0;
-        self.emitted_rows = target_row;
-
         output
     }
 


### PR DESCRIPTION
On exit, `Engine::finalize` only did anything when the tail had shrunk: it reclaimed trailing blank rows, which as a side effect parked the cursor at column 0 below the content. When the tail still had content — the `echo` example's prompt and spinner line, for instance — it returned nothing, leaving the cursor wherever the last diff ended, often mid-line and mid-tail. Anything printed after `run()` returned (`main`'s `println!`, the shell prompt) started at that cell, on top of the tail. This is also what made Atuin AI's last response line vulnerable to being overwritten by the zsh prompt redraw.

`finalize` is now a true shell-handoff step. When the tail still has content it moves to the region bottom and opens a fresh line with LF — not CNL, which clamps instead of scrolling at the bottom margin, where the new line may not exist yet. Both paths end in the same state: cursor at column 0 on the row after the last content row, with a repeated `finalize` as a no-op so the two paths compose.

Regression tests cover the visible-tail exit (including simulated post-exit output landing on its own line), the LF-scrolls-at-bottom case, and the hide-the-tail-then-exit-on-a-later-message flow, all verified through `TestTerminal`. `perf_report` alloc counts are unchanged.
