### PR TITLE
fix: Anchor resize repaints on cursor position reports

### DIFF
--- a/crates/eye_declare/examples/resize_probe.rs
+++ b/crates/eye_declare/examples/resize_probe.rs
@@ -1,0 +1,95 @@
+//! Manual test bed for resize behavior.
+//!
+//!     cargo run -p eye_declare --example resize_probe
+//!
+//! Commits two fake conversation turns at startup, then sits on a
+//! bordered-input tail. Resize the terminal every way you can — the
+//! committed turns must survive and the tail must repaint cleanly.
+//! Ctrl+C or Esc exits.
+
+use crossterm::event::KeyCode;
+use eye_declare::{
+    App, Ctx, Element, ElementExt, Focus, FocusHandle, InputEvent, KeyboardProtocol, Keymap,
+    RunOptions, TextAreaState, col, driver_tokio, key, keymap, panel, text, text_area,
+};
+use ratatui_core::style::{Color, Modifier, Style};
+
+#[derive(Clone)]
+enum Msg {
+    Edit(InputEvent),
+    Quit,
+}
+
+struct Probe {
+    input_focus: FocusHandle,
+    input: TextAreaState,
+}
+
+impl App for Probe {
+    type Msg = Msg;
+    type Output = ();
+
+    fn init(&mut self, ctx: &mut Ctx<'_, Self>) {
+        ctx.push(
+            col()
+                .child(text(" You ").style(Style::default().add_modifier(Modifier::REVERSED)))
+                .child(text("Hi!").pad_left(2)),
+        );
+        ctx.push(
+            col()
+                .child(text(" Atuin AI ").style(Style::default().add_modifier(Modifier::REVERSED)))
+                .child(
+                    text("Hi! I'm the Atuin AI assistant. I can help you with shell commands.")
+                        .pad_left(2),
+                ),
+        );
+    }
+
+    fn update(&mut self, msg: Msg, ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            Msg::Edit(ev) => self.input.handle(&ev),
+            Msg::Quit => ctx.exit(()),
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        col()
+            .child(
+                panel(
+                    text_area(&self.input)
+                        .placeholder("Type a message...")
+                        .placeholder_style(Style::default().fg(Color::DarkGray))
+                        .track_focus(&self.input_focus),
+                )
+                .title("Generate a command or ask a question")
+                .title_right("Atuin AI")
+                .footer("[Enter] Send  [Shift+Enter] New line  [Esc] Exit")
+                .border_style(Style::default().fg(Color::DarkGray))
+                .pad_top(1),
+            )
+            .child(text("Model: balanced (/model to change)").pad_left(1))
+    }
+
+    fn keymap(&self) -> Keymap<Msg> {
+        keymap()
+            .on_override(key(KeyCode::Char('c')).ctrl(), Msg::Quit)
+            .on_override(key(KeyCode::Esc), Msg::Quit)
+            .fallthrough(&self.input_focus, Msg::Edit)
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> std::io::Result<()> {
+    let focus = Focus::new();
+    let input_focus = focus.handle();
+    input_focus.focus();
+
+    driver_tokio::run_with(
+        Probe {
+            input_focus,
+            input: TextAreaState::new(),
+        },
+        RunOptions::default().keyboard(KeyboardProtocol::Enhanced),
+    )
+    .await
+}

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -49,6 +49,7 @@ where
     let mut stdout = io::stdout().lock();
 
     let _guard = RawModeGuard::enable(options.keyboard)?;
+    crate::runtime::normalize_start_column();
 
     let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
@@ -78,7 +79,72 @@ where
                         runtime.handle(InputEvent::Key(k))
                     }
                     Some(Ok(Event::Paste(s))) => runtime.handle(InputEvent::Paste(s)),
-                    Some(Ok(Event::Resize(w, h))) => (runtime.resize(w, h), None),
+                    // Coalesce resize storms: a drag delivers events
+                    // faster than an erase + repaint + cursor query per
+                    // event can keep up, which queues stale sizes and
+                    // multiplies position queries. Drain whatever is
+                    // already queued — keys are processed in order,
+                    // resizes collapse into one handled at the latest
+                    // size. Querying the cursor synchronously here is
+                    // safe: the EventStream's reader thread is parked
+                    // between events, so the shared crossterm reader is
+                    // free, and events arriving during the query are
+                    // re-queued, not dropped.
+                    Some(Ok(Event::Resize(w, h))) => {
+                        // Drain via the plain poll/read API, NOT the
+                        // stream: polling the stream to Pending wakes its
+                        // background reader, which then holds crossterm's
+                        // shared reader lock and starves the position
+                        // query below into its timeout.
+                        let mut queued = Vec::new();
+                        while queued.len() < 64
+                            && crossterm::event::poll(Duration::ZERO).unwrap_or(false)
+                        {
+                            match crossterm::event::read() {
+                                Ok(ev) => queued.push(ev),
+                                Err(_) => break,
+                            }
+                        }
+
+                        let (mut w, mut h) = (w, h);
+                        let mut bytes = Vec::new();
+                        let mut exit = None;
+                        for ev in queued {
+                            match ev {
+                                Event::Resize(nw, nh) => (w, h) = (nw, nh),
+                                Event::Key(k)
+                                    if matches!(
+                                        k.kind,
+                                        KeyEventKind::Press | KeyEventKind::Repeat
+                                    ) =>
+                                {
+                                    let (b, e) = runtime.handle(InputEvent::Key(k));
+                                    bytes.extend_from_slice(&b);
+                                    if e.is_some() {
+                                        exit = e;
+                                        break;
+                                    }
+                                }
+                                Event::Paste(s) => {
+                                    let (b, e) = runtime.handle(InputEvent::Paste(s));
+                                    bytes.extend_from_slice(&b);
+                                    if e.is_some() {
+                                        exit = e;
+                                        break;
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        if exit.is_none() {
+                            bytes.extend_from_slice(&crate::runtime::resize_with_report(
+                                &mut runtime,
+                                w,
+                                h,
+                            ));
+                        }
+                        (bytes, exit)
+                    }
                     Some(Ok(_)) => (Vec::new(), None),
                     Some(Err(e)) => return Err(e),
                     // Terminal input ended (stdin closed): exit cleanly,

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -148,9 +148,28 @@ where
 
     /// Handle a terminal resize. Committed blocks keep the terminal's own
     /// reflow; the live region is erased and repainted at the new width.
+    ///
+    /// Prefer [`resize_anchored`](Runtime::resize_anchored) when the
+    /// driver can query the cursor position (CSI 6n).
     pub fn resize(&mut self, width: u16, terminal_height: u16) -> Vec<u8> {
         self.timeline.set_terminal_height(terminal_height);
         let mut bytes = self.timeline.resize(width);
+        bytes.extend_from_slice(&self.present());
+        bytes
+    }
+
+    /// [`resize`](Runtime::resize) with the cursor's reported absolute
+    /// position (`(col, row)`, 0-based) queried after the resize event:
+    /// the erase re-anchors on it instead of pre-reflow row arithmetic,
+    /// keeping committed blocks intact on reflowing terminals.
+    pub fn resize_anchored(
+        &mut self,
+        width: u16,
+        terminal_height: u16,
+        cursor: (u16, u16),
+    ) -> Vec<u8> {
+        self.timeline.set_terminal_height(terminal_height);
+        let mut bytes = self.timeline.resize_anchored(width, cursor);
         bytes.extend_from_slice(&self.present());
         bytes
     }
@@ -224,6 +243,7 @@ where
     let mut stdout = io::stdout().lock();
 
     let _guard = RawModeGuard::enable(options.keyboard)?;
+    normalize_start_column();
 
     let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
@@ -261,7 +281,47 @@ where
                     }
                     bytes
                 }
-                Event::Resize(w, h) => runtime.resize(w, h),
+                Event::Resize(w, h) => {
+                    // Coalesce resize storms (see the tokio driver): drain
+                    // queued events, process keys in order, and handle one
+                    // resize at the latest size.
+                    let (mut w, mut h) = (w, h);
+                    let mut bytes = Vec::new();
+                    let mut exited = None;
+                    while crossterm::event::poll(Duration::ZERO)? {
+                        match crossterm::event::read()? {
+                            Event::Resize(nw, nh) => (w, h) = (nw, nh),
+                            Event::Key(k)
+                                if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                            {
+                                let (b, e) = runtime.handle(InputEvent::Key(k));
+                                reject_effects(&mut runtime)?;
+                                bytes.extend_from_slice(&b);
+                                if e.is_some() {
+                                    exited = e;
+                                    break;
+                                }
+                            }
+                            Event::Paste(s) => {
+                                let (b, e) = runtime.handle(InputEvent::Paste(s));
+                                reject_effects(&mut runtime)?;
+                                bytes.extend_from_slice(&b);
+                                if e.is_some() {
+                                    exited = e;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let Some(output) = exited {
+                        stdout.write_all(&bytes)?;
+                        stdout.flush()?;
+                        return Ok(output);
+                    }
+                    bytes.extend_from_slice(&resize_with_report(&mut runtime, w, h));
+                    bytes
+                }
                 _ => Vec::new(),
             }
         } else {
@@ -273,6 +333,77 @@ where
             stdout.write_all(&bytes)?;
             stdout.flush()?;
         }
+    }
+}
+
+/// Read the cursor position, discarding possibly-stale replies first.
+///
+/// Terminal replies are matched to queries only by arrival order. A
+/// reply can be sitting in the input buffer before we ever ask — a zsh
+/// prompt theme (powerlevel10k) also speaks CSI 6n, and a zle widget
+/// hands us the tty with its last reply potentially unread — and a
+/// timed-out query of our own leaves its late reply queued. Either way
+/// every later read returns the *previous* query's answer, forever.
+/// Reading twice (plus once per known orphan) makes the final value
+/// describe the current screen: all reads happen against the same
+/// screen state, and the extra reads consume queued strays.
+pub(crate) fn read_cursor_position() -> std::io::Result<(u16, u16)> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    /// Replies orphaned by our own timed-out queries.
+    static ORPHANS: AtomicUsize = AtomicUsize::new(0);
+
+    let discard = ORPHANS.load(Ordering::Relaxed) + 1;
+    for _ in 0..discard {
+        if let Err(e) = crossterm::cursor::position() {
+            ORPHANS.fetch_add(1, Ordering::Relaxed);
+            return Err(e);
+        }
+    }
+    match crossterm::cursor::position() {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            ORPHANS.fetch_add(1, Ordering::Relaxed);
+            Err(e)
+        }
+    }
+}
+
+/// Start the region on a fresh line if the embedding handed us the
+/// terminal with the cursor mid-line — a zle widget leaves it at the end
+/// of the still-painted prompt, and raw-ish tty modes mean even a prior
+/// `println!` may not have carried a carriage return. The engine paints
+/// relative to column 0. Called once per run, at startup; terminals that
+/// never answer CSI 6n cost one timeout here.
+pub(crate) fn normalize_start_column() {
+    let Ok((col, _)) = read_cursor_position() else {
+        return;
+    };
+    if col != 0 {
+        // Stdout's lock is reentrant, so this is safe under the
+        // driver's lock.
+        let mut out = io::stdout().lock();
+        let _ = out.write_all(b"\r\n");
+        let _ = out.flush();
+    }
+}
+
+/// Resize re-anchored by a fresh cursor position report — the terminal
+/// has already reflowed by the time the resize event arrives, so the
+/// report is post-reflow ground truth. Falls back to stale-arithmetic
+/// [`Runtime::resize`] if the terminal doesn't answer.
+///
+/// The event's dimensions may be stale during a drag (events queue while
+/// the terminal keeps resizing); painting at a stale width soft-wraps
+/// for real and corrupts row tracking, so re-query the current size and
+/// prefer it.
+pub(crate) fn resize_with_report<A: App>(runtime: &mut Runtime<A>, w: u16, h: u16) -> Vec<u8>
+where
+    A::Msg: Clone,
+{
+    let (w, h) = crossterm::terminal::size().unwrap_or((w, h));
+    match read_cursor_position() {
+        Ok(pos) => runtime.resize_anchored(w, h, pos),
+        Err(_) => runtime.resize(w, h),
     }
 }
 

--- a/crates/eye_declare/src/text_area.rs
+++ b/crates/eye_declare/src/text_area.rs
@@ -99,6 +99,13 @@ impl TextAreaState {
     }
 
     fn insert_char(&mut self, c: char) {
+        // Control characters reach here only by accident — a terminal
+        // reply (cursor report, mode response) racing the input parser,
+        // or one embedded in a paste. Rendering them would corrupt the
+        // painted row.
+        if c.is_control() {
+            return;
+        }
         let line = &mut self.lines[self.line];
         let at = byte_at(line, self.col);
         line.insert(at, c);
@@ -108,8 +115,16 @@ impl TextAreaState {
         self.col = grapheme_count(&line[..at + c.len_utf8()]);
     }
 
-    /// Insert text at the cursor; newlines split lines.
+    /// Insert text at the cursor; newlines split lines. Control
+    /// characters other than `\n` and `\t` are dropped (see
+    /// `insert_char`).
     pub fn insert_str(&mut self, s: &str) {
+        let keep = |c: char| !c.is_control() || c == '\n' || c == '\t';
+        let s: std::borrow::Cow<'_, str> = if s.chars().all(keep) {
+            s.into()
+        } else {
+            s.chars().filter(|&c| keep(c)).collect::<String>().into()
+        };
         for (i, part) in s.split('\n').enumerate() {
             if i > 0 {
                 self.insert_newline();

--- a/crates/eye_declare/src/timeline.rs
+++ b/crates/eye_declare/src/timeline.rs
@@ -67,8 +67,21 @@ impl Timeline {
     /// reflow, per the committed-is-immutable semantics) and reset
     /// tracking. Follow with a [`present`](Timeline::present) to repaint
     /// the tail at the new width.
+    ///
+    /// Prefer [`resize_anchored`](Timeline::resize_anchored) when a
+    /// cursor position report is available: without one the erase relies
+    /// on pre-reflow row arithmetic, which drifts on reflowing terminals.
     pub fn resize(&mut self, new_width: u16) -> Vec<u8> {
         self.engine.reset_region(new_width)
+    }
+
+    /// [`resize`](Timeline::resize) re-anchored by a cursor position
+    /// report: `cursor` is the absolute `(col, row)` (0-based) the
+    /// terminal reported *after* reflowing at the new width. The erase
+    /// targets the region top exactly instead of trusting stale row
+    /// arithmetic.
+    pub fn resize_anchored(&mut self, new_width: u16, cursor: (u16, u16)) -> Vec<u8> {
+        self.engine.reset_region_anchored(new_width, cursor)
     }
 
     /// Hand the terminal back to the shell: park the cursor at column 0

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -26,6 +26,18 @@ pub struct Engine {
     emitted_rows: u16,
     /// Terminal height, used to avoid writing to rows in scrollback.
     terminal_height: u16,
+    /// Whether the last present parked the hidden cursor on the region's
+    /// top row (no cursor hint). See
+    /// [`position_cursor`](Engine::position_cursor): a parked cursor
+    /// makes a resize-time position report the region top directly.
+    parked: bool,
+    /// Set by the resize resets: the screen row the erased region starts
+    /// at (`None` when unknown). The next present is a repaint of
+    /// content that was *already on screen* — it must not stream
+    /// overflow rows into scrollback again (a resize drag would dump a
+    /// screenful of duplicates per event), and an overflowing tail
+    /// takes the visible screen instead of scrolling for rows.
+    resumed_at: Option<u16>,
 }
 
 impl Engine {
@@ -40,7 +52,74 @@ impl Engine {
             prev_frame: None,
             emitted_rows: 0,
             terminal_height,
+            parked: false,
+            resumed_at: None,
         }
+    }
+
+    /// The present after a resize reset: the region was just erased from
+    /// screen row `resumed_at` down and the frame replaces content that
+    /// was already visible.
+    ///
+    /// Unlike a true first render, nothing here belongs in scrollback —
+    /// the frame's overflow (if it is taller than the screen) was
+    /// already emitted in some earlier form, so re-streaming it would
+    /// duplicate a screenful per resize event. An overflowing frame
+    /// instead claims the whole screen and paints only its visible
+    /// window; rows above the window become unreachable, like any
+    /// scrolled content.
+    fn repaint_after_reset(
+        &mut self,
+        new_frame: Frame,
+        cursor_hint: Option<(u16, u16)>,
+        park_hidden: bool,
+    ) -> Vec<u8> {
+        let start = self.resumed_at.take().unwrap_or(0);
+        let new_height = new_frame.area().height;
+        let mut output = Vec::new();
+
+        let rows_below = self.terminal_height.saturating_sub(start);
+        let start = if new_height > rows_below && start > 0 {
+            // The frame needs more rows than remain below the erase
+            // point: take the whole screen — it would end up covered
+            // anyway, and claiming rows by scrolling would shove the
+            // content above into scrollback line by line.
+            output.extend_from_slice(b"\x1b[H\x1b[J");
+            0
+        } else {
+            start
+        };
+
+        if new_height <= self.terminal_height.saturating_sub(start) {
+            // Fits below the erase point: claim rows without scrolling.
+            output.resize(output.len() + new_height as usize - 1, b'\n');
+            self.emitted_rows = new_height;
+            self.cursor.row = new_height - 1;
+        } else {
+            // Taller than the screen: fill it, no scrolling. Rows above
+            // the visible window are never physically claimed — they're
+            // unreachable regardless, exactly as if they had scrolled.
+            // (Saturating: a resize can report height zero.)
+            output.resize(
+                output.len() + self.terminal_height.saturating_sub(1) as usize,
+                b'\n',
+            );
+            self.emitted_rows = new_height;
+            self.cursor.row = new_height - 1;
+        }
+        self.cursor.col = 0;
+
+        let empty = Frame::new(ratatui_core::buffer::Buffer::empty(
+            ratatui_core::layout::Rect::new(0, 0, self.width, 0),
+        ));
+        let scrolled_past = self.emitted_rows.saturating_sub(self.terminal_height);
+        let mut diff = new_frame.diff_from(&empty, scrolled_past);
+        diff.retain_visible(scrolled_past);
+        output.extend_from_slice(&diff.to_escape_sequences(&mut self.cursor));
+
+        self.position_cursor(&mut output, cursor_hint, park_hidden);
+        self.prev_frame = Some(new_frame);
+        output
     }
 
     /// The content width frames are expected to be rendered at.
@@ -68,6 +147,19 @@ impl Engine {
     ///
     /// Returns an empty Vec if nothing changed.
     pub fn present(&mut self, new_frame: Frame, cursor_hint: Option<(u16, u16)>) -> Vec<u8> {
+        self.present_inner(new_frame, cursor_hint, true)
+    }
+
+    /// [`present`](Engine::present), with control over parking the
+    /// hidden cursor. [`commit`](Engine::commit) presents the block as
+    /// an intermediate frame and immediately claims the row below it —
+    /// parking there would be movement churn undone a byte later.
+    fn present_inner(
+        &mut self,
+        new_frame: Frame,
+        cursor_hint: Option<(u16, u16)>,
+        park_hidden: bool,
+    ) -> Vec<u8> {
         let new_height = new_frame.area().height;
 
         // First render
@@ -75,6 +167,10 @@ impl Engine {
             if new_height == 0 {
                 self.prev_frame = Some(new_frame);
                 return Vec::new();
+            }
+
+            if self.resumed_at.is_some() {
+                return self.repaint_after_reset(new_frame, cursor_hint, park_hidden);
             }
 
             // For the first render, we need to claim space and write everything.
@@ -114,7 +210,7 @@ impl Engine {
             let escape_bytes = diff.to_escape_sequences(&mut self.cursor);
             output.extend_from_slice(&escape_bytes);
 
-            self.position_cursor(&mut output, cursor_hint);
+            self.position_cursor(&mut output, cursor_hint, park_hidden);
             self.prev_frame = Some(new_frame);
             return output;
         }
@@ -130,7 +226,7 @@ impl Engine {
             // Even if content didn't change, cursor position might have
             // (e.g., cursor moved within an input field)
             let mut output = Vec::new();
-            self.position_cursor(&mut output, cursor_hint);
+            self.position_cursor(&mut output, cursor_hint, park_hidden);
             self.prev_frame = Some(new_frame);
             return output;
         }
@@ -200,7 +296,7 @@ impl Engine {
         let escape_bytes = diff.to_escape_sequences(&mut self.cursor);
         output.extend_from_slice(&escape_bytes);
 
-        self.position_cursor(&mut output, cursor_hint);
+        self.position_cursor(&mut output, cursor_hint, park_hidden);
         self.prev_frame = Some(new_frame);
         output
     }
@@ -228,7 +324,86 @@ impl Engine {
         self.cursor = CursorState::new();
         self.prev_frame = None;
         self.emitted_rows = 0;
+        self.resumed_at = Some(0);
         output
+    }
+
+    /// [`reset_region`](Engine::reset_region) with ground truth: the
+    /// cursor's absolute screen position `(col, row)` (0-based) as
+    /// reported by the terminal *after* it reflowed for the new width.
+    ///
+    /// A stale-arithmetic erase after a reflow either starts too low
+    /// (leaving unrepaintable fragments above the region) or too high
+    /// (destroying committed rows). The report re-anchors us:
+    ///
+    /// - A parked cursor (hidden — presents without a cursor hint park
+    ///   it) sits on the region's top row, so the report *is* the erase
+    ///   target — exact on every terminal, reflowing or truncating.
+    /// - A visible cursor sits at the app's hint, and the distance up
+    ///   to the region top is recomputed from the previous frame: each
+    ///   region row is a hard line the terminal re-wraps at the new
+    ///   width, occupying `ceil(content/width)` physical rows, trailing
+    ///   blanks trimmed (terminals drop them when re-wrapping).
+    ///   Trimming errs toward starting the erase *lower*: a model
+    ///   mismatch leaves a stale fragment rather than destroying
+    ///   committed output. (Truncating terminals — xterm, urxvt,
+    ///   screen — don't re-wrap, so this path over-erases there; every
+    ///   terminal Atuin targets re-wraps, and the parked path is exact
+    ///   everywhere.)
+    ///
+    /// The erase then targets the region top absolutely, which also
+    /// stops the erase point from drifting across a resize drag.
+    pub fn reset_region_anchored(&mut self, new_width: u16, cursor: (u16, u16)) -> Vec<u8> {
+        let (_, cpr_row) = cursor;
+        let distance = if self.parked {
+            0
+        } else {
+            self.reflow_distance(new_width)
+        };
+
+        let start = (cpr_row as i32 - distance as i32).max(0);
+
+        let mut output = Vec::new();
+        output.extend_from_slice(format!("\x1b[{};1H", start + 1).as_bytes());
+        output.extend_from_slice(b"\x1b[J");
+
+        self.width = new_width;
+        self.cursor = CursorState::new();
+        self.prev_frame = None;
+        self.emitted_rows = 0;
+        self.resumed_at = Some(start.min(u16::MAX as i32) as u16);
+        output
+    }
+
+    /// Physical rows between the region top and the cursor after the
+    /// terminal re-wrapped our rows (each one a hard line, created by
+    /// its own linefeed) at `new_width`.
+    fn reflow_distance(&self, new_width: u16) -> u32 {
+        let new_width = new_width.max(1) as u32;
+        if new_width >= self.width as u32 {
+            // Hard lines never rejoin on widen; one physical row each.
+            return self.cursor.row as u32;
+        }
+        let prev_height = self
+            .prev_frame
+            .as_ref()
+            .map(|f| f.area().height)
+            .unwrap_or(0);
+        let mut distance: u32 = 0;
+        for row in 0..self.cursor.row {
+            let content = if row < prev_height {
+                self.prev_frame
+                    .as_ref()
+                    .map(|f| f.content_width_of_row(row) as u32)
+                    .unwrap_or(0)
+            } else {
+                // Claimed rows below the frame are blank.
+                0
+            };
+            distance += content.div_ceil(new_width).max(1);
+        }
+        // The cursor's own row: the fragment its column lands on.
+        distance + self.cursor.col as u32 / new_width
     }
 
     /// Reset for a width change: clear the visible screen (scrollback is
@@ -248,6 +423,7 @@ impl Engine {
         self.cursor = CursorState::new();
         self.prev_frame = None;
         self.emitted_rows = 0;
+        self.resumed_at = Some(0);
         b"\x1b[2J\x1b[H".to_vec()
     }
 
@@ -274,7 +450,7 @@ impl Engine {
             return Vec::new();
         }
 
-        let mut output = self.present(Frame::new(rows.clone()), None);
+        let mut output = self.present_inner(Frame::new(rows.clone()), None, false);
 
         // The next region origin is the row below the block. Make it
         // physically exist with the cursor on it before the shift: an LF
@@ -283,8 +459,8 @@ impl Engine {
         if self.cursor.row < committed_height {
             output.push(b'\r');
             self.cursor.col = 0;
-            let down = (committed_height - self.cursor.row) as usize;
-            output.resize(output.len() + down, b'\n');
+            let down = committed_height - self.cursor.row;
+            output.resize(output.len() + down as usize, b'\n');
             self.cursor.row = committed_height;
             self.emitted_rows = self.emitted_rows.max(committed_height + 1);
         }
@@ -428,14 +604,34 @@ impl Engine {
 
     /// Append escape sequences to position (and show) the terminal cursor
     /// at `hint` (`(col, row)`), or hide it when `hint` is `None`.
-    fn position_cursor(&mut self, output: &mut Vec<u8>, hint: Option<(u16, u16)>) {
+    fn position_cursor(
+        &mut self,
+        output: &mut Vec<u8>,
+        hint: Option<(u16, u16)>,
+        park_hidden: bool,
+    ) {
         if let Some((col, row)) = hint {
             crate::escape::write_relative_move(output, &mut self.cursor, row, col);
             // Show cursor at the component's cursor position
             output.extend_from_slice(b"\x1b[?25h");
-        } else {
-            // No cursor hint — hide cursor
+            self.parked = false;
+        } else if !park_hidden {
             output.extend_from_slice(b"\x1b[?25l");
+            self.parked = false;
+        } else {
+            // No cursor hint: hide the cursor and park it on the
+            // region's reachable top row. The position is invisible, but
+            // it makes a later resize's position report *be* the region
+            // top: the cursor rides its logical line through any reflow,
+            // and stays put in a truncating terminal — either way no
+            // arithmetic can drift. (Left at the last painted cell it
+            // would sit on the content's final row, which reflowing
+            // terminals pin to its screen row — a report from there is
+            // blind to re-wrapping above it.)
+            let top = self.emitted_rows.saturating_sub(self.terminal_height);
+            crate::escape::write_relative_move(output, &mut self.cursor, top, 0);
+            output.extend_from_slice(b"\x1b[?25l");
+            self.parked = true;
         }
     }
 }
@@ -462,10 +658,24 @@ mod tests {
     #[test]
     fn commit_scrolled_is_silent_when_cursor_below_origin() {
         let mut engine = Engine::new(10, 24);
-        let _ = engine.present(Frame::new(buffer_with_lines(10, &["aaa", "bbb"])), None);
-        // Cursor ended on the last diffed row (row 1), at/below origin 1.
+        // A visible cursor on row 1 sits at/below the new origin 1.
+        let _ = engine.present(
+            Frame::new(buffer_with_lines(10, &["aaa", "bbb"])),
+            Some((0, 1)),
+        );
         let bytes = engine.commit_scrolled(1);
         assert!(bytes.is_empty());
+        assert_eq!(engine.emitted_rows(), 1);
+    }
+
+    #[test]
+    fn commit_scrolled_moves_parked_cursor_to_origin() {
+        let mut engine = Engine::new(10, 24);
+        // No hint: the hidden cursor parks on the region top, above the
+        // new origin — the shift must move it down first.
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["aaa", "bbb"])), None);
+        let bytes = engine.commit_scrolled(1);
+        assert!(!bytes.is_empty());
         assert_eq!(engine.emitted_rows(), 1);
     }
 
@@ -516,10 +726,22 @@ mod tests {
             "sealing identical content must not repaint it, got {printable:?}"
         );
         assert!(
-            printable.ends_with("\r\n"),
+            printable.ends_with('\n'),
             "seal should end by claiming the origin row, got {printable:?}"
         );
         assert_eq!(engine.emitted_rows(), 1);
+    }
+
+    #[test]
+    fn zero_height_resize_does_not_panic() {
+        // Terminals can report a zero-height size mid-drag; the repaint
+        // must not underflow its row claim.
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["aaa", "bbb"])), None);
+        engine.set_terminal_height(0);
+        let _ = engine.reset_region_anchored(10, (0, 0));
+        let bytes = engine.present(Frame::new(buffer_with_lines(10, &["aaa", "bbb"])), None);
+        let _ = bytes;
     }
 
     #[test]

--- a/crates/eye_declare_engine/src/escape.rs
+++ b/crates/eye_declare_engine/src/escape.rs
@@ -50,18 +50,43 @@ impl Diff {
     /// end — the caller is responsible for positioning and showing the
     /// cursor afterward (e.g., at the focused input's cursor position).
     pub fn to_escape_sequences(&self, cursor: &mut CursorState) -> Vec<u8> {
-        if self.cells.is_empty() {
+        if self.cells.is_empty() && self.line_clears.is_empty() {
             return Vec::new();
         }
 
-        let mut out = Vec::with_capacity(self.cells.len() * 12);
+        let mut out = Vec::with_capacity(self.cells.len() * 12 + self.line_clears.len() * 8);
 
         // Begin synchronized update + hide cursor
         out.extend_from_slice(BSU);
         out.extend_from_slice(HIDE_CURSOR);
 
-        // Cells are already in (y, x) order from Buffer::diff's row-major iteration.
+        // Cells and line clears are each in (y, x) order; a row's clear
+        // anchor lies at or right of every kept cell on that row, so the
+        // merge below emits it after the row's cells.
+        let mut clears = self.line_clears.iter().peekable();
+        let write_clear = |out: &mut Vec<u8>, cursor: &mut CursorState, x: u16, y: u16| {
+            if cursor.row != y || cursor.col != x {
+                write_relative_move(out, cursor, y, x);
+            }
+            // EL fills with the current background (BCE); reset first so
+            // the erased cells are genuinely empty.
+            if cursor.style != Style::default() {
+                out.extend_from_slice(b"\x1b[0m");
+                cursor.style = Style::default();
+            }
+            out.extend_from_slice(b"\x1b[K");
+        };
+
         for (x, y, cell) in &self.cells {
+            while let Some(&&(cx, cy)) = clears.peek() {
+                if (cy, cx) < (*y, *x) {
+                    write_clear(&mut out, cursor, cx, cy);
+                    clears.next();
+                } else {
+                    break;
+                }
+            }
+
             let target_row = *y;
             let target_col = *x;
 
@@ -83,6 +108,9 @@ impl Diff {
             // Advance cursor column by the symbol's display width
             let width = unicode_display_width(symbol);
             cursor.col = cursor.col.saturating_add(width as u16);
+        }
+        for &(cx, cy) in clears {
+            write_clear(&mut out, cursor, cx, cy);
         }
 
         // Reset style so we don't leak into terminal
@@ -152,9 +180,14 @@ pub fn write_committed_row<'a>(
     cursor.col = 0;
 
     let cells: Vec<&Cell> = cells.into_iter().collect();
+    // Note `Cell::default().style()`, not `Style::default()`: a cell
+    // reports explicit `Reset` colors, which the bare style never
+    // equals — comparing against the wrong one keeps every trailing
+    // blank and streams full-width rows into scrollback.
+    let blank_style = Cell::default().style();
     let mut last_nonblank = None;
     for (i, cell) in cells.iter().enumerate() {
-        if cell.symbol() != " " || cell.style() != Style::default() {
+        if cell.symbol() != " " || cell.style() != blank_style {
             last_nonblank = Some(i);
         }
     }
@@ -410,6 +443,7 @@ mod tests {
     fn empty_diff_produces_no_output() {
         let diff = Diff {
             cells: vec![],
+            line_clears: vec![],
             new_area: Rect::new(0, 0, 5, 1),
             prev_area: Rect::new(0, 0, 5, 1),
         };

--- a/crates/eye_declare_engine/src/frame.rs
+++ b/crates/eye_declare_engine/src/frame.rs
@@ -1,6 +1,7 @@
 use ratatui_core::{
     buffer::{Buffer, Cell},
     layout::Rect,
+    style::Style,
 };
 
 /// The output of a render pass. Owns the buffer.
@@ -39,6 +40,25 @@ impl Frame {
         );
     }
 
+    /// The row's rendered width up to its last non-blank cell — the
+    /// content a reflowing terminal re-wraps when the width shrinks
+    /// (terminals drop trailing blanks when re-wrapping, whether the
+    /// cells were written or erased).
+    pub fn content_width_of_row(&self, row: u16) -> u16 {
+        let area = self.buffer.area;
+        if row >= area.height {
+            return 0;
+        }
+        for x in (0..area.width).rev() {
+            let symbol = self.buffer[(x, row)].symbol();
+            if symbol != " " {
+                let width = unicode_width::UnicodeWidthStr::width(symbol).max(1) as u16;
+                return (x + width).min(area.width);
+            }
+        }
+        0
+    }
+
     /// Diff against a previous frame, producing the set of changed cells.
     ///
     /// Handles height mismatches: if the frames have different heights,
@@ -67,11 +87,7 @@ impl Frame {
                 .into_iter()
                 .map(|(x, y, cell)| (x, y, cell.clone()))
                 .collect();
-            return Diff {
-                cells: changes,
-                new_area,
-                prev_area,
-            };
+            return self.build_diff(changes, prev_area);
         }
 
         // Heights differ — compare directly without allocating padded buffers.
@@ -117,8 +133,65 @@ impl Frame {
             }
         }
 
+        self.build_diff(changes, prev_area)
+    }
+
+    /// Build a [`Diff`], lifting each row's trailing run of blank
+    /// default-styled cell writes into a line clear.
+    ///
+    /// Writing spaces to clear old content plants real cells the
+    /// terminal treats as content — they re-wrap on resize (phantom
+    /// blank fragments) and pad committed rows in scrollback. An
+    /// erase-to-end-of-line leaves genuinely empty cells (and is far
+    /// fewer bytes). A run is only lifted when everything to its right
+    /// in the new frame is blank and default-styled, so the erase can't
+    /// eat styled cells that aren't repainted.
+    fn build_diff(&self, cells: Vec<(u16, u16, Cell)>, prev_area: Rect) -> Diff {
+        let new_area = self.buffer.area;
+        // A default cell's style, for blankness checks — `Cell::style()`
+        // reports explicit `Reset` colors, which a bare
+        // `Style::default()` (all `None`) never equals.
+        let blank_style: Style = Cell::default().style();
+        // Per new-frame row: index one past the last cell that must
+        // survive an erase (non-space symbol or non-default style).
+        let boundary = |y: u16| -> u16 {
+            if y >= new_area.height {
+                return 0;
+            }
+            for x in (0..new_area.width).rev() {
+                let cell = &self.buffer[(x, y)];
+                if cell.symbol() != " " || cell.style() != blank_style {
+                    return x + 1;
+                }
+            }
+            0
+        };
+
+        let mut kept = Vec::with_capacity(cells.len());
+        let mut line_clears: Vec<(u16, u16)> = Vec::new();
+        let mut current_boundary: Option<(u16, u16)> = None;
+        for (x, y, cell) in cells {
+            let b = match current_boundary {
+                Some((row, b)) if row == y => b,
+                _ => {
+                    let b = boundary(y);
+                    current_boundary = Some((y, b));
+                    b
+                }
+            };
+            if x >= b && cell.symbol() == " " && cell.style() == blank_style {
+                match line_clears.last_mut() {
+                    Some((cx, cy)) if *cy == y => *cx = (*cx).min(x),
+                    _ => line_clears.push((x, y)),
+                }
+            } else {
+                kept.push((x, y, cell));
+            }
+        }
+
         Diff {
-            cells: changes,
+            cells: kept,
+            line_clears,
             new_area,
             prev_area,
         }
@@ -129,6 +202,11 @@ impl Frame {
 pub struct Diff {
     /// Changed cells: (x, y, new_cell).
     pub cells: Vec<(u16, u16, Cell)>,
+    /// Erase-to-end-of-line anchors, row-major: at `(x, y)`, everything
+    /// from `x` rightward is blank in the new frame and cleared with EL
+    /// instead of written spaces — written blanks are content a
+    /// reflowing terminal re-wraps; erased cells are not.
+    pub line_clears: Vec<(u16, u16)>,
     /// The area of the new (current) frame.
     pub new_area: Rect,
     /// The area of the previous frame.
@@ -160,7 +238,7 @@ impl Frame {
 impl Diff {
     /// Whether there are no changes.
     pub fn is_empty(&self) -> bool {
-        self.cells.is_empty()
+        self.cells.is_empty() && self.line_clears.is_empty()
     }
 
     /// Number of changed cells.
@@ -187,6 +265,7 @@ impl Diff {
     pub fn retain_visible(&mut self, min_row: u16) {
         if min_row > 0 {
             self.cells.retain(|(_, y, _)| *y >= min_row);
+            self.line_clears.retain(|(_, y)| *y >= min_row);
         }
     }
 }
@@ -204,6 +283,41 @@ mod tests {
         let f2 = make_frame(&["hello", "world"]);
         let diff = f2.diff(&f1);
         assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn diff_lifts_trailing_blank_writes_into_line_clear() {
+        let f1 = make_frame(&["hello world"]);
+        let f2 = make_frame(&["hi         "]);
+        let diff = f2.diff(&f1);
+        // 'i' is written; the old "llo world" tail becomes one erase
+        // instead of nine space cells the terminal would treat as
+        // content.
+        assert_eq!(diff.line_clears, vec![(2, 0)]);
+        assert!(
+            diff.cells
+                .iter()
+                .all(|(x, _, c)| *x < 2 || c.symbol() != " "),
+            "no blank writes past the content boundary"
+        );
+    }
+
+    #[test]
+    fn diff_keeps_styled_blank_cells() {
+        use ratatui_core::style::{Color, Style};
+        let f1 = make_frame(&["hello world"]);
+        let mut f2 = make_frame(&["hi         "]);
+        // A styled blank cell (e.g. highlighted padding) must be painted,
+        // and the erase may only cover what lies right of it.
+        f2.buffer[(5, 0)].set_style(Style::default().bg(Color::Blue));
+        let diff = f2.diff(&f1);
+        assert!(
+            diff.cells
+                .iter()
+                .any(|(x, _, c)| *x == 5 && c.symbol() == " "),
+            "styled blank is written"
+        );
+        assert!(diff.line_clears.iter().all(|&(x, _)| x > 5));
     }
 
     #[test]
@@ -243,8 +357,9 @@ mod tests {
         let f2 = make_frame(&["hello"]);
         let diff = f2.diff(&f1);
         assert!(!diff.grew());
-        // The removed row should show as changed (cleared to empty)
-        let removed_row_cells: Vec<_> = diff.cells.iter().filter(|(_, y, _)| *y == 1).collect();
-        assert!(!removed_row_cells.is_empty());
+        // The removed row is cleared with a single erase-to-end-of-line
+        // from column 0, not a run of written spaces.
+        assert!(diff.cells.iter().all(|(_, y, _)| *y != 1));
+        assert_eq!(diff.line_clears, vec![(0, 1)]);
     }
 }

--- a/crates/eye_declare_engine/src/test_terminal.rs
+++ b/crates/eye_declare_engine/src/test_terminal.rs
@@ -18,7 +18,17 @@ pub struct TestTerminal {
     cursor_col: usize,
     pending_wrap: bool,
     viewport: Vec<Vec<char>>,
-    scrollback: Vec<String>,
+    /// Per-viewport-row soft-wrap flag: `wrapped[r]` means row `r`
+    /// overflowed and continues on row `r + 1` (set only by auto-wrap,
+    /// never by an explicit linefeed). This is what lets
+    /// [`resize_reflow`](TestTerminal::resize_reflow) rejoin lines the
+    /// way reflowing terminals do.
+    wrapped: Vec<bool>,
+    /// Rows scrolled out the top, oldest first, with their soft-wrap
+    /// flags — kept as raw cells so [`resize_reflow`](TestTerminal::resize_reflow)
+    /// can rejoin them and pull them back on widen, as real reflowing
+    /// terminals do.
+    scrollback: Vec<(Vec<char>, bool)>,
 }
 
 impl TestTerminal {
@@ -31,6 +41,7 @@ impl TestTerminal {
             cursor_col: 0,
             pending_wrap: false,
             viewport: vec![vec![' '; width]; height],
+            wrapped: vec![false; height],
             scrollback: Vec::new(),
         }
     }
@@ -45,7 +56,10 @@ impl TestTerminal {
     /// Lines that have scrolled out of the viewport, oldest first.
     /// Trailing whitespace is trimmed.
     pub fn scrollback_lines(&self) -> Vec<String> {
-        self.scrollback.clone()
+        self.scrollback
+            .iter()
+            .map(|(cells, _)| trimmed_line(cells))
+            .collect()
     }
 
     /// The current viewport contents, top to bottom, trailing whitespace
@@ -68,8 +82,10 @@ impl TestTerminal {
         }
         if self.cursor_row + 1 >= self.height {
             let top = self.viewport.remove(0);
-            self.scrollback.push(trimmed_line(&top));
+            let flag = self.wrapped.remove(0);
+            self.scrollback.push((top, flag));
             self.viewport.push(vec![' '; self.width]);
+            self.wrapped.push(false);
             self.cursor_row = self.height - 1;
         } else {
             self.cursor_row += 1;
@@ -92,7 +108,10 @@ impl TestTerminal {
         }
         if self.pending_wrap || self.cursor_col + char_width > self.width {
             // Auto-wrap, including a wide glyph that would straddle the
-            // right edge: terminals push it whole onto the next row.
+            // right edge: terminals push it whole onto the next row. The
+            // row being left records the soft wrap (before linefeed —
+            // a scroll at the bottom shifts the flags too).
+            self.wrapped[self.cursor_row] = true;
             self.linefeed();
             self.cursor_col = 0;
         }
@@ -160,17 +179,149 @@ impl TestTerminal {
 
         while self.viewport.len() > height && self.cursor_row + 1 > height {
             let top = self.viewport.remove(0);
-            self.scrollback.push(trimmed_line(&top));
+            let flag = self.wrapped.remove(0);
+            self.scrollback.push((top, flag));
             self.cursor_row -= 1;
         }
         self.viewport.truncate(height);
+        self.wrapped.truncate(height);
         while self.viewport.len() < height {
             self.viewport.push(vec![' '; width]);
+            self.wrapped.push(false);
         }
         self.height = height;
 
         self.cursor_col = self.cursor_col.min(width.saturating_sub(1));
         self.cursor_row = self.cursor_row.min(height.saturating_sub(1));
+        self.pending_wrap = false;
+    }
+
+    /// Change dimensions the way reflowing terminals (Ghostty, kitty,
+    /// iTerm2, WezTerm, tmux, …) do: scrollback and viewport re-wrap as
+    /// one document — soft-wrapped rows rejoin into logical lines,
+    /// logical lines re-wrap at the new width — and the *content end
+    /// stays pinned to its screen row*: on narrow the growth scrolls out
+    /// the top (even with blank rows below), on widen rows are pulled
+    /// back from scrollback. The cursor follows its logical position.
+    /// (Verified against tmux 3.6; Ghostty and kitty behave the same
+    /// way.) Rows created by explicit linefeeds are hard lines and never
+    /// rejoin.
+    ///
+    /// Model notes, matching common terminal behavior closely enough for
+    /// engine tests:
+    /// - Trailing blank cells of a hard line are trimmed before
+    ///   re-wrapping (so a blank row stays one row at any width).
+    /// - Trailing all-blank rows below the content and cursor don't
+    ///   count as content (they never push anything into scrollback).
+    /// - Wide glyphs may be split at the wrap point (real terminals push
+    ///   them whole); keep test content narrow-glyph-only near edges.
+    pub fn resize_reflow(&mut self, width: usize, height: usize) {
+        // The whole document: scrollback rows, then viewport rows. The
+        // cursor is a document row index from here on.
+        let mut doc: Vec<(Vec<char>, bool)> = std::mem::take(&mut self.scrollback);
+        let sb_len = doc.len();
+        for (row, flag) in self.viewport.drain(..).zip(self.wrapped.drain(..)) {
+            doc.push((row, flag));
+        }
+        let cursor_doc = sb_len + self.cursor_row;
+
+        // Drop trailing blank rows that hold neither content nor cursor.
+        let mut used = doc.len();
+        while used > cursor_doc + 1
+            && used > 0
+            && trimmed_line(&doc[used - 1].0).is_empty()
+            && !doc[used - 1].1
+        {
+            used -= 1;
+        }
+        // How far the content end sat above the bottom of the screen —
+        // reflowing terminals preserve this gap exactly.
+        let bottom_gap = (self.height + sb_len).saturating_sub(used);
+
+        // Rejoin soft-wrapped rows into logical lines. A wrapped row
+        // contributes its full width (it overflowed, so it is full);
+        // the final hard fragment is trimmed.
+        let mut lines: Vec<Vec<char>> = Vec::new();
+        let mut cursor_line = 0;
+        let mut cursor_offset = 0;
+        let mut current: Vec<char> = Vec::new();
+        for (row, (cells, wrapped)) in doc.iter().take(used).enumerate() {
+            if row == cursor_doc {
+                cursor_line = lines.len();
+                cursor_offset = current.len() + self.cursor_col;
+            }
+            if *wrapped {
+                current.extend(cells.iter().copied());
+            } else {
+                let mut tail = cells.clone();
+                while tail.last() == Some(&' ') {
+                    tail.pop();
+                }
+                current.extend(tail);
+                lines.push(std::mem::take(&mut current));
+            }
+        }
+        if !current.is_empty() {
+            lines.push(current);
+        }
+        if lines.is_empty() {
+            lines.push(Vec::new());
+        }
+
+        // Re-wrap each logical line at the new width.
+        let mut rows: Vec<(Vec<char>, bool)> = Vec::new();
+        let mut cursor_new = (0, 0);
+        for (i, line) in lines.iter().enumerate() {
+            let start = rows.len();
+            let mut chunks: Vec<&[char]> = line.chunks(width.max(1)).collect();
+            if chunks.is_empty() {
+                chunks.push(&[]);
+            }
+            let n = chunks.len();
+            for (j, chunk) in chunks.into_iter().enumerate() {
+                let mut row: Vec<char> = chunk.to_vec();
+                row.resize(width, ' ');
+                rows.push((row, j + 1 < n));
+            }
+            if i == cursor_line {
+                let frag = (cursor_offset / width.max(1)).min(n - 1);
+                cursor_new = (
+                    start + frag,
+                    (cursor_offset - frag * width.max(1)).min(width.saturating_sub(1)),
+                );
+            }
+        }
+
+        // Pin the content end: the first visible document row is chosen
+        // so the last content row keeps its distance from the screen
+        // bottom (until scrollback runs dry), while keeping the cursor
+        // on screen.
+        let visible_below_end = height.saturating_sub(bottom_gap).max(1);
+        let mut first_visible = rows.len().saturating_sub(visible_below_end);
+        first_visible = first_visible.min(cursor_new.0);
+        if cursor_new.0 - first_visible >= height {
+            first_visible = cursor_new.0 + 1 - height;
+        }
+
+        self.scrollback = rows.drain(..first_visible).collect();
+        self.viewport = Vec::with_capacity(height);
+        self.wrapped = Vec::with_capacity(height);
+        for (row, flag) in rows {
+            if self.viewport.len() == height {
+                break;
+            }
+            self.viewport.push(row);
+            self.wrapped.push(flag);
+        }
+        while self.viewport.len() < height {
+            self.viewport.push(vec![' '; width]);
+            self.wrapped.push(false);
+        }
+
+        self.width = width;
+        self.height = height;
+        self.cursor_row = cursor_new.0 - first_visible;
+        self.cursor_col = cursor_new.1;
         self.pending_wrap = false;
     }
 
@@ -258,9 +409,31 @@ impl vte::Perform for TestTerminal {
                 self.pending_wrap = false;
             }
             'H' => {
-                self.cursor_row = 0;
-                self.cursor_col = 0;
+                // CUP: 1-based `row;col`, both defaulting to 1.
+                let mut values = params.iter();
+                let row = values
+                    .next()
+                    .and_then(|v| v.first().copied())
+                    .map(usize::from)
+                    .filter(|&n| n > 0)
+                    .unwrap_or(1);
+                let col = values
+                    .next()
+                    .and_then(|v| v.first().copied())
+                    .map(usize::from)
+                    .filter(|&n| n > 0)
+                    .unwrap_or(1);
+                self.cursor_row = (row - 1).min(self.height.saturating_sub(1));
+                self.cursor_col = (col - 1).min(self.width.saturating_sub(1));
                 self.pending_wrap = false;
+            }
+            'K' => {
+                // EL 0: erase cursor to end of line. Breaks the row's
+                // continuation, like real reflowing terminals.
+                for col in self.cursor_col..self.width {
+                    self.viewport[self.cursor_row][col] = ' ';
+                }
+                self.wrapped[self.cursor_row] = false;
             }
             'J' => {
                 for row in self.cursor_row..self.height {
@@ -272,6 +445,9 @@ impl vte::Perform for TestTerminal {
                     for col in start_col..self.width {
                         self.viewport[row][col] = ' ';
                     }
+                    // Erasing a row's tail breaks its continuation onto
+                    // the next row, as in real reflowing terminals.
+                    self.wrapped[row] = false;
                 }
             }
             'h' | 'l' | 'm' => {}

--- a/crates/eye_declare_engine/tests/resize_reflow.rs
+++ b/crates/eye_declare_engine/tests/resize_reflow.rs
@@ -1,0 +1,360 @@
+//! Resize behavior against a *reflowing* terminal (Ghostty, kitty,
+//! iTerm2, WezTerm…). The engine's committed rows must survive width
+//! changes: they are immutable and can never be repainted, so erasing
+//! one is permanent data loss for the user.
+//!
+//! Each test mirrors the runtime's real call order on `Event::Resize`:
+//! the terminal reflows first (that's what a resize *is* from the
+//! app's point of view), then `set_terminal_height` + `reset_region` +
+//! a fresh `present` at the new width.
+
+use eye_declare_engine::Engine;
+use eye_declare_engine::frame::Frame;
+use eye_declare_engine::test_terminal::TestTerminal;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+fn buffer_with_lines(width: u16, lines: &[String]) -> Buffer {
+    let mut buf = Buffer::empty(Rect::new(0, 0, width, lines.len() as u16));
+    for (y, line) in lines.iter().enumerate() {
+        buf.set_stringn(
+            0,
+            y as u16,
+            line,
+            width as usize,
+            ratatui_core::style::Style::default(),
+        );
+    }
+    buf
+}
+
+/// An Atuin-AI-shaped live tail: a full-width bordered input box plus a
+/// status line. The border rows span the entire width, so they re-wrap
+/// on narrow — the geometry that breaks stale row arithmetic.
+fn tail_lines(w: usize) -> Vec<String> {
+    vec![
+        format!("┌{}┐", "─".repeat(w - 2)),
+        format!("│ Type a message...{}│", " ".repeat(w - 20)),
+        format!("└{}┘", "─".repeat(w - 2)),
+        " Model: balanced".to_string(),
+    ]
+}
+
+const COMMITTED: [&str; 4] = [" You", "  Hello!", " Atuin AI", "  Hey there!"];
+
+struct Sim {
+    term: TestTerminal,
+    engine: Engine,
+    height: usize,
+    /// Cursor hint for presents: `Some` = visible cursor in the input
+    /// (wrap-model resize path), `None` = hidden cursor parked on the
+    /// region top (report-is-the-answer resize path, what Atuin AI's
+    /// custom-drawn cursor uses).
+    hint: Option<(u16, u16)>,
+}
+
+impl Sim {
+    /// Paint the committed conversation and the live tail at `width`.
+    fn start(width: usize, height: usize) -> Self {
+        Self::start_with_hint(width, height, Some((3, 1)))
+    }
+
+    fn start_with_hint(width: usize, height: usize, hint: Option<(u16, u16)>) -> Self {
+        let mut sim = Sim {
+            term: TestTerminal::new(width, height),
+            engine: Engine::new(width as u16, height as u16),
+            height,
+            hint,
+        };
+        let committed: Vec<String> = COMMITTED.iter().map(|s| s.to_string()).collect();
+        let bytes = sim
+            .engine
+            .commit(&buffer_with_lines(width as u16, &committed));
+        sim.term.feed(&bytes);
+        sim.present_tail(width);
+        sim
+    }
+
+    fn present_tail(&mut self, width: usize) {
+        let tail = buffer_with_lines(width as u16, &tail_lines(width));
+        let bytes = self.engine.present(Frame::new(tail), self.hint);
+        self.term.feed(&bytes);
+    }
+
+    /// One user resize: the terminal reflows, then the app reacts the
+    /// way `Runtime::resize_anchored` does — querying the (post-reflow)
+    /// cursor position and re-anchoring the erase on it.
+    fn resize(&mut self, width: usize) {
+        self.term.resize_reflow(width, self.height);
+        self.engine.set_terminal_height(self.height as u16);
+        let (row, col) = self.term.cursor();
+        let bytes = self
+            .engine
+            .reset_region_anchored(width as u16, (col as u16, row as u16));
+        self.term.feed(&bytes);
+        self.present_tail(width);
+    }
+
+    /// Everything on the terminal, scrollback then viewport.
+    fn all_lines(&self) -> Vec<String> {
+        let mut lines = self.term.scrollback_lines();
+        lines.extend(self.term.viewport_lines());
+        lines
+    }
+
+    fn assert_committed_intact(&self, context: &str) {
+        let all = self.all_lines();
+        for line in COMMITTED {
+            assert_eq!(
+                all.iter().filter(|l| l.as_str() == line).count(),
+                1,
+                "{context}: committed line {line:?} must appear exactly once, screen:\n{}",
+                self.all_lines().join("\n")
+            );
+        }
+    }
+
+    /// The terminal document (scrollback then viewport, trailing blanks
+    /// dropped) must be exactly: committed conversation, then the tail
+    /// at the current width — no stale fragments, no duplicates.
+    /// Committed rows may sit in scrollback: reflowing terminals pin the
+    /// content end and scroll them out on narrow, and the erase+repaint
+    /// leaves hard lines the terminal won't pull back on widen.
+    fn assert_document_exact(&self, width: usize) {
+        let mut expected: Vec<String> = COMMITTED.iter().map(|s| s.to_string()).collect();
+        expected.extend(tail_lines(width).iter().map(|l| l.trim_end().to_string()));
+        let mut actual = self.all_lines();
+        while actual.last().is_some_and(|l| l.is_empty()) {
+            actual.pop();
+        }
+        assert_eq!(actual, expected, "document after resize to width {width}");
+    }
+}
+
+#[test]
+fn narrow_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 12);
+    sim.resize(34);
+    sim.assert_committed_intact("after narrow 40->34");
+    sim.assert_document_exact(34);
+}
+
+#[test]
+fn widen_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 12);
+    sim.resize(46);
+    sim.assert_committed_intact("after widen 40->46");
+    sim.assert_document_exact(46);
+}
+
+#[test]
+fn widen_after_narrow_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 12);
+    sim.resize(34);
+    sim.assert_committed_intact("after narrow 40->34");
+    sim.resize(40);
+    sim.assert_committed_intact("after widen back 34->40");
+    sim.assert_document_exact(40);
+}
+
+/// Consecutive drag steps on a content-end-pinning terminal can push a
+/// border fragment of the old region into scrollback *before* the erase
+/// runs — those rows are physically unreachable, so a drag may orphan
+/// fragments in history. The screen itself must stay clean: committed
+/// rows intact, and the viewport showing exactly one tail.
+fn assert_viewport_clean(sim: &Sim, width: usize) {
+    let mut vp = sim.term.viewport_lines();
+    while vp.last().is_some_and(|l| l.is_empty()) {
+        vp.pop();
+    }
+    let tail: Vec<String> = tail_lines(width)
+        .iter()
+        .map(|l| l.trim_end().to_string())
+        .collect();
+    assert!(
+        vp.len() >= tail.len() && vp[vp.len() - tail.len()..] == tail[..],
+        "viewport must end with exactly the tail at width {width}, got:\n{}",
+        vp.join("\n")
+    );
+    let box_tops = vp.iter().filter(|l| l.starts_with('┌')).count();
+    assert_eq!(
+        box_tops,
+        1,
+        "exactly one box top on screen, got:\n{}",
+        vp.join("\n")
+    );
+}
+
+#[test]
+fn drag_narrow_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 12);
+    for w in [38, 36, 34, 32, 30] {
+        sim.resize(w);
+        sim.assert_committed_intact(&format!("during drag at width {w}"));
+    }
+    assert_viewport_clean(&sim, 30);
+}
+
+#[test]
+fn drag_narrow_then_widen_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 12);
+    for w in [36, 32, 30, 34, 38, 40] {
+        sim.resize(w);
+        sim.assert_committed_intact(&format!("during drag at width {w}"));
+    }
+    assert_viewport_clean(&sim, 40);
+}
+
+/// A session whose screen is already full (shell history above the app):
+/// commits and presents scroll the terminal, and on narrow the scroll can
+/// cancel the growth signal. Committed rows must never be lost — at worst
+/// they scroll into scrollback; a stale fragment above the tail is
+/// tolerated in this edge, destroyed history is not.
+#[test]
+fn full_screen_drag_never_loses_committed_rows() {
+    let width = 40;
+    let height = 12;
+    let mut sim = Sim {
+        term: TestTerminal::new(width, height),
+        engine: Engine::new(width as u16, height as u16),
+        height,
+        hint: Some((3, 1)),
+    };
+    // Fill the screen with shell history so the app starts at the bottom.
+    for i in 0..height - 1 {
+        sim.term.feed(format!("hist {i}\r\n").as_bytes());
+    }
+    let committed: Vec<String> = COMMITTED.iter().map(|s| s.to_string()).collect();
+    let bytes = sim
+        .engine
+        .commit(&buffer_with_lines(width as u16, &committed));
+    sim.term.feed(&bytes);
+    sim.present_tail(width);
+    sim.assert_committed_intact("before resizing");
+
+    for w in [36, 32, 30, 34, 38, 40] {
+        sim.resize(w);
+        sim.assert_committed_intact(&format!("during full-screen drag at width {w}"));
+    }
+}
+
+/// A terminal that does NOT reflow on resize (xterm-style truncation),
+/// with a hidden cursor parked on the region top: the position report
+/// is the region top on any terminal, so the erase stays exact.
+#[test]
+fn non_reflowing_terminal_stays_exact_when_parked() {
+    let mut sim = Sim::start_with_hint(40, 12, None);
+    for w in [34_usize, 30, 36, 40] {
+        sim.term.resize(w, 12); // truncating resize, no reflow
+        sim.engine.set_terminal_height(12);
+        let (row, col) = sim.term.cursor();
+        let bytes = sim
+            .engine
+            .reset_region_anchored(w as u16, (col as u16, row as u16));
+        sim.term.feed(&bytes);
+        sim.present_tail(w);
+        sim.assert_committed_intact(&format!("no-reflow terminal at width {w}"));
+    }
+    sim.assert_document_exact(40);
+}
+
+/// The Atuin AI shape: the app draws its own cursor glyph and passes no
+/// hint, so the hidden cursor parks on the region top and every resize
+/// report is the erase target directly — exact even when the reflow
+/// pins the content end (where a cursor left on the last row would
+/// make the report useless).
+#[test]
+fn parked_cursor_drag_stays_exact_on_reflow_terminal() {
+    let mut sim = Sim::start_with_hint(40, 12, None);
+    for w in [38, 36, 34, 32, 30, 34, 38, 40] {
+        sim.resize(w);
+        sim.assert_committed_intact(&format!("parked drag at width {w}"));
+    }
+    sim.assert_document_exact(40);
+}
+
+/// Without a startup anchor (a custom driver that never reported the
+/// cursor), the anchored resize can't detect reflow and must fall back
+/// to the never-destructive assumption: committed rows survive narrow,
+/// possibly at the cost of a stale fragment above the tail.
+#[test]
+fn unanchored_fallback_never_destroys() {
+    let width = 40;
+    let height = 12;
+    let mut sim = Sim {
+        term: TestTerminal::new(width, height),
+        engine: Engine::new(width as u16, height as u16),
+        height,
+        hint: Some((3, 1)),
+    };
+    let committed: Vec<String> = COMMITTED.iter().map(|s| s.to_string()).collect();
+    let bytes = sim
+        .engine
+        .commit(&buffer_with_lines(width as u16, &committed));
+    sim.term.feed(&bytes);
+    sim.present_tail(width);
+
+    for w in [34, 30, 36, 40] {
+        sim.resize(w);
+        sim.assert_committed_intact(&format!("unanchored at width {w}"));
+    }
+}
+
+/// Width and height changing together (the common case for a corner
+/// drag). The reflow happens at the new width while the height shrinks
+/// past the content.
+#[test]
+fn narrow_with_height_shrink_keeps_committed_rows() {
+    let mut sim = Sim::start(40, 16);
+    sim.term.resize_reflow(34, 11);
+    sim.height = 11;
+    sim.engine.set_terminal_height(11);
+    let (row, col) = sim.term.cursor();
+    let bytes = sim
+        .engine
+        .reset_region_anchored(34, (col as u16, row as u16));
+    sim.term.feed(&bytes);
+    sim.present_tail(34);
+    sim.assert_committed_intact("after narrow + height shrink");
+}
+
+/// A tail taller than the screen (window shrunk under the input UI).
+/// Resize repaints must not re-stream the overflow into scrollback —
+/// before the resumed-repaint path, every drag event dumped a
+/// screenful of duplicate rows into history and scrolled the screen.
+#[test]
+fn oversized_tail_resize_does_not_duplicate() {
+    let width = 40;
+    let height = 8;
+    let mut term = TestTerminal::new(width, height);
+    let mut engine = Engine::new(width as u16, height as u16);
+
+    let tall: Vec<String> = (0..12).map(|i| format!("tail row {i}")).collect();
+    term.feed(&engine.present(Frame::new(buffer_with_lines(width as u16, &tall)), None));
+    let baseline = term.scrollback_lines().len();
+
+    for w in [36_usize, 32, 36, 40] {
+        term.resize_reflow(w, height);
+        engine.set_terminal_height(height as u16);
+        let (row, col) = term.cursor();
+        let bytes = engine.reset_region_anchored(w as u16, (col as u16, row as u16));
+        term.feed(&bytes);
+        let bytes = engine.present(Frame::new(buffer_with_lines(w as u16, &tall)), None);
+        term.feed(&bytes);
+
+        // The visible screen is the bottom window of the tail.
+        assert_eq!(
+            term.viewport_lines(),
+            tall[4..].to_vec(),
+            "screen shows the tail's last rows at width {w}"
+        );
+    }
+    // No overflow re-streamed: scrollback growth stays bounded (reflow
+    // may shuffle a few rows, never a screenful per event).
+    let growth = term.scrollback_lines().len().saturating_sub(baseline);
+    assert!(
+        growth <= 2,
+        "scrollback grew by {growth} rows across 4 resizes:\n{}",
+        term.scrollback_lines().join("\n")
+    );
+}

--- a/crates/eye_declare_engine/tests/test_terminal_behavior.rs
+++ b/crates/eye_declare_engine/tests/test_terminal_behavior.rs
@@ -125,3 +125,78 @@ fn resize_height_grow_adds_blank_rows_below() {
     assert_eq!(term.viewport_lines(), vec!["a", "b", "", ""]);
     assert_eq!(term.cursor(), (1, 1));
 }
+
+#[test]
+fn reflow_narrow_splits_hard_line() {
+    let mut term = TestTerminal::new(8, 4);
+    term.feed(b"abcdefgh\r\nxy");
+    term.resize_reflow(4, 4);
+    // The content end keeps its screen row (tmux-verified): the growth
+    // scrolls out the top even though blank rows remain below.
+    assert_eq!(term.scrollback_lines(), vec!["abcd"]);
+    assert_eq!(term.viewport_lines(), vec!["efgh", "xy", "", ""]);
+    assert_eq!(term.cursor(), (1, 2));
+}
+
+#[test]
+fn reflow_widen_rejoins_soft_wrapped_line() {
+    let mut term = TestTerminal::new(4, 4);
+    term.feed(b"abcdef");
+    assert_eq!(term.cursor(), (1, 2));
+    term.resize_reflow(8, 4);
+    assert_eq!(term.viewport_lines(), vec!["abcdef", "", "", ""]);
+    // Offset 6 within the rejoined logical line.
+    assert_eq!(term.cursor(), (0, 6));
+}
+
+#[test]
+fn reflow_widen_does_not_rejoin_hard_lines() {
+    let mut term = TestTerminal::new(4, 4);
+    term.feed(b"abcd\r\nef");
+    term.resize_reflow(8, 4);
+    assert_eq!(term.viewport_lines(), vec!["abcd", "ef", "", ""]);
+    assert_eq!(term.cursor(), (1, 2));
+}
+
+#[test]
+fn reflow_narrow_overflow_scrolls_top_into_scrollback() {
+    let mut term = TestTerminal::new(6, 3);
+    term.feed(b"aaaaaa\r\nbbb\r\nccc");
+    term.resize_reflow(3, 3);
+    assert_eq!(term.scrollback_lines(), vec!["aaa"]);
+    assert_eq!(term.viewport_lines(), vec!["aaa", "bbb", "ccc"]);
+    assert_eq!(term.cursor(), (2, 2));
+}
+
+#[test]
+fn reflow_blank_rows_stay_single_at_any_width() {
+    let mut term = TestTerminal::new(8, 5);
+    term.feed(b"top\r\n\r\nbottom");
+    term.resize_reflow(4, 5);
+    // Blank line stays one row; content-end pinning scrolls "top" out.
+    assert_eq!(term.scrollback_lines(), vec!["top"]);
+    assert_eq!(term.viewport_lines(), vec!["", "bott", "om", "", ""]);
+}
+
+#[test]
+fn reflow_widen_pulls_rows_back_from_scrollback() {
+    let mut term = TestTerminal::new(8, 4);
+    term.feed(b"abcdefgh\r\nxy");
+    term.resize_reflow(4, 4); // "abcd" scrolls out (content-end pinned)
+    term.resize_reflow(8, 4); // rejoins and comes back down
+    assert_eq!(term.scrollback_lines(), Vec::<String>::new());
+    assert_eq!(term.viewport_lines(), vec!["abcdefgh", "xy", "", ""]);
+    assert_eq!(term.cursor(), (1, 2));
+}
+
+#[test]
+fn reflow_erase_breaks_soft_link() {
+    let mut term = TestTerminal::new(4, 4);
+    term.feed(b"abcdef");
+    // Move to the start of the soft-wrapped first row and erase below:
+    // the wrap link must not survive into the next reflow.
+    term.feed(b"\x1b[H\x1b[J");
+    term.feed(b"xy");
+    term.resize_reflow(8, 4);
+    assert_eq!(term.viewport_lines(), vec!["xy", "", "", ""]);
+}


### PR DESCRIPTION
Resizing the terminal destroyed inline apps: committed rows vanished or duplicated, the region drifted during drags, and shrinking the window under the tail filled scrollback with stacked copies (seen as Atuin AI losing its conversation on any resize).

The root cause is that `reset_region` erased with pre-reflow row arithmetic, while every terminal Atuin targets rewraps and scrolls *before* the app hears about the resize. Investigating against real terminals turned up the behavior this PR is built on (verified with CPR probes in tmux 3.6; Ghostty matches): terminals pin the content's last row to its screen position while rewrapping around it. That makes any tracked-row math unusable after a reflow — but it also means a cursor parked on the region's *top* row rides the reflow perfectly. So: presents without a cursor hint now park the hidden cursor on the region top, and each resize queries the cursor position (CSI 6n) and erases at exactly the reported row — correct on reflowing, content-pinning, and truncating terminals alike. Apps with a visible cursor fall back to recomputing the distance from the previous frame's row contents.

Along the way this fixes three adjacent bugs the investigation surfaced: diffs cleared shrunk rows by writing space cells, which reflowing terminals treat as content and rewrap into phantom fragments (now one EL per row, plus a fix for the dead trailing-blank trim in `write_committed_row`); the post-resize repaint ran as a first render and re-streamed the off-screen overflow into scrollback on every drag event; and stray terminal replies (zsh prompt themes also speak CSI 6n) or escape bytes in pastes could end up inserted into text inputs.

`TestTerminal` learned the verified reflow semantics (document-wide rewrap, soft-wrap tracking, content-end pinning, scrollback pull-back), so all of the above is covered headless in `tests/resize_reflow.rs`, including drag storms, oversized tails, full-screen sessions, and truncating terminals. A new `resize_probe` example serves as the manual test bed.

Known residuals, inherent to erase-based repair on content-pinning terminals: a hard drag can push old rows into scroll history before any erase can reach them, and sustained narrows can walk the tail up the screen. The visible screen stays correct in both cases.
