### PR TITLE
feat: terminal capabilities for fullscreen TUIs

### DIFF
--- a/crates/eye_declare/src/app.rs
+++ b/crates/eye_declare/src/app.rs
@@ -1,6 +1,7 @@
 //! The application contract: Elm-shaped, with the timeline as the effect
 //! boundary.
 
+use eye_declare_engine::escape::CursorStyle;
 use futures_core::Stream;
 
 use crate::element::Element;
@@ -45,6 +46,24 @@ pub trait App: Sized {
     /// driver.
     fn subscriptions(&self) -> Subscriptions<Self::Msg> {
         Subscriptions::new()
+    }
+
+    /// The hardware cursor shape, re-derived from the model each present
+    /// (like [`keymap`](App::keymap)): return the shape for the current
+    /// mode and the runtime emits changes as DECSCUSR. The shape is never
+    /// reset at teardown — an app that changes shapes should end on the
+    /// shape it wants to leave behind (usually `DefaultUserShape`).
+    fn cursor_style(&self) -> CursorStyle {
+        CursorStyle::DefaultUserShape
+    }
+
+    /// Called with the terminal dimensions at startup and after every
+    /// resize, before the accompanying repaint: return a message to feed
+    /// the new size into the model (e.g. to size a fixed-height tail).
+    /// Default: `None`, sizes are ignored.
+    fn on_resize(&self, width: u16, height: u16) -> Option<Self::Msg> {
+        let _ = (width, height);
+        None
     }
 }
 

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -48,8 +48,10 @@ where
     let (tx, mut rx) = unbounded_channel::<A::Msg>();
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable(options.keyboard)?;
-    crate::runtime::normalize_start_column();
+    let _guard = RawModeGuard::enable(options.keyboard, options.screen)?;
+    if options.screen != crate::runtime::ScreenMode::AltScreen {
+        crate::runtime::normalize_start_column();
+    }
 
     let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
@@ -137,11 +139,14 @@ where
                             }
                         }
                         if exit.is_none() {
-                            bytes.extend_from_slice(&crate::runtime::resize_with_report(
+                            let (resize_bytes, resize_exit) = crate::runtime::resize_with_report(
                                 &mut runtime,
                                 w,
                                 h,
-                            ));
+                                options.screen,
+                            );
+                            bytes.extend_from_slice(&resize_bytes);
+                            exit = resize_exit;
                         }
                         (bytes, exit)
                     }

--- a/crates/eye_declare/src/lib.rs
+++ b/crates/eye_declare/src/lib.rs
@@ -36,12 +36,13 @@ pub mod viewport;
 
 pub use app::{App, Ctx};
 pub use element::{AnyElement, Element, ElementExt, Empty, Fluent, Padded, empty};
+pub use eye_declare_engine::escape::CursorStyle;
 pub use focus::{Focus, FocusHandle};
 pub use input::{InputEvent, Key, Keymap, key, keymap};
 #[cfg(feature = "markdown")]
 pub use markdown::{Markdown, MarkdownStyles, markdown};
 pub use panel::{Panel, panel};
-pub use runtime::{KeyboardProtocol, RunOptions, Runtime, run, run_with};
+pub use runtime::{KeyboardProtocol, RunOptions, Runtime, ScreenMode, run, run_with};
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
 pub use subscription::Subscriptions;

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -47,7 +47,19 @@ where
             exit: None,
         };
         app.init(&mut ctx);
-        let init_exit = ctx.exit;
+        let mut init_exit = ctx.exit;
+        if init_exit.is_none()
+            && let Some(msg) = app.on_resize(width, terminal_height)
+        {
+            let mut ctx = Ctx {
+                timeline: &mut timeline,
+                output: &mut pending,
+                effects: &mut effects,
+                exit: None,
+            };
+            app.update(msg, &mut ctx);
+            init_exit = ctx.exit;
+        }
         Self {
             app,
             timeline,
@@ -104,15 +116,8 @@ where
         let mut bytes = std::mem::take(&mut self.pending);
         let mut exit = None;
         for msg in msgs {
-            let mut ctx = Ctx {
-                timeline: &mut self.timeline,
-                output: &mut bytes,
-                effects: &mut self.effects,
-                exit: None,
-            };
-            self.app.update(msg, &mut ctx);
-            if let Some(output) = ctx.exit {
-                exit = Some(output);
+            exit = self.apply_msg(msg, &mut bytes);
+            if exit.is_some() {
                 break;
             }
         }
@@ -124,6 +129,19 @@ where
         (bytes, exit)
     }
 
+    /// Run one message through `update`, collecting pushed-block bytes into
+    /// `bytes` and queued effects into the runtime. No present.
+    fn apply_msg(&mut self, msg: A::Msg, bytes: &mut Vec<u8>) -> Option<A::Output> {
+        let mut ctx = Ctx {
+            timeline: &mut self.timeline,
+            output: bytes,
+            effects: &mut self.effects,
+            exit: None,
+        };
+        self.app.update(msg, &mut ctx);
+        ctx.exit
+    }
+
     /// Effects queued by `update` (spawned streams), for the driver to
     /// execute. Drain after every [`handle`](Runtime::handle) /
     /// [`process`](Runtime::process).
@@ -133,6 +151,7 @@ where
 
     /// Re-present the live tail (also called on animation ticks).
     pub fn present(&mut self) -> Vec<u8> {
+        self.timeline.set_cursor_style(self.app.cursor_style());
         let tail = self.app.tail();
         self.animate = tail.animated();
         let mut bytes = std::mem::take(&mut self.pending);
@@ -174,6 +193,62 @@ where
         bytes
     }
 
+    /// [`resize_anchored`](Runtime::resize_anchored), plus
+    /// [`App::on_resize`] delivery: the size message (if any) runs through
+    /// `update` after the region reset and before the single repaint, so
+    /// the new frame is laid out at the new size. Returns the app's output
+    /// if the update exited.
+    ///
+    /// `cursor` is the post-reflow cursor position report when available
+    /// (preferred); `None` falls back to stale-arithmetic erase.
+    pub fn resize_msg(
+        &mut self,
+        width: u16,
+        terminal_height: u16,
+        cursor: Option<(u16, u16)>,
+    ) -> (Vec<u8>, Option<A::Output>) {
+        self.timeline.set_terminal_height(terminal_height);
+        let mut bytes = match cursor {
+            Some(pos) => self.timeline.resize_anchored(width, pos),
+            None => self.timeline.resize(width),
+        };
+        let exit = self.deliver_resize(width, terminal_height, &mut bytes);
+        bytes.extend_from_slice(&self.present());
+        if exit.is_some() {
+            bytes.extend_from_slice(&self.timeline.finalize());
+        }
+        (bytes, exit)
+    }
+
+    /// Resize for alt-screen (fullscreen) apps: clear the visible screen
+    /// and repaint, with [`App::on_resize`] delivered in between. There is
+    /// no committed content to preserve and no scrollback to protect, so
+    /// no cursor report is needed.
+    pub fn resize_screen(
+        &mut self,
+        width: u16,
+        terminal_height: u16,
+    ) -> (Vec<u8>, Option<A::Output>) {
+        self.timeline.set_terminal_height(terminal_height);
+        let mut bytes = self.timeline.reset_screen(width);
+        let exit = self.deliver_resize(width, terminal_height, &mut bytes);
+        bytes.extend_from_slice(&self.present());
+        if exit.is_some() {
+            bytes.extend_from_slice(&self.timeline.finalize());
+        }
+        (bytes, exit)
+    }
+
+    fn deliver_resize(
+        &mut self,
+        width: u16,
+        terminal_height: u16,
+        bytes: &mut Vec<u8>,
+    ) -> Option<A::Output> {
+        let msg = self.app.on_resize(width, terminal_height)?;
+        self.apply_msg(msg, bytes)
+    }
+
     /// Shell handoff for exits that bypass the message loop: park the
     /// cursor at column 0 below the content. Message-driven exits get
     /// this automatically from [`process_batch`](Runtime::process_batch);
@@ -201,6 +276,30 @@ pub enum KeyboardProtocol {
     /// Disambiguates modified keys (Shift+Enter) in supporting terminals
     /// (kitty, WezTerm, foot, Ghostty, Windows Terminal, …).
     Enhanced,
+    /// Push an explicit kitty flag set. With `probe: true` the terminal is
+    /// asked first (one query round-trip) and unsupporting terminals fall
+    /// back to legacy; with `probe: false` the flags are pushed blind —
+    /// no round-trip, and terminals that ignore the protocol ignore the
+    /// push (the pop at teardown is equally ignored).
+    Custom {
+        flags: crossterm::event::KeyboardEnhancementFlags,
+        probe: bool,
+    },
+}
+
+/// Which screen the interactive drivers run on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScreenMode {
+    /// The main screen: the region starts at the shell prompt, committed
+    /// blocks flow into scrollback (the timeline model). The default.
+    #[default]
+    Inline,
+    /// The alternate screen: fullscreen apps. The prior screen contents
+    /// are restored at teardown, resizes clear-and-repaint (no cursor
+    /// position query), and startup skips the start-column query — the
+    /// cursor is homed explicitly. Committed blocks are of limited use
+    /// here: they scroll away within the alt screen and vanish with it.
+    AltScreen,
 }
 
 /// Terminal options for the interactive drivers ([`run_with`],
@@ -212,11 +311,17 @@ pub enum KeyboardProtocol {
 #[non_exhaustive]
 pub struct RunOptions {
     pub keyboard: KeyboardProtocol,
+    pub screen: ScreenMode,
 }
 
 impl RunOptions {
     pub fn keyboard(mut self, protocol: KeyboardProtocol) -> Self {
         self.keyboard = protocol;
+        self
+    }
+
+    pub fn screen(mut self, screen: ScreenMode) -> Self {
+        self.screen = screen;
         self
     }
 }
@@ -242,8 +347,10 @@ where
     let mut runtime = Runtime::new(app, width, height);
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable(options.keyboard)?;
-    normalize_start_column();
+    let _guard = RawModeGuard::enable(options.keyboard, options.screen)?;
+    if options.screen != ScreenMode::AltScreen {
+        normalize_start_column();
+    }
 
     let (bytes, init_exit) = runtime.startup();
     stdout.write_all(&bytes)?;
@@ -319,7 +426,15 @@ where
                         stdout.flush()?;
                         return Ok(output);
                     }
-                    bytes.extend_from_slice(&resize_with_report(&mut runtime, w, h));
+                    let (resize_bytes, resize_exit) =
+                        resize_with_report(&mut runtime, w, h, options.screen);
+                    reject_effects(&mut runtime)?;
+                    bytes.extend_from_slice(&resize_bytes);
+                    if let Some(output) = resize_exit {
+                        stdout.write_all(&bytes)?;
+                        stdout.flush()?;
+                        return Ok(output);
+                    }
                     bytes
                 }
                 _ => Vec::new(),
@@ -390,20 +505,29 @@ pub(crate) fn normalize_start_column() {
 /// Resize re-anchored by a fresh cursor position report — the terminal
 /// has already reflowed by the time the resize event arrives, so the
 /// report is post-reflow ground truth. Falls back to stale-arithmetic
-/// [`Runtime::resize`] if the terminal doesn't answer.
+/// erase if the terminal doesn't answer. On the alt screen there is
+/// nothing to anchor: clear and repaint, no query.
 ///
 /// The event's dimensions may be stale during a drag (events queue while
 /// the terminal keeps resizing); painting at a stale width soft-wraps
 /// for real and corrupts row tracking, so re-query the current size and
 /// prefer it.
-pub(crate) fn resize_with_report<A: App>(runtime: &mut Runtime<A>, w: u16, h: u16) -> Vec<u8>
+pub(crate) fn resize_with_report<A: App>(
+    runtime: &mut Runtime<A>,
+    w: u16,
+    h: u16,
+    screen: ScreenMode,
+) -> (Vec<u8>, Option<A::Output>)
 where
     A::Msg: Clone,
 {
     let (w, h) = crossterm::terminal::size().unwrap_or((w, h));
-    match read_cursor_position() {
-        Ok(pos) => runtime.resize_anchored(w, h, pos),
-        Err(_) => runtime.resize(w, h),
+    match screen {
+        ScreenMode::AltScreen => runtime.resize_screen(w, h),
+        ScreenMode::Inline => {
+            let cursor = read_cursor_position().ok();
+            runtime.resize_msg(w, h, cursor)
+        }
     }
 }
 
@@ -428,35 +552,66 @@ where
     Ok(())
 }
 
+/// The kitty flags to push for a protocol choice, or `None` for legacy.
+/// Pure so the probe/blind/fallback logic is unit-testable.
+fn keyboard_flags_to_push(
+    keyboard: KeyboardProtocol,
+    terminal_supports: impl FnOnce() -> bool,
+) -> Option<crossterm::event::KeyboardEnhancementFlags> {
+    match keyboard {
+        KeyboardProtocol::Legacy => None,
+        // Disambiguation only: it's all Shift+Enter detection needs.
+        // REPORT_EVENT_TYPES would add key-release events, which the
+        // built-in drivers filter but a custom driver feeding
+        // Runtime::handle directly could easily double-dispatch.
+        KeyboardProtocol::Enhanced => terminal_supports()
+            .then_some(crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
+        KeyboardProtocol::Custom { flags, probe } => {
+            (!probe || terminal_supports()).then_some(flags)
+        }
+    }
+}
+
 /// Restores the terminal on drop, including panic unwind.
 pub(crate) struct RawModeGuard {
     keyboard_enhanced: bool,
+    alt_screen: bool,
 }
 
 impl RawModeGuard {
-    pub(crate) fn enable(keyboard: KeyboardProtocol) -> io::Result<Self> {
+    pub(crate) fn enable(keyboard: KeyboardProtocol, screen: ScreenMode) -> io::Result<Self> {
         crossterm::terminal::enable_raw_mode()?;
         let mut stdout = io::stdout();
+
+        let alt_screen = screen == ScreenMode::AltScreen;
+        if alt_screen {
+            let _ = crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen);
+            // The alt screen starts blank but the cursor position is
+            // whatever the terminal felt like; home it so the engine's
+            // (0,0) origin assumption holds without a position query.
+            let _ = stdout.write_all(b"\x1b[2J\x1b[H");
+            let _ = stdout.flush();
+        }
+
         let _ = crossterm::execute!(stdout, crossterm::event::EnableBracketedPaste);
 
-        // Only push if the terminal supports it — the silent-fallback
+        // Only probe when the protocol asks for it — the silent-fallback
         // contract of KeyboardProtocol::Enhanced.
-        let keyboard_enhanced = keyboard == KeyboardProtocol::Enhanced
-            && crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false);
-        if keyboard_enhanced {
-            // Disambiguation only: it's all Shift+Enter detection needs.
-            // REPORT_EVENT_TYPES would add key-release events, which the
-            // built-in drivers filter but a custom driver feeding
-            // Runtime::handle directly could easily double-dispatch.
+        let flags = keyboard_flags_to_push(keyboard, || {
+            crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false)
+        });
+        let keyboard_enhanced = flags.is_some();
+        if let Some(flags) = flags {
             let _ = crossterm::execute!(
                 stdout,
-                crossterm::event::PushKeyboardEnhancementFlags(
-                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                )
+                crossterm::event::PushKeyboardEnhancementFlags(flags)
             );
         }
 
-        Ok(Self { keyboard_enhanced })
+        Ok(Self {
+            keyboard_enhanced,
+            alt_screen,
+        })
     }
 }
 
@@ -466,11 +621,68 @@ impl Drop for RawModeGuard {
         if self.keyboard_enhanced {
             let _ = crossterm::execute!(stdout, crossterm::event::PopKeyboardEnhancementFlags);
         }
+        if self.alt_screen {
+            let _ = crossterm::execute!(stdout, crossterm::terminal::LeaveAlternateScreen);
+        }
         let _ = crossterm::execute!(stdout, crossterm::event::DisableBracketedPaste);
         let _ = crossterm::terminal::disable_raw_mode();
         // The engine hides the cursor while no element hints one; make
         // sure the shell gets it back.
         let _ = stdout.write_all(b"\x1b[?25h");
         let _ = stdout.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyboardEnhancementFlags as Flags;
+
+    #[test]
+    fn legacy_pushes_nothing_and_never_probes() {
+        let flags = keyboard_flags_to_push(KeyboardProtocol::Legacy, || {
+            panic!("legacy must not query the terminal")
+        });
+        assert_eq!(flags, None);
+    }
+
+    #[test]
+    fn enhanced_probes_and_falls_back() {
+        assert_eq!(
+            keyboard_flags_to_push(KeyboardProtocol::Enhanced, || true),
+            Some(Flags::DISAMBIGUATE_ESCAPE_CODES)
+        );
+        assert_eq!(
+            keyboard_flags_to_push(KeyboardProtocol::Enhanced, || false),
+            None
+        );
+    }
+
+    #[test]
+    fn custom_blind_push_skips_the_probe_round_trip() {
+        let flags = Flags::DISAMBIGUATE_ESCAPE_CODES
+            | Flags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+            | Flags::REPORT_ALTERNATE_KEYS;
+        let pushed = keyboard_flags_to_push(
+            KeyboardProtocol::Custom {
+                flags,
+                probe: false,
+            },
+            || panic!("blind push must not query the terminal"),
+        );
+        assert_eq!(pushed, Some(flags));
+    }
+
+    #[test]
+    fn custom_with_probe_respects_the_answer() {
+        let flags = Flags::REPORT_ALTERNATE_KEYS;
+        assert_eq!(
+            keyboard_flags_to_push(KeyboardProtocol::Custom { flags, probe: true }, || true),
+            Some(flags)
+        );
+        assert_eq!(
+            keyboard_flags_to_push(KeyboardProtocol::Custom { flags, probe: true }, || false),
+            None
+        );
     }
 }

--- a/crates/eye_declare/src/timeline.rs
+++ b/crates/eye_declare/src/timeline.rs
@@ -7,6 +7,7 @@
 //! each frame ends in [`Timeline::present`].
 
 use eye_declare_engine::Engine;
+use eye_declare_engine::escape::CursorStyle;
 use eye_declare_engine::frame::Frame;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
@@ -34,6 +35,19 @@ impl Timeline {
 
     pub fn set_terminal_height(&mut self, height: u16) {
         self.engine.set_terminal_height(height);
+    }
+
+    /// Request a hardware cursor shape; emitted with the next
+    /// [`present`](Timeline::present) if it changed.
+    pub fn set_cursor_style(&mut self, style: CursorStyle) {
+        self.engine.set_cursor_style(style);
+    }
+
+    /// Reset for a width change by clearing the visible screen (alt-screen
+    /// semantics: no committed content to preserve, no scrollback to
+    /// protect). Follow with a [`present`](Timeline::present).
+    pub fn reset_screen(&mut self, new_width: u16) -> Vec<u8> {
+        self.engine.reset(new_width)
     }
 
     /// Commit a finished block above the live tail. The block is rendered

--- a/crates/eye_declare/tests/capabilities.rs
+++ b/crates/eye_declare/tests/capabilities.rs
@@ -1,0 +1,119 @@
+//! Size delivery (`App::on_resize`), hardware cursor shapes
+//! (`App::cursor_style`), and the resize variants that carry them.
+
+use eye_declare::{App, Ctx, CursorStyle, Element, Runtime, text};
+use eye_declare_engine::test_terminal::TestTerminal;
+
+#[derive(Clone)]
+enum Msg {
+    Size(u16, u16),
+    Style(CursorStyle),
+}
+
+struct Sizer {
+    size: Option<(u16, u16)>,
+    style: CursorStyle,
+}
+
+impl Sizer {
+    fn new() -> Self {
+        Self {
+            size: None,
+            style: CursorStyle::DefaultUserShape,
+        }
+    }
+}
+
+impl App for Sizer {
+    type Msg = Msg;
+    type Output = ();
+
+    fn update(&mut self, msg: Msg, _ctx: &mut Ctx<'_, Self>) {
+        match msg {
+            Msg::Size(w, h) => self.size = Some((w, h)),
+            Msg::Style(style) => self.style = style,
+        }
+    }
+
+    fn tail(&self) -> impl Element + '_ {
+        let (w, h) = self.size.unwrap_or((0, 0));
+        text(format!("size {w}x{h}"))
+    }
+
+    fn cursor_style(&self) -> CursorStyle {
+        self.style
+    }
+
+    fn on_resize(&self, width: u16, height: u16) -> Option<Msg> {
+        Some(Msg::Size(width, height))
+    }
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[test]
+fn initial_size_arrives_through_on_resize() {
+    let mut rt = Runtime::new(Sizer::new(), 80, 24);
+    let mut term = TestTerminal::new(80, 24);
+
+    let (bytes, exit) = rt.startup();
+    assert!(exit.is_none());
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "size 80x24");
+}
+
+#[test]
+fn resize_msg_delivers_the_new_size_before_the_repaint() {
+    let mut rt = Runtime::new(Sizer::new(), 80, 24);
+    let mut term = TestTerminal::new(80, 24);
+    let (bytes, _) = rt.startup();
+    term.feed(&bytes);
+
+    let (bytes, exit) = rt.resize_msg(100, 30, None);
+    assert!(exit.is_none());
+    term.resize_reflow(100, 30);
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "size 100x30");
+}
+
+#[test]
+fn resize_screen_clears_and_repaints_at_the_new_size() {
+    let mut rt = Runtime::new(Sizer::new(), 80, 24);
+    let mut term = TestTerminal::new(80, 24);
+    let (bytes, _) = rt.startup();
+    term.feed(&bytes);
+
+    let (bytes, exit) = rt.resize_screen(60, 20);
+    assert!(exit.is_none());
+    assert!(
+        contains(&bytes, b"\x1b[2J"),
+        "alt-screen resize should clear the screen"
+    );
+    term.resize(60, 20);
+    term.feed(&bytes);
+    assert_eq!(term.viewport_lines()[0], "size 60x20");
+}
+
+#[test]
+fn cursor_style_changes_emit_decscusr_exactly_once() {
+    let mut rt = Runtime::new(Sizer::new(), 80, 24);
+
+    // The default shape is never emitted unprompted.
+    let (bytes, _) = rt.startup();
+    assert!(!contains(&bytes, b" q"), "no DECSCUSR at default shape");
+
+    // A change emits with the present that carries it.
+    let (bytes, _) = rt.process(Msg::Style(CursorStyle::SteadyBlock));
+    assert!(contains(&bytes, b"\x1b[2 q"));
+
+    // Unchanged shape: no re-emission on later presents.
+    let (bytes, _) = rt.process(Msg::Size(80, 24));
+    assert!(!contains(&bytes, b" q"));
+
+    // Returning to the default emits its code (there is no teardown
+    // reset; the final shape is whatever the app last presented).
+    let (bytes, _) = rt.process(Msg::Style(CursorStyle::DefaultUserShape));
+    assert!(contains(&bytes, b"\x1b[0 q"));
+}

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -3,7 +3,7 @@
 
 use ratatui_core::buffer::Buffer;
 
-use crate::escape::CursorState;
+use crate::escape::{CursorState, CursorStyle};
 use crate::frame::Frame;
 
 /// Synchronizes rendered frames with a real terminal.
@@ -31,6 +31,11 @@ pub struct Engine {
     /// [`position_cursor`](Engine::position_cursor): a parked cursor
     /// makes a resize-time position report the region top directly.
     parked: bool,
+    /// The shape the app wants the hardware cursor to have.
+    requested_style: CursorStyle,
+    /// The shape last emitted to the terminal, so unchanged shapes cost
+    /// zero bytes per present.
+    emitted_style: CursorStyle,
     /// Set by the resize resets: the screen row the erased region starts
     /// at (`None` when unknown). The next present is a repaint of
     /// content that was *already on screen* — it must not stream
@@ -52,9 +57,18 @@ impl Engine {
             prev_frame: None,
             emitted_rows: 0,
             terminal_height,
+            requested_style: CursorStyle::DefaultUserShape,
+            emitted_style: CursorStyle::DefaultUserShape,
             parked: false,
             resumed_at: None,
         }
+    }
+
+    /// Request a hardware cursor shape; the change is emitted with the next
+    /// present. Shape state survives resizes and resets — the terminal's
+    /// cursor shape is global, untouched by erasing content.
+    pub fn set_cursor_style(&mut self, style: CursorStyle) {
+        self.requested_style = style;
     }
 
     /// The present after a resize reset: the region was just erased from
@@ -610,6 +624,10 @@ impl Engine {
         hint: Option<(u16, u16)>,
         park_hidden: bool,
     ) {
+        if self.requested_style != self.emitted_style {
+            output.extend_from_slice(self.requested_style.decscusr());
+            self.emitted_style = self.requested_style;
+        }
         if let Some((col, row)) = hint {
             crate::escape::write_relative_move(output, &mut self.cursor, row, col);
             // Show cursor at the component's cursor position

--- a/crates/eye_declare_engine/src/engine.rs
+++ b/crates/eye_declare_engine/src/engine.rs
@@ -71,6 +71,13 @@ impl Engine {
         self.requested_style = style;
     }
 
+    fn emit_cursor_style(&mut self, output: &mut Vec<u8>) {
+        if self.requested_style != self.emitted_style {
+            output.extend_from_slice(self.requested_style.decscusr());
+            self.emitted_style = self.requested_style;
+        }
+    }
+
     /// The present after a resize reset: the region was just erased from
     /// screen row `resumed_at` down and the frame replaces content that
     /// was already visible.
@@ -179,8 +186,13 @@ impl Engine {
         // First render
         if self.prev_frame.is_none() {
             if new_height == 0 {
+                // Nothing to paint or position, but a requested shape must
+                // still reach the terminal: this can be the only present an
+                // init-exiting app ever makes.
+                let mut output = Vec::new();
+                self.emit_cursor_style(&mut output);
                 self.prev_frame = Some(new_frame);
-                return Vec::new();
+                return output;
             }
 
             if self.resumed_at.is_some() {
@@ -624,10 +636,7 @@ impl Engine {
         hint: Option<(u16, u16)>,
         park_hidden: bool,
     ) {
-        if self.requested_style != self.emitted_style {
-            output.extend_from_slice(self.requested_style.decscusr());
-            self.emitted_style = self.requested_style;
-        }
+        self.emit_cursor_style(output);
         if let Some((col, row)) = hint {
             crate::escape::write_relative_move(output, &mut self.cursor, row, col);
             // Show cursor at the component's cursor position
@@ -657,6 +666,7 @@ impl Engine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::escape::CursorStyle;
     use ratatui_core::layout::Rect;
 
     fn buffer_with_lines(width: u16, lines: &[&str]) -> Buffer {
@@ -671,6 +681,43 @@ mod tests {
             );
         }
         buf
+    }
+
+    #[test]
+    fn cursor_style_emits_on_a_first_zero_height_present() {
+        // An app that sets a shape and exits from init presents exactly one
+        // frame: an empty one. The shape must still reach the terminal.
+        let mut engine = Engine::new(10, 24);
+        engine.set_cursor_style(CursorStyle::SteadyBar);
+        let bytes = engine.present(Frame::new(Buffer::empty(Rect::new(0, 0, 10, 0))), None);
+        assert!(
+            bytes.windows(5).any(|w| w == b"\x1b[6 q"),
+            "DECSCUSR must be emitted even when the frame is empty"
+        );
+    }
+
+    #[test]
+    fn cursor_style_emits_when_the_tail_shrinks_to_zero() {
+        // The exit flow: content presented, then a final empty tail carrying
+        // the shell-handoff shape.
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["hello"])), None);
+        engine.set_cursor_style(CursorStyle::DefaultUserShape);
+        // Default == default: no change, no emission.
+        let bytes = engine.present(Frame::new(Buffer::empty(Rect::new(0, 0, 10, 0))), None);
+        assert!(
+            !bytes.windows(2).any(|w| w == b" q"),
+            "unchanged shape must not re-emit DECSCUSR"
+        );
+
+        let mut engine = Engine::new(10, 24);
+        let _ = engine.present(Frame::new(buffer_with_lines(10, &["hello"])), None);
+        engine.set_cursor_style(CursorStyle::BlinkingBar);
+        let bytes = engine.present(Frame::new(Buffer::empty(Rect::new(0, 0, 10, 0))), None);
+        assert!(
+            bytes.windows(5).any(|w| w == b"\x1b[5 q"),
+            "shape change must ride the final empty present"
+        );
     }
 
     #[test]

--- a/crates/eye_declare_engine/src/escape.rs
+++ b/crates/eye_declare_engine/src/escape.rs
@@ -13,6 +13,41 @@ const HIDE_CURSOR: &[u8] = b"\x1b[?25l";
 #[allow(dead_code)]
 const SHOW_CURSOR: &[u8] = b"\x1b[?25h";
 
+/// Hardware cursor shape, emitted as DECSCUSR (`CSI n SP q`).
+///
+/// The engine emits a shape change with the next
+/// [`present`](crate::Engine::present); it never resets the shape at
+/// teardown — an app that changes shapes and wants the user's default back
+/// on exit presents `DefaultUserShape` (or its final shape of choice)
+/// before exiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum CursorStyle {
+    #[default]
+    DefaultUserShape,
+    BlinkingBlock,
+    SteadyBlock,
+    BlinkingUnderScore,
+    SteadyUnderScore,
+    BlinkingBar,
+    SteadyBar,
+}
+
+impl CursorStyle {
+    /// The DECSCUSR parameter for this shape.
+    pub(crate) fn decscusr(self) -> &'static [u8] {
+        match self {
+            CursorStyle::DefaultUserShape => b"\x1b[0 q",
+            CursorStyle::BlinkingBlock => b"\x1b[1 q",
+            CursorStyle::SteadyBlock => b"\x1b[2 q",
+            CursorStyle::BlinkingUnderScore => b"\x1b[3 q",
+            CursorStyle::SteadyUnderScore => b"\x1b[4 q",
+            CursorStyle::BlinkingBar => b"\x1b[5 q",
+            CursorStyle::SteadyBar => b"\x1b[6 q",
+        }
+    }
+}
+
 /// Tracks terminal cursor position and current style to minimize output.
 #[derive(Debug, Clone)]
 pub struct CursorState {

--- a/docs/content/guide/input.md
+++ b/docs/content/guide/input.md
@@ -90,3 +90,22 @@ driver_tokio::run_with(app, options).await?;
 
 `Enhanced` silently falls back to legacy on terminals without support, so
 bind a fallback chord (Ctrl+J is the convention) alongside Shift+Enter.
+
+For full control there is `Custom { flags, probe }`: an explicit kitty
+flag set (e.g. adding `REPORT_ALTERNATE_KEYS` when your keybinding layer
+depends on how modified keys arrive). With `probe: true` the terminal is
+asked first — one query round-trip — and unsupporting terminals fall back
+to legacy. With `probe: false` the flags are pushed blind: no round-trip,
+and terminals that ignore the protocol ignore the push and the matching
+pop at teardown. Blind pushing is the right call when you are matching
+the behavior of an app that always pushed, or when startup latency over
+SSH matters more than tidiness on ancient terminals.
+
+```rust
+use crossterm::event::KeyboardEnhancementFlags as Flags;
+
+let options = RunOptions::default().keyboard(KeyboardProtocol::Custom {
+    flags: Flags::DISAMBIGUATE_ESCAPE_CODES | Flags::REPORT_ALTERNATE_KEYS,
+    probe: false,
+});
+```

--- a/docs/content/reference/runtime.md
+++ b/docs/content/reference/runtime.md
@@ -36,12 +36,52 @@ restore the terminal on exit, including panic unwind.
 
 ## RunOptions
 
-| option     | values                                            | notes                                                                                                                                          |
-| ---------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyboard` | `KeyboardProtocol::Legacy` (default) / `Enhanced` | `Enhanced` requests the kitty protocol's disambiguated escape codes (Shift+Enter vs Enter), falling back to legacy silently where unsupported. |
+| option     | values                                                                     | notes                                                                                                                                                                             |
+| ---------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyboard` | `KeyboardProtocol::Legacy` (default) / `Enhanced` / `Custom { flags, probe }` | `Enhanced` requests the kitty protocol's disambiguated escape codes (Shift+Enter vs Enter), falling back to legacy silently where unsupported. `Custom` pushes an explicit flag set; see [input](../../guide/input/). |
+| `screen`   | `ScreenMode::Inline` (default) / `AltScreen`                                | Where the app runs: the main screen (the timeline model), or the alternate screen for fullscreen apps.                                                                             |
 
 The struct is `#[non_exhaustive]`; construct with `Default` and the
 setters.
+
+## Fullscreen: the alt screen
+
+`ScreenMode::AltScreen` runs the app on the alternate screen — for
+"whole terminal" TUIs rather than inline ones. What changes:
+
+- The prior screen contents are restored at teardown, like any fullscreen
+  program.
+- Startup homes the cursor explicitly instead of querying the start
+  column, and resizes clear-and-repaint instead of anchoring on a cursor
+  report — fullscreen startup and resizes cost **zero** position-query
+  round-trips.
+- Size the tail to the terminal with [`App::on_resize`](#sizes-and-resizes):
+  a fullscreen tail should fill exactly the height it is told about.
+- `ctx.push` still works but is of limited use: committed blocks scroll
+  away within the alt screen and vanish with it. The timeline model is an
+  inline-mode idea.
+
+## Sizes and resizes
+
+`App::on_resize(width, height) -> Option<Msg>` turns the terminal size
+into a model input. It is called with the initial size during
+`Runtime::new` and with the new size after every resize, before the
+accompanying repaint — return a message and the frame that follows is
+laid out with the size already in the model. The default returns `None`:
+apps whose tails size themselves from content never need it.
+
+This is how a fixed-height or fullscreen tail tracks the terminal;
+content-sized inline tails should ignore it and keep measuring naturally.
+
+## Cursor shape
+
+`App::cursor_style() -> CursorStyle` is re-derived from the model at
+every present, like `keymap()`: return the shape for the current mode
+(`SteadyBlock` in a vim-normal mode, `BlinkingBar` in insert, …) and the
+engine emits the change — only the change — as DECSCUSR. There is no
+teardown reset: the terminal keeps the last shape presented, so an app
+that changes shapes should end on the one it means to leave behind
+(usually `CursorStyle::DefaultUserShape`).
 
 ## Runtime: the headless core
 
@@ -55,10 +95,14 @@ let (bytes, exit) = rt.handle(input_event);     // keymap → update → present
 let (bytes, exit) = rt.process(msg);            // update → present
 let (bytes, exit) = rt.process_batch(msgs);     // many updates, one present
 let bytes = rt.present();                        // re-present (animation tick)
-let bytes = rt.resize(w, h);
+let (bytes, exit) = rt.resize_msg(w, h, cursor); // inline resize + on_resize delivery
+let (bytes, exit) = rt.resize_screen(w, h);      // alt-screen resize + on_resize delivery
 let effects = rt.take_effects();                 // spawned work, for the driver
 let interval = rt.animation_interval();          // Some(_) while tail animates
 ```
+
+(`resize`/`resize_anchored` remain for compatibility; they repaint but do
+not deliver `App::on_resize`.)
 
 This is the surface for [headless testing](../../guide/testing/) and for
 custom drivers (another executor, a remote terminal, an event-sourced
@@ -78,6 +122,8 @@ impl App for MyApp {
     fn tail(&self) -> impl Element + '_;
     fn keymap(&self) -> Keymap<Msg>;               // optional: default empty
     fn subscriptions(&self) -> Subscriptions<Msg>; // optional: default none
+    fn on_resize(&self, w: u16, h: u16) -> Option<Msg>; // optional: default None
+    fn cursor_style(&self) -> CursorStyle;         // optional: default user shape
 }
 ```
 


### PR DESCRIPTION
Four additive capabilities, batched for a 0.6.5 release, motivated by porting atuin's interactive search to eye-declare. The search TUI is the first fixed-height, mode-heavy, fullscreen-capable app on the framework, and it needed four things the API couldn't previously express:

- **`App::on_resize(width, height) -> Option<Msg>`** — the terminal size as a model input, delivered at startup and after every resize, before the accompanying repaint, so a fixed-height or fullscreen tail lays out at the new size in the same frame. New `Runtime::resize_msg`/`resize_screen` carry the delivery; the existing resize methods are unchanged for compatibility.
- **`App::cursor_style`** — hardware cursor shapes (vim block/bar), re-derived from the model each present like `keymap()`, emitted by the engine as DECSCUSR only on change. No teardown reset: an app ends on the shape it means to leave behind.
- **`KeyboardProtocol::Custom { flags, probe }`** — explicit kitty flag sets, optionally pushed blind. Atuin's ratatui path always blind-pushed `REPORT_ALL_KEYS_AS_ESCAPE_CODES | REPORT_ALTERNATE_KEYS`; matching that keeps user keybindings behaving identically, and skipping the probe saves a query round-trip over SSH.
- **`ScreenMode::AltScreen`** — run on the alternate screen. Teardown restores the prior screen, resizes clear-and-repaint, and startup homes the cursor instead of querying the start column: fullscreen apps pay zero position-query round-trips.

Validated against the atuin port under a local patch: fullscreen renders cell-identical to the ratatui path through typing, resize, and exit; cursor shapes emit exactly once per mode transition, with the shell handoff restoring the default; the blind push cuts inline first-paint at 100ms simulated RTT from ~500ms to ~310ms, and fullscreen starts with no terminal queries at all. The engine perf report is alloc-for-alloc identical to main, and the book gains reference coverage for all four (runtime reference and input guide).
