### PR TITLE
docs: Clean up and improve docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,6 @@ crates/
   eye_declare_engine/  Terminal-sync engine: frame diffing, escape generation,
                        scrollback streaming, cursor discipline; VTE TestTerminal
                        behind the `test-util` feature (no crossterm dependency)
-  spike/               Historical: the Phase-1 API bake-off (compile-only).
-                       Verdicts in crates/spike/FINDINGS.md. Do not extend.
 ```
 
 ## Build & Commands

--- a/README.md
+++ b/README.md
@@ -2,36 +2,21 @@
 
 [![Crates.io Version](https://img.shields.io/crates/v/eye_declare)](https://crates.io/crates/eye_declare) [![docs.rs](https://img.shields.io/docsrs/eye_declare)](https://docs.rs/eye_declare)
 
-Inline terminal UIs for Rust, built on [Ratatui](https://ratatui.rs) —
-interfaces that live in your terminal's normal flow, where finished output
-scrolls into native scrollback and only a small live region updates in place.
-Built for CLI tools, AI agents, and interactive prompts: the programs where
-output accumulates and history should stay visible, exactly as if the program
-had printed it.
+Inline terminal UIs for Rust, built on [Ratatui](https://ratatui.rs).
+
+Inline interfaces live in your terminal's normal flow, where finished output scrolls into native scrollback and only a small live region updates in place. Ideal for CLI tools, AI agents, and interactive prompts: programs where output accumulates and history should stay visible, exactly as if the program had printed it.
 
 ![Demo](https://github.com/BinaryMuse/eye-declare/blob/main/assets/demo.gif?raw=true)
 
 ## The idea
 
-An inline app's output isn't a screen — it's a **timeline**: an append-only
-sequence of finished output with a small live region at the bottom.
-eye-declare models exactly that:
+eye-declare models inline applications as a **timeline**: an append-only sequence of finished output with a small live region at the bottom.
 
-> **Committed output is an effect. The live tail is a view.**
+Emitting a finished block is I/O, irreversible like `println!`, so it happens in your update function (`ctx.push`). The live tail is the only thing that behaves like a screen, so it's the only thing described by a view function — re-run every frame, pure, cheap because it's small.
 
-Emitting a finished block is I/O, irreversible like `println!`, so it happens
-in your update function (`ctx.push`). The live tail is the only thing that
-behaves like a screen, so it's the only thing described by a view function —
-re-run every frame, pure, cheap because it's small.
+If you've written Elm, iced, or Redux, the rest is familiar: your struct is the model, messages drive `update`, async work arrives as streams of messages, and cancellation is dropping a handle. There's no reconciliation, no keys, no dirty tracking, no framework-owned widget state, and no hidden focus registry, because a timeline needs none of them.
 
-If you've written Elm, iced, or Redux, the rest is familiar: your struct is
-the model, messages drive `update`, async work arrives as streams of
-messages, and cancellation is dropping a handle. What the design _removes_ is
-the point — there's no reconciliation, no keys, no dirty tracking, no
-framework-owned widget state, and no hidden focus registry, because a
-timeline needs none of them.
-
-## A taste
+## Example
 
 ```rust
 use eye_declare::{App, Ctx, Element, Fluent, Keymap, Task, col, key, keymap, markdown, panel, spinner, text_area};
@@ -51,15 +36,18 @@ impl App for Chat {
         match msg {
             Msg::Submit => {
                 let prompt = self.input.take_text();
-                ctx.push(user_turn(&prompt));                     // committed: permanent output
-                self.request = Some(ctx.spawn(stream(prompt)));   // async work = a stream of Msgs
+                // ctx.push() commits as permanent, unchangeable output:
+                ctx.push(user_turn(&prompt));
+                // async work is a stream of `Msg`s:
+                self.request = Some(ctx.spawn(stream(prompt)));
             }
             Msg::Chunk(delta) if self.request.is_some() => self.reply.push_str(&delta),
             Msg::Done => {
                 self.request = None;
                 ctx.push(markdown(std::mem::take(&mut self.reply)));
             }
-            Msg::Cancel => self.request = None,                   // Esc-cancels-generation. That's it.
+            // Simply drop the task to cancel async work:
+            Msg::Cancel => self.request = None,
             _ => {}
         }
     }
@@ -74,16 +62,16 @@ impl App for Chat {
     fn keymap(&self) -> Keymap<Msg> {
         let mut km = keymap().on(key(KeyCode::Esc), Msg::Cancel);
         if self.request.is_none() && !self.input.is_blank() {
-            km = km.on(key(KeyCode::Enter), Msg::Submit);   // Enter means "send" only when it can
+            // Enter is only bound to Submit when no request is in progress
+            // and the input box is not blank.
+            km = km.on(key(KeyCode::Enter), Msg::Submit);
         }
         km.fallthrough(&self.input_focus, Msg::Input)
     }
 }
 ```
 
-For the complete, runnable version of this — a streaming AI chat against the
-OpenRouter API in one commented file — see
-[`examples/openrouter.rs`](crates/eye_declare/examples/openrouter.rs):
+For a complete, runnable example of a streaming AI chat against the OpenRouter API in one commented file, see [`examples/openrouter.rs`](crates/eye_declare/examples/openrouter.rs):
 
 ```sh
 export OPENROUTER_API_KEY=sk-or-...
@@ -92,47 +80,21 @@ cargo run --release --example openrouter
 
 ## Highlights
 
-- **Fluent builders, no macro DSL** — views are plain Rust (`col()`,
-  `.when(…)`, iterators), with full rust-analyzer support.
-- **Strict-Elm state** — widget state (text areas, selects) lives in _your_
-  model as plain values. Everything is constructible and testable.
-- **Keys are data** — a `Keymap` rebuilt from the model each update makes
-  conditional bindings one-liners and mode conflicts impossible.
-- **Cancel-on-drop async** — `ctx.spawn` returns a `Task`; cancellation and
-  replacement are field assignments.
-- **Headless testing** — the runtime is sync at its core (events in, bytes
-  out); whole apps run in tests against a real VTE terminal emulator.
-- **Measured performance** — no dirty tracking, and none needed: ~780µs and
-  ~2.3K allocations per frame with 10KB of live markdown; bursts of stream
-  chunks coalesce into single frames.
-- **The hard part is invisible** — scrollback-safe diffing, burst streaming,
-  cursor discipline, resize handling, and DEC synchronized output live in a
-  dedicated engine crate with a VTE-based test suite.
+- **Fluent builders, no macro DSL** — views are plain Rust (`col()`, `.when(…)`, iterators), with full rust-analyzer and `cargo fmt` support.
+- **Strict-Elm state** — widget state (text areas, selects) lives in _your_ model as plain values. Everything is constructible and testable.
+- **Keys are data** — a `Keymap` rebuilt from the model each update makes conditional bindings simple one-liners, and makes mode conflicts impossible.
+- **Cancel-on-drop async** — `ctx.spawn` returns a `Task`; cancellation and replacement are field assignments.
+- **Headless testing** — the runtime is sync at its core (events in, bytes out); whole apps run in tests against a real VTE terminal emulator.
+- **Measured performance** — no dirty tracking, and none needed: ~780µs and ~2.3K allocations per frame with 10KB of live markdown; bursts of stream chunks coalesce into single frames.
+- **The hard part is invisible** — scrollback-safe diffing, burst streaming, cursor discipline, resize handling, and DEC synchronized output live in a dedicated engine crate with a VTE-based test suite.
 
 ## Documentation
 
-The [book](https://eye-declare.rs) covers everything: the
-[introduction](https://eye-declare.rs/getting-started/introduction) explains
-the design; the [quick start](https://eye-declare.rs/getting-started/quick-start)
-builds a working app in sixty lines; guide chapters cover the timeline,
-elements, input, async, components-as-a-convention, testing, and
-performance. Migrating from 0.5? There's a
-[dedicated chapter](https://eye-declare.rs/reference/migration).
+The [eye-declare book](https://eye-declare.rs) covers everything: the [introduction](https://eye-declare.rs/getting-started/introduction) explains the design; the [quick start](https://eye-declare.rs/getting-started/quick-start) builds a working app in sixty lines; guide chapters cover the timeline, elements, input, async, components-as-a-convention, testing, and performance. Migrating from 0.5? There's a [dedicated chapter](https://eye-declare.rs/reference/migration).
 
 ## Status
 
-0.6.0 is a ground-up redesign of the library around the timeline
-architecture. The 0.5.x component-model API is frozen and will not receive
-further changes. Expect the 0.6 API to settle toward 1.0 as it accumulates
-mileage.
-
-## Crate structure
-
-```
-crates/
-  eye_declare/         The library: App/Msg/update, elements, keymap, drivers
-  eye_declare_engine/  Terminal-sync engine: diffing, scrollback, cursor discipline
-```
+0.6.0 is a ground-up redesign of the library around the timeline architecture. The 0.5.x component-model API is frozen and will not receive further changes. Expect the 0.6 API to settle toward 1.0 as it accumulates mileage.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ performance. Migrating from 0.5? There's a
 ## Status
 
 0.6.0 is a ground-up redesign of the library around the timeline
-architecture, validated by porting a production AI agent TUI onto it before
-release. The 0.5.x component-model API is frozen and will not receive
+architecture. The 0.5.x component-model API is frozen and will not receive
 further changes. Expect the 0.6 API to settle toward 1.0 as it accumulates
 mileage.
 

--- a/crates/eye_declare/examples/openrouter.rs
+++ b/crates/eye_declare/examples/openrouter.rs
@@ -75,6 +75,7 @@ struct Chat {
     request: Option<Task>,
     started: Option<Instant>,
 
+    exiting: bool,
     input: TextAreaState,
     input_focus: FocusHandle,
     error: Option<String>,
@@ -92,6 +93,7 @@ impl Chat {
             streaming: String::new(),
             request: None,
             started: None,
+            exiting: false,
             input: TextAreaState::new(),
             input_focus,
             error: None,
@@ -189,6 +191,7 @@ impl App for Chat {
                     // partial reply is still worth keeping.
                     self.finish_reply(Some("interrupted"), ctx);
                 } else {
+                    self.exiting = true;
                     ctx.exit(());
                 }
             }
@@ -230,24 +233,26 @@ impl App for Chat {
                         .pad_top(1),
                 )
             })
-            .child(
-                panel(
-                    text_area(&self.input)
-                        .placeholder("Ask anything…")
-                        .track_focus(&self.input_focus)
-                        .max_height(6),
+            .when(!self.exiting, |c| {
+                c.child(
+                    panel(
+                        text_area(&self.input)
+                            .placeholder("Ask anything…")
+                            .track_focus(&self.input_focus)
+                            .max_height(6),
+                    )
+                    .title("You")
+                    .title_right(&self.model)
+                    .footer(if self.busy() {
+                        "[Esc] Cancel"
+                    } else {
+                        "[Enter] Send  [Shift+Enter] Newline  [Esc] Quit"
+                    })
+                    .border_style(Style::default().fg(Color::DarkGray))
+                    .pad_x(1)
+                    .pad_top(1),
                 )
-                .title("You")
-                .title_right(&self.model)
-                .footer(if self.busy() {
-                    "[Esc] Cancel"
-                } else {
-                    "[Enter] Send  [Shift+Enter] Newline  [Esc] Quit"
-                })
-                .border_style(Style::default().fg(Color::DarkGray))
-                .pad_x(1)
-                .pad_top(1),
-            )
+            })
     }
 
     fn keymap(&self) -> Keymap<Msg> {

--- a/crates/eye_declare/src/element.rs
+++ b/crates/eye_declare/src/element.rs
@@ -1,9 +1,8 @@
 //! The core `Element` trait and universal combinators.
 //!
-//! Elements are `Msg`-free (bake-off O7): they describe structure and
-//! pixels. Message emission lives in the keymap layer, so display code
-//! never names the app's message type and none of the spike's
-//! `Msg`-inference workarounds are needed.
+//! Elements are `Msg`-free: they describe structure and pixels. Message
+//! emission lives in the keymap layer, so display code never names the
+//! app's message type.
 
 use std::time::Duration;
 
@@ -41,9 +40,9 @@ pub trait Element {
 /// A boxed, type-erased element. Heterogeneous match arms converge on this
 /// via [`ElementExt::any`].
 ///
-/// Carries a lifetime so views can borrow the app model (bake-off rule 3):
-/// the tail is built, rendered, and dropped within one frame, so model
-/// borrows are naturally scoped. Fully-owned trees are `AnyElement<'static>`.
+/// Carries a lifetime so views can borrow the app model: the tail is
+/// built, rendered, and dropped within one frame, so model borrows are
+/// naturally scoped. Fully-owned trees are `AnyElement<'static>`.
 pub type AnyElement<'a> = Box<dyn Element + 'a>;
 
 impl Element for Box<dyn Element + '_> {

--- a/crates/eye_declare/src/focus.rs
+++ b/crates/eye_declare/src/focus.rs
@@ -1,4 +1,4 @@
-//! Focus as data (GPUI's `FocusHandle` pattern, per the bake-off).
+//! Focus as data (GPUI's `FocusHandle` pattern).
 //!
 //! The app model owns a [`Focus`] system and creates [`FocusHandle`]s from
 //! it. All handles from one system share a single "currently focused" cell,

--- a/crates/eye_declare/src/input.rs
+++ b/crates/eye_declare/src/input.rs
@@ -2,7 +2,7 @@
 //! rebuilt from the model each update so bindings can be conditional on
 //! app state.
 //!
-//! Dispatch order (bake-off O2, first match in declaration order wins):
+//! Dispatch order (first match in declaration order wins):
 //! 1. [`on_override`](Keymap::on_override) bindings — Ctrl+C-tier chords
 //!    that fire regardless of focus
 //! 2. [`in_scope`](Keymap::in_scope) bindings for the focused handle
@@ -73,8 +73,8 @@ enum Scope {
 type FallthroughFn<Msg> = Box<dyn Fn(InputEvent) -> Msg + Send>;
 
 /// Key → message bindings. Values, not callbacks: rebuild from the model
-/// each update (see the conditional Tab bindings in the spike's Port 3A —
-/// this is what makes key-policy conflicts impossible by construction).
+/// each update, so bindings can be conditional on app state and key-policy
+/// conflicts are impossible by construction.
 pub struct Keymap<Msg> {
     bindings: Vec<(Scope, Key, Msg)>,
     fallthrough: Vec<(FocusHandle, FallthroughFn<Msg>)>,

--- a/crates/eye_declare/src/lib.rs
+++ b/crates/eye_declare/src/lib.rs
@@ -1,17 +1,15 @@
 //! Inline terminal UIs: timeline-first, Elm-shaped, built on Ratatui.
 //!
-//! Built on `eye_declare_engine`; designed in `.planning/REDESIGN.md` and
-//! validated by the `spike` crate's bake-off and a production port. Core
-//! commitments:
+//! Built on `eye_declare_engine`. Core commitments:
 //!
 //! - **Committed output is an effect; the live tail is a view.** Blocks are
 //!   pushed once from `update` and flow into scrollback; only the small
 //!   tail re-renders, every frame, with no dirty tracking.
-//! - **Strict-Elm state** (bake-off O1): widget state lives in the app
-//!   model as plain values; views borrow it.
-//! - **`Msg`-free elements** (bake-off O7): elements describe structure and
-//!   pixels only. All message emission happens in the keymap layer, so the
-//!   element tree carries no message type parameter.
+//! - **Strict-Elm state:** widget state lives in the app model as plain
+//!   values; views borrow it.
+//! - **`Msg`-free elements:** elements describe structure and pixels only.
+//!   All message emission happens in the keymap layer, so the element tree
+//!   carries no message type parameter.
 //! - **Honest measurement:** `Element::height(width)` is required, exact,
 //!   and cheap. No probe rendering.
 

--- a/crates/eye_declare/src/lib.rs
+++ b/crates/eye_declare/src/lib.rs
@@ -12,6 +12,8 @@
 //!   carries no message type parameter.
 //! - **Honest measurement:** `Element::height(width)` is required, exact,
 //!   and cheap. No probe rendering.
+//!
+//! For more information and examples, check out the [eye-declare book](https://eye-declare.rs).
 
 pub mod app;
 #[cfg(feature = "tokio")]

--- a/crates/eye_declare/src/text_area.rs
+++ b/crates/eye_declare/src/text_area.rs
@@ -1,7 +1,7 @@
-//! Editable multi-line text: state as a plain model value (strict Elm,
-//! bake-off O1), view as a borrowing element.
+//! Editable multi-line text: state as a plain model value (strict Elm),
+//! view as a borrowing element.
 //!
-//! Division of labor, as validated by the spike's Port 3A:
+//! Division of labor:
 //!
 //! - [`TextAreaState`] owns content + cursor and applies *ordinary editing*
 //!   ([`handle`](TextAreaState::handle)): characters, backspace/delete,

--- a/crates/eye_declare/tests/composition.rs
+++ b/crates/eye_declare/tests/composition.rs
@@ -1,8 +1,8 @@
-//! Component composition, the strict-Elm way (the spike's Port 3A pattern
-//! made real): a reusable `PromptBox` sub-model with its own Msg, update,
-//! keymap, and view — embedded in a parent app by enum wrapping. The
-//! parent claims the child's `Submit` (app policy) and delegates the rest.
-//! No context system, no event phases, no OutMsg machinery.
+//! Component composition, the strict-Elm way: a reusable `PromptBox`
+//! sub-model with its own Msg, update, keymap, and view — embedded in a
+//! parent app by enum wrapping. The parent claims the child's `Submit`
+//! (app policy) and delegates the rest. No context system, no event
+//! phases, no OutMsg machinery.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use eye_declare::{

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -1,7 +1,5 @@
 //! The terminal-sync state machine: owns cursor tracking, row accounting,
-//! and the scrollback boundary. Extracted verbatim from `eye_declare`'s
-//! `InlineRenderer` (Phase 2, step 2) — that type now delegates all
-//! terminal mechanics here and keeps only the component-tree concerns.
+//! and the scrollback boundary.
 
 use ratatui_core::buffer::Buffer;
 

--- a/crates/eye_declare_engine/src/lib.rs
+++ b/crates/eye_declare_engine/src/lib.rs
@@ -1,15 +1,10 @@
 //! The inline terminal rendering engine behind `eye_declare`.
 //!
 //! Contract: frames in, terminal-synced scrollback out. This crate knows
-//! nothing about components, element trees, or reconciliation — it speaks
-//! `ratatui` `Buffer`s and emits ANSI escape bytes.
+//! nothing about components, element trees, or reconciliation; it speaks
+//! ratatui `Buffer`s and emits ANSI escape bytes.
 //!
-//! Modules: `engine` (the terminal-sync state machine: row accounting,
-//! scrollback streaming, resize/finalize), `frame` (buffer diffing),
-//! `escape` (ANSI generation, relative-cursor discipline, synchronized
-//! output), `wrap` (word-wrap measurement), and — behind the `test-util`
-//! feature — `test_terminal`, a VTE-based terminal emulator for headless
-//! tests.
+//! For more information, see the [eye-declare documentation](https://docs.rs/eye_declare/).
 
 pub mod engine;
 pub mod escape;

--- a/crates/eye_declare_engine/src/lib.rs
+++ b/crates/eye_declare_engine/src/lib.rs
@@ -1,18 +1,15 @@
-//! The inline terminal rendering engine extracted from `eye_declare`
-//! (redesign Phase 2 — see `.planning/REDESIGN.md` at the repo root).
+//! The inline terminal rendering engine behind `eye_declare`.
 //!
 //! Contract: frames in, terminal-synced scrollback out. This crate knows
 //! nothing about components, element trees, or reconciliation — it speaks
 //! `ratatui` `Buffer`s and emits ANSI escape bytes.
 //!
-//! Extraction in progress: `frame` (buffer diffing), `escape` (ANSI
-//! generation, relative-cursor discipline, synchronized output), and `wrap`
-//! (word-wrap measurement) have moved; the terminal-sync state machine from
-//! `inline.rs` (row accounting, scrollback streaming, resize/finalize) is
-//! next, along with the VTE test terminal.
-//!
-//! `publish = false` until the extraction completes and the crate is named
-//! for real (spec question O4).
+//! Modules: `engine` (the terminal-sync state machine: row accounting,
+//! scrollback streaming, resize/finalize), `frame` (buffer diffing),
+//! `escape` (ANSI generation, relative-cursor discipline, synchronized
+//! output), `wrap` (word-wrap measurement), and — behind the `test-util`
+//! feature — `test_terminal`, a VTE-based terminal emulator for headless
+//! tests.
 
 pub mod engine;
 pub mod escape;

--- a/crates/eye_declare_engine/src/wrap.rs
+++ b/crates/eye_declare_engine/src/wrap.rs
@@ -6,9 +6,9 @@ use ratatui_widgets::paragraph::{Paragraph, Wrap};
 /// Below this width the word wrapper is unsafe: at width 2 a multi-column
 /// grapheme mid-word (plain CJK does it — `"a佉b"`) makes ratatui's
 /// `WordWrapper` emit a line wider than the limit, and `Paragraph::render`
-/// then writes past the buffer edge (upstream bug, fuzz-found; minimal
-/// repros in `.planning/FUZZING.md`). Under this width both measuring and
-/// rendering fall back to truncation, which is panic-free at any width.
+/// then writes past the buffer edge (upstream bug, found by fuzzing).
+/// Under this width both measuring and rendering fall back to truncation,
+/// which is panic-free at any width.
 const MIN_WRAP_WIDTH: u16 = 3;
 
 /// Compute how many terminal rows `text` occupies at `width` with word wrapping.

--- a/crates/eye_declare_engine/tests/test_terminal_behavior.rs
+++ b/crates/eye_declare_engine/tests/test_terminal_behavior.rs
@@ -1,8 +1,7 @@
 //! The emulator is the oracle for every headless test in the workspace,
 //! so it gets direct behavior tests of its own (mutation testing showed
-//! several of its CSI arms could be deleted unnoticed —
-//! `.planning/MUTATION.md`). Each test feeds raw escape bytes and asserts
-//! on screen and cursor state.
+//! several of its CSI arms could be deleted unnoticed). Each test feeds
+//! raw escape bytes and asserts on screen and cursor state.
 
 use eye_declare_engine::test_terminal::TestTerminal;
 

--- a/docs/content/guide/elements.md
+++ b/docs/content/guide/elements.md
@@ -32,12 +32,12 @@ conveniences from the `Fluent` trait available on every builder:
 
 ```rust
 pub trait Element {
-    /// Exact height at the given width. Must be cheap and honest.
+    // Exact height at the given width. Must be cheap and honest.
     fn height(&self, width: u16) -> u16;
     fn render(&self, area: Rect, buf: &mut Buffer);
-    /// Frame interval if self-animating (Spinner returns ~80ms).
+    // Frame interval if self-animating (Spinner returns ~80ms).
     fn animated(&self) -> Option<Duration> { None }
-    /// Hardware-cursor position, if this element wants it.
+    // Hardware-cursor position, if this element wants it.
     fn cursor(&self, area: Rect) -> Option<(u16, u16)> { None }
 }
 ```
@@ -48,7 +48,7 @@ elements describe pixels, and all message emission lives in the
 part of the contract, exact, called before `render`. For wrapped text the
 `wrap` helpers in the engine make it a one-liner.
 
-Note that `animated()` covers *view-only* time dependence — pixels that
+Note that `animated()` covers _view-only_ time dependence — pixels that
 change while the model doesn't, like a spinner glyph or an elapsed-seconds
 label. Time that should change your model goes through
 [subscriptions](../async/) as messages. Animation ticks are not messages.
@@ -71,7 +71,7 @@ fn event_view(event: &UiEvent) -> AnyElement<'_> {
 ## Writing view helper functions
 
 A helper that borrows data and returns `impl Element` needs Rust's precise
-capturing syntax when it *doesn't* capture the borrow:
+capturing syntax when it _doesn't_ capture the borrow:
 
 ```rust
 // Clones what it needs: tell the compiler nothing is captured.
@@ -95,7 +95,7 @@ Implement the trait directly; it's small on purpose. Two conventions from
 the built-ins worth copying:
 
 **Same-frame caching for expensive work.** Elements are values rebuilt
-every frame, but *within* a frame, `height` runs more than once (the tail
+every frame, but _within_ a frame, `height` runs more than once (the tail
 measure, then container placement during render) and `render` follows. An
 element that parses or lays out something non-trivial should do that work
 once per lifetime with a `RefCell` cache — the built-in `markdown()` does

--- a/docs/content/guide/the-timeline.md
+++ b/docs/content/guide/the-timeline.md
@@ -14,7 +14,7 @@ Every eye-declare app manages two kinds of output:
 - **The live tail** — everything below the last committed block, described
   by `tail(&self)` and replaced wholesale every frame.
 
-## Push is `println!` for elements
+## Push is println! for elements
 
 ```rust
 ctx.push(markdown(&finished_turn));

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,11 +1,11 @@
 ---
 title: eye-declare
-description: Inline terminal UIs for Rust — timeline-first, Elm-shaped
+description: Inline terminal UIs for Rust
 ---
 
 # eye-declare
 
-A library for building inline terminal UIs in Rust — interfaces that live in
+A library for building inline terminal UIs in Rust: interfaces that live in
 your terminal's normal flow, where finished output scrolls into native
 scrollback and only a small live region updates in place.
 
@@ -13,28 +13,71 @@ eye-declare is built for CLI tools, AI agents, and interactive prompts: the
 programs where output accumulates and history should stay visible, exactly as
 if the program had printed it.
 
+## Rust Docs
+
+For the rustdoc documentation, visit [https://docs.rs/eye_declare](https://docs.rs/eye_declare).
+
+## Example
+
+The whole design in one small fragment: a streaming agent turn. Content lives in
+the live tail while it's changing; the moment it's finished, `ctx.push`
+commits it to scrollback, like `println!`:
+
 ```rust
-fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
-    match msg {
-        Msg::StreamDone => {
-            // The finished reply becomes permanent terminal output…
-            ctx.push(markdown(std::mem::take(&mut self.reply)));
-        }
-        // …
-    }
+struct Agent {
+    response: String,
+    streaming: Option<Task>,
 }
 
-fn tail(&self) -> impl Element + '_ {
-    // …and the live region is a pure view of the model, rebuilt
-    // every frame.
-    col()
-        .when(!self.reply.is_empty(), |c| c.child(markdown(self.reply.clone())))
-        .child(panel(text_area(&self.input)).title("Ask"))
+enum Msg {
+    Delta(String),
+    Done,
+}
+
+impl App for Agent {
+    type Msg = Msg;
+    type Output = ();
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            // Still changing: lives in the tail.
+            Msg::Delta(word) => self.response.push_str(&word),
+            // Finished: commit to scrollback.
+            Msg::Done => {
+                let reply = std::mem::take(&mut self.response);
+                ctx.push(markdown(reply));
+                self.streaming = None;
+            }
+        }
+    }
+
+    // The live region: a pure view of the model, rebuilt every frame.
+    fn tail(&self) -> impl Element + '_ {
+        col()
+            .when(self.streaming.is_some(), |c| {
+                c.child(spinner("Thinking…"))
+            })
+            .child(text(self.response.as_str()))
+    }
 }
 ```
 
+Messages arrive from terminal input through a keymap and from async work
+through `ctx.spawn` — both shown in the [quick start](/getting-started/quick-start/),
+which builds a complete runnable app in about sixty lines.
+
+## Examples
+
+The repository ships runnable examples that double as learning material:
+
+- [`echo`](https://github.com/atuinsh/eye-declare/blob/main/crates/eye_declare/examples/echo.rs) — the smallest useful app: type, Enter commits, Ctrl+C exits.
+- [`stream`](https://github.com/atuinsh/eye-declare/blob/main/crates/eye_declare/examples/stream.rs) — a mini agent: a streaming turn with a spinner, Esc cancels.
+- [`openrouter`](https://github.com/atuinsh/eye-declare/blob/main/crates/eye_declare/examples/openrouter.rs) — a real streaming AI chat TUI in one commented file.
+
+## Where to go next
+
 Start with the [introduction](/getting-started/introduction/) for the idea
 behind the design, or jump to the [quick start](/getting-started/quick-start/)
-to build a working app in about sixty lines. For a complete real-world
-program, see the [OpenRouter chat example](https://github.com/atuinsh/eye-declare/blob/main/crates/eye_declare/examples/openrouter.rs)
-— a streaming AI chat TUI in one commented file.
+to build a working app. The [guide](/guide/the-timeline/) covers the concepts
+in depth; the [reference](/reference/widgets/) documents the widgets, runtime,
+and migration path.

--- a/docs/content/reference/migration.md
+++ b/docs/content/reference/migration.md
@@ -8,10 +8,9 @@ description: From the component tree to the timeline
 0.6.0 is a redesign, not an increment. The scrollback engine — the part of
 0.5 that was genuinely hard to get right — carries over intact underneath,
 but the component model above it is replaced. There is no mechanical
-migration; expect to restructure, and expect the result to be smaller.
-(The largest 0.5 application shrank by about a sixth while gaining a test
-suite when ported; its adapter layers — an event-channel bridge, a
-view-state sync, commit detection by key parsing — all deleted outright.)
+migration; expect to restructure, and expect the result to be smaller —
+adapter layers like event-channel bridges, view-state sync, and commit
+detection by key parsing tend to delete outright.
 
 ## The conceptual change
 


### PR DESCRIPTION
- **Clean up docs mentions of spikes, bakeoffs, etc**
- **Restructure readme**
- **Improve docs**
- **Hide input box when exiting in openrouter example**
