### PR TITLE
feat!: mouse events via the keymap fallthrough

### DIFF
--- a/crates/eye_declare/examples/echo.rs
+++ b/crates/eye_declare/examples/echo.rs
@@ -80,6 +80,7 @@ impl App for Echo {
                     _ => Msg::Typed(' '),
                 },
                 InputEvent::Paste(s) => Msg::Typed(s.chars().next().unwrap_or(' ')),
+                _ => Msg::Typed(' '),
             })
     }
 }

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -48,7 +48,7 @@ where
     let (tx, mut rx) = unbounded_channel::<A::Msg>();
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable(options.keyboard, options.screen)?;
+    let _guard = RawModeGuard::enable(options.keyboard, options.screen, options.mouse_capture)?;
     if options.screen != crate::runtime::ScreenMode::AltScreen {
         crate::runtime::normalize_start_column();
     }
@@ -81,6 +81,7 @@ where
                         runtime.handle(InputEvent::Key(k))
                     }
                     Some(Ok(Event::Paste(s))) => runtime.handle(InputEvent::Paste(s)),
+                    Some(Ok(Event::Mouse(m))) => runtime.handle(InputEvent::Mouse(m)),
                     // Coalesce resize storms: a drag delivers events
                     // faster than an erase + repaint + cursor query per
                     // event can keep up, which queues stale sizes and

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::future::poll_fn;
 use std::io::{self, Write};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,7 +49,7 @@ where
     let (tx, mut rx) = unbounded_channel::<A::Msg>();
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable(options.keyboard, options.screen, options.mouse_capture)?;
+    let mut guard = RawModeGuard::enable(options.keyboard, options.screen, options.mouse_capture)?;
     if options.screen != crate::runtime::ScreenMode::AltScreen {
         crate::runtime::normalize_start_column();
     }
@@ -57,6 +58,7 @@ where
     stdout.write_all(&bytes)?;
     stdout.flush()?;
     if let Some(output) = init_exit {
+        shutdown_mouse_sync(&mut guard, &mut stdout);
         return Ok(output);
     }
     spawn_effects(runtime.take_effects(), &tx);
@@ -191,8 +193,58 @@ where
             stdout.flush()?;
         }
         if let Some(output) = exit {
+            shutdown_mouse(&mut guard, &mut stdout, &mut events).await;
             return Ok(output);
         }
+    }
+}
+
+/// Disable mouse capture and drain in-flight reports through the stream.
+///
+/// Between the exit and the terminal processing the disable, the terminal
+/// keeps emitting reports — a fast wheel that triggered the exit has
+/// dozens still in flight. Undrained, they land in the parent shell's
+/// input as escape-sequence garbage (and have been seen to wedge fragile
+/// emulators). The guard's own drop-time drain can't do this here: the
+/// stream's reader thread owns crossterm's shared reader, so synchronous
+/// `event::poll` sees nothing while the reports flow into the stream.
+/// Bounded: quiet for 5ms or 50ms total.
+async fn shutdown_mouse(
+    guard: &mut RawModeGuard,
+    stdout: &mut impl Write,
+    events: &mut crossterm::event::EventStream,
+) {
+    if !guard.take_mouse_capture() {
+        return;
+    }
+    let _ = crossterm::execute!(stdout, crossterm::event::DisableMouseCapture);
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(50);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(
+            Duration::from_millis(5),
+            poll_fn(|cx| Pin::new(&mut *events).poll_next(cx)),
+        )
+        .await
+        {
+            Ok(Some(_)) => {}
+            // Quiet, or the stream ended: done.
+            _ => break,
+        }
+    }
+}
+
+/// The pre-loop exit (`App::init` exited): no stream exists yet, so the
+/// synchronous drain works — no reader thread is holding the source.
+fn shutdown_mouse_sync(guard: &mut RawModeGuard, stdout: &mut impl Write) {
+    if !guard.take_mouse_capture() {
+        return;
+    }
+    let _ = crossterm::execute!(stdout, crossterm::event::DisableMouseCapture);
+    let deadline = std::time::Instant::now() + Duration::from_millis(50);
+    while std::time::Instant::now() < deadline
+        && matches!(crossterm::event::poll(Duration::from_millis(5)), Ok(true))
+    {
+        let _ = crossterm::event::read();
     }
 }
 

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -136,6 +136,14 @@ where
                                         break;
                                     }
                                 }
+                                Event::Mouse(m) => {
+                                    let (b, e) = runtime.handle(InputEvent::Mouse(m));
+                                    bytes.extend_from_slice(&b);
+                                    if e.is_some() {
+                                        exit = e;
+                                        break;
+                                    }
+                                }
                                 _ => {}
                             }
                         }

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -68,104 +68,75 @@ where
 
     let mut events = crossterm::event::EventStream::new();
 
+    // Frame pacing: the stream delivers one event per poll through its
+    // reader thread, so an event burst (a wheel flick queues dozens)
+    // cannot be batched at the source — it arrives as a rapid trickle,
+    // and presenting per event paints every intermediate state, which
+    // reads as lag. Instead, events accumulate in `pending` and flush
+    // through `handle_batch` at most once per FRAME. An event arriving
+    // with the frame budget already spent (the common typing case)
+    // flushes immediately: pacing only engages during bursts.
+    const FRAME: Duration = Duration::from_millis(8);
+    let mut pending: Vec<InputEvent> = Vec::new();
+    let mut last_flush = tokio::time::Instant::now() - FRAME;
+
     loop {
         let anim = runtime.animation_interval();
+        let flush_at = (!pending.is_empty()).then(|| last_flush + FRAME);
 
-        let (bytes, exit) = tokio::select! {
+        enum Step<O> {
+            Out(Vec<u8>, Option<O>),
+            Flush,
+        }
+
+        let step = tokio::select! {
             biased;
 
             maybe_event = poll_fn(|cx| Pin::new(&mut events).poll_next(cx)) => {
                 use crossterm::event::{Event, KeyEventKind};
                 match maybe_event {
-                    Some(Ok(Event::Key(k)))
-                        if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
-                    {
-                        runtime.handle(InputEvent::Key(k))
-                    }
-                    Some(Ok(Event::Paste(s))) => runtime.handle(InputEvent::Paste(s)),
-                    Some(Ok(Event::Mouse(m))) => runtime.handle(InputEvent::Mouse(m)),
-                    // Coalesce resize storms: a drag delivers events
-                    // faster than an erase + repaint + cursor query per
-                    // event can keep up, which queues stale sizes and
-                    // multiplies position queries. Drain whatever is
-                    // already queued — keys are processed in order,
-                    // resizes collapse into one handled at the latest
-                    // size. Querying the cursor synchronously here is
-                    // safe: the EventStream's reader thread is parked
-                    // between events, so the shared crossterm reader is
-                    // free, and events arriving during the query are
-                    // re-queued, not dropped.
-                    Some(Ok(Event::Resize(w, h))) => {
-                        // Drain via the plain poll/read API, NOT the
-                        // stream: polling the stream to Pending wakes its
-                        // background reader, which then holds crossterm's
-                        // shared reader lock and starves the position
-                        // query below into its timeout.
-                        let mut queued = Vec::new();
-                        while queued.len() < 64
-                            && crossterm::event::poll(Duration::ZERO).unwrap_or(false)
+                    Some(Ok(first)) => match first {
+                        Event::Key(k)
+                            if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
                         {
-                            match crossterm::event::read() {
-                                Ok(ev) => queued.push(ev),
-                                Err(_) => break,
+                            pending.push(InputEvent::Key(k));
+                            Step::Flush
+                        }
+                        Event::Paste(s) => {
+                            pending.push(InputEvent::Paste(s));
+                            Step::Flush
+                        }
+                        Event::Mouse(m) => {
+                            pending.push(InputEvent::Mouse(m));
+                            Step::Flush
+                        }
+                        Event::Resize(w, h) => {
+                            // Resizes repaint the whole region and may
+                            // query the cursor; never paced. Flush pending
+                            // input first so it lays out against the state
+                            // the user last saw.
+                            let (mut bytes, mut exit) =
+                                runtime.handle_batch(pending.drain(..));
+                            last_flush = tokio::time::Instant::now();
+                            if exit.is_none() {
+                                let (resize_bytes, resize_exit) =
+                                    crate::runtime::resize_with_report(
+                                        &mut runtime,
+                                        w,
+                                        h,
+                                        options.screen,
+                                    );
+                                bytes.extend_from_slice(&resize_bytes);
+                                exit = resize_exit;
                             }
+                            Step::Out(bytes, exit)
                         }
-
-                        let (mut w, mut h) = (w, h);
-                        let mut bytes = Vec::new();
-                        let mut exit = None;
-                        for ev in queued {
-                            match ev {
-                                Event::Resize(nw, nh) => (w, h) = (nw, nh),
-                                Event::Key(k)
-                                    if matches!(
-                                        k.kind,
-                                        KeyEventKind::Press | KeyEventKind::Repeat
-                                    ) =>
-                                {
-                                    let (b, e) = runtime.handle(InputEvent::Key(k));
-                                    bytes.extend_from_slice(&b);
-                                    if e.is_some() {
-                                        exit = e;
-                                        break;
-                                    }
-                                }
-                                Event::Paste(s) => {
-                                    let (b, e) = runtime.handle(InputEvent::Paste(s));
-                                    bytes.extend_from_slice(&b);
-                                    if e.is_some() {
-                                        exit = e;
-                                        break;
-                                    }
-                                }
-                                Event::Mouse(m) => {
-                                    let (b, e) = runtime.handle(InputEvent::Mouse(m));
-                                    bytes.extend_from_slice(&b);
-                                    if e.is_some() {
-                                        exit = e;
-                                        break;
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        if exit.is_none() {
-                            let (resize_bytes, resize_exit) = crate::runtime::resize_with_report(
-                                &mut runtime,
-                                w,
-                                h,
-                                options.screen,
-                            );
-                            bytes.extend_from_slice(&resize_bytes);
-                            exit = resize_exit;
-                        }
-                        (bytes, exit)
-                    }
-                    Some(Ok(_)) => (Vec::new(), None),
+                        _ => Step::Out(Vec::new(), None),
+                    },
                     Some(Err(e)) => return Err(e),
                     // Terminal input ended (stdin closed): exit cleanly,
                     // with the shell handoff process_batch would have done.
-                    None => (runtime.finalize(), Some(A::Output::default())),
+                    None => Step::Out(runtime.finalize(), Some(A::Output::default())),
                 }
             }
 
@@ -179,10 +150,28 @@ where
                         Err(_) => break,
                     }
                 }
-                runtime.process_batch(batch)
+                let (bytes, exit) = runtime.process_batch(batch);
+                Step::Out(bytes, exit)
             }
 
-            _ = sleep_opt(anim), if anim.is_some() => (runtime.present(), None),
+            _ = sleep_opt(flush_at.map(|at| at.saturating_duration_since(tokio::time::Instant::now()))), if flush_at.is_some() => {
+                Step::Flush
+            }
+
+            _ = sleep_opt(anim), if anim.is_some() => Step::Out(runtime.present(), None),
+        };
+
+        let (bytes, exit) = match step {
+            Step::Out(bytes, exit) => (bytes, exit),
+            Step::Flush => {
+                if !pending.is_empty() && tokio::time::Instant::now() >= last_flush + FRAME {
+                    let out = runtime.handle_batch(pending.drain(..));
+                    last_flush = tokio::time::Instant::now();
+                    out
+                } else {
+                    (Vec::new(), None)
+                }
+            }
         };
 
         spawn_effects(runtime.take_effects(), &tx);

--- a/crates/eye_declare/src/input.rs
+++ b/crates/eye_declare/src/input.rs
@@ -14,11 +14,19 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::focus::FocusHandle;
 
-/// A terminal input event as delivered to the app: key press or paste.
+/// A terminal input event as delivered to the app: key press, paste, or
+/// mouse event (the latter only when the driver runs with
+/// [`mouse_capture`](crate::RunOptions::mouse_capture)).
+///
+/// Non-exhaustive: keymaps resolve `Key` events; everything else reaches
+/// the app through [`fallthrough`](Keymap::fallthrough), so a wildcard arm
+/// there is both required and the natural place for future event kinds.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum InputEvent {
     Key(KeyEvent),
     Paste(String),
+    Mouse(crossterm::event::MouseEvent),
 }
 
 /// A key pattern for bindings.
@@ -229,6 +237,7 @@ mod tests {
                 }
             }
             InputEvent::Paste(_) => Msg::Edit('P'),
+            _ => Msg::Edit('?'),
         }
     }
 
@@ -278,6 +287,45 @@ mod tests {
         assert_eq!(
             km.dispatch(&InputEvent::Paste("hi".into())),
             Some(Msg::Edit('P'))
+        );
+    }
+
+    #[test]
+    fn mouse_events_reach_the_fallthrough() {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+        let focus = Focus::new();
+        let input = focus.handle();
+        input.focus();
+
+        let km: Keymap<&'static str> = keymap().fallthrough(&input, |ev| match ev {
+            InputEvent::Mouse(m) => match m.kind {
+                MouseEventKind::ScrollUp => "scroll-up",
+                MouseEventKind::ScrollDown => "scroll-down",
+                _ => "other-mouse",
+            },
+            _ => "not-mouse",
+        });
+
+        let scroll = |kind| {
+            InputEvent::Mouse(MouseEvent {
+                kind,
+                column: 3,
+                row: 5,
+                modifiers: KeyModifiers::NONE,
+            })
+        };
+        assert_eq!(
+            km.dispatch(&scroll(MouseEventKind::ScrollUp)),
+            Some("scroll-up")
+        );
+        assert_eq!(
+            km.dispatch(&scroll(MouseEventKind::ScrollDown)),
+            Some("scroll-down")
+        );
+        assert_eq!(
+            km.dispatch(&scroll(MouseEventKind::Down(MouseButton::Left))),
+            Some("other-mouse")
         );
     }
 

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -412,46 +412,59 @@ where
 
         let bytes = if crossterm::event::poll(timeout)? {
             use crossterm::event::{Event, KeyEventKind};
-            // Coalesce everything already queued into one frame (wheel
-            // flicks and paste storms queue dozens of events; painting
-            // per event reads as lag). Input is processed in order,
-            // resizes collapse into one handled at the latest size.
-            let mut inputs: Vec<InputEvent> = Vec::new();
-            let mut resize: Option<(u16, u16)> = None;
+            // Coalesce everything already queued (wheel flicks and paste
+            // storms queue dozens of events; painting per event reads as
+            // lag), preserving arrival order: mouse hit-testing after a
+            // resize must see post-resize geometry, so only runs of
+            // CONSECUTIVE resizes collapse into one at the latest size.
+            enum Seg {
+                Inputs(Vec<InputEvent>),
+                Resize(u16, u16),
+            }
+            let mut segs: Vec<Seg> = Vec::new();
+            let mut drained = 0usize;
             let mut first = true;
-            while first || crossterm::event::poll(Duration::ZERO)? {
+            while first || (drained < 64 && crossterm::event::poll(Duration::ZERO)?) {
                 first = false;
-                match crossterm::event::read()? {
+                drained += 1;
+                let input = match crossterm::event::read()? {
                     Event::Key(k)
                         if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
                     {
-                        inputs.push(InputEvent::Key(k));
+                        InputEvent::Key(k)
                     }
-                    Event::Paste(s) => inputs.push(InputEvent::Paste(s)),
-                    Event::Mouse(m) => inputs.push(InputEvent::Mouse(m)),
-                    Event::Resize(w, h) => resize = Some((w, h)),
-                    _ => {}
-                }
-                if inputs.len() >= 64 {
-                    break;
+                    Event::Paste(s) => InputEvent::Paste(s),
+                    Event::Mouse(m) => InputEvent::Mouse(m),
+                    Event::Resize(w, h) => {
+                        if let Some(Seg::Resize(rw, rh)) = segs.last_mut() {
+                            (*rw, *rh) = (w, h);
+                        } else {
+                            segs.push(Seg::Resize(w, h));
+                        }
+                        continue;
+                    }
+                    _ => continue,
+                };
+                if let Some(Seg::Inputs(v)) = segs.last_mut() {
+                    v.push(input);
+                } else {
+                    segs.push(Seg::Inputs(vec![input]));
                 }
             }
 
-            let (mut bytes, mut exit) = runtime.handle_batch(inputs);
-            reject_effects(&mut runtime)?;
-            if exit.is_none()
-                && let Some((w, h)) = resize
-            {
-                let (resize_bytes, resize_exit) =
-                    resize_with_report(&mut runtime, w, h, options.screen);
+            let mut bytes = Vec::new();
+            for seg in segs {
+                let (seg_bytes, seg_exit) = match seg {
+                    Seg::Inputs(inputs) => runtime.handle_batch(inputs),
+                    Seg::Resize(w, h) => resize_with_report(&mut runtime, w, h, options.screen),
+                };
                 reject_effects(&mut runtime)?;
-                bytes.extend_from_slice(&resize_bytes);
-                exit = resize_exit;
-            }
-            if let Some(output) = exit {
-                stdout.write_all(&bytes)?;
-                stdout.flush()?;
-                return Ok(output);
+                bytes.extend_from_slice(&seg_bytes);
+                if let Some(output) = seg_exit {
+                    stdout.write_all(&bytes)?;
+                    stdout.flush()?;
+                    return Ok(output);
+                }
             }
             bytes
         } else {

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -438,6 +438,15 @@ where
                                     break;
                                 }
                             }
+                            Event::Mouse(m) => {
+                                let (b, e) = runtime.handle(InputEvent::Mouse(m));
+                                reject_effects(&mut runtime)?;
+                                bytes.extend_from_slice(&b);
+                                if e.is_some() {
+                                    exited = e;
+                                    break;
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -661,6 +661,22 @@ impl Drop for RawModeGuard {
         }
         if self.mouse_capture {
             let _ = crossterm::execute!(stdout, crossterm::event::DisableMouseCapture);
+            // The terminal keeps sending reports until it processes the
+            // disable; anything already queued (a fast wheel queues dozens,
+            // possibly the very events that triggered the exit) would land
+            // in the parent shell's input as escape-sequence garbage — and
+            // has been seen to wedge fragile emulators outright. Drain
+            // until quiet, bounded, while raw mode is still on. Costs up to
+            // 50ms at teardown, only for capture-enabled apps.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+            while std::time::Instant::now() < deadline
+                && matches!(
+                    crossterm::event::poll(std::time::Duration::from_millis(5)),
+                    Ok(true)
+                )
+            {
+                let _ = crossterm::event::read();
+            }
         }
         if self.alt_screen {
             let _ = crossterm::execute!(stdout, crossterm::terminal::LeaveAlternateScreen);

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -88,10 +88,45 @@ where
     /// message results, processes it. Returns the bytes to write and the
     /// app's output when it exited.
     pub fn handle(&mut self, event: InputEvent) -> (Vec<u8>, Option<A::Output>) {
-        match self.app.keymap().dispatch(&event) {
-            Some(msg) => self.process(msg),
-            None => (Vec::new(), None),
+        self.handle_batch(std::iter::once(event))
+    }
+
+    /// Feed a burst of input events, presenting once at the end — the
+    /// input-side analogue of [`process_batch`](Runtime::process_batch).
+    /// A wheel flick or paste storm that queued dozens of events becomes
+    /// one frame instead of one per event.
+    ///
+    /// Dispatch is interleaved: each event resolves against a freshly
+    /// derived keymap *after* the previous event's update, so a mid-batch
+    /// mode change dispatches the rest of the batch under the new mode.
+    /// Stops early if an update exits; if no event dispatched to a
+    /// message, nothing is presented and no bytes are returned.
+    pub fn handle_batch(
+        &mut self,
+        events: impl IntoIterator<Item = InputEvent>,
+    ) -> (Vec<u8>, Option<A::Output>) {
+        let mut bytes: Option<Vec<u8>> = None;
+        let mut exit = None;
+        for event in events {
+            if let Some(msg) = self.app.keymap().dispatch(&event) {
+                // Undelivered init bytes come first, taken only once a
+                // message actually lands (an all-unmatched batch must
+                // leave them pending, like `handle` always has).
+                let buf = bytes.get_or_insert_with(|| std::mem::take(&mut self.pending));
+                exit = self.apply_msg(msg, buf);
+                if exit.is_some() {
+                    break;
+                }
+            }
         }
+        let Some(mut bytes) = bytes else {
+            return (Vec::new(), None);
+        };
+        bytes.extend_from_slice(&self.present());
+        if exit.is_some() {
+            bytes.extend_from_slice(&self.timeline.finalize());
+        }
+        (bytes, exit)
     }
 
     /// Feed one message (from the keymap, or — in the async driver — from
@@ -377,97 +412,48 @@ where
 
         let bytes = if crossterm::event::poll(timeout)? {
             use crossterm::event::{Event, KeyEventKind};
-            match crossterm::event::read()? {
-                Event::Key(k) if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
-                    let (bytes, exit) = runtime.handle(InputEvent::Key(k));
-                    reject_effects(&mut runtime)?;
-                    if let Some(output) = exit {
-                        stdout.write_all(&bytes)?;
-                        stdout.flush()?;
-                        return Ok(output);
+            // Coalesce everything already queued into one frame (wheel
+            // flicks and paste storms queue dozens of events; painting
+            // per event reads as lag). Input is processed in order,
+            // resizes collapse into one handled at the latest size.
+            let mut inputs: Vec<InputEvent> = Vec::new();
+            let mut resize: Option<(u16, u16)> = None;
+            let mut first = true;
+            while first || crossterm::event::poll(Duration::ZERO)? {
+                first = false;
+                match crossterm::event::read()? {
+                    Event::Key(k)
+                        if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                    {
+                        inputs.push(InputEvent::Key(k));
                     }
-                    bytes
+                    Event::Paste(s) => inputs.push(InputEvent::Paste(s)),
+                    Event::Mouse(m) => inputs.push(InputEvent::Mouse(m)),
+                    Event::Resize(w, h) => resize = Some((w, h)),
+                    _ => {}
                 }
-                Event::Paste(s) => {
-                    let (bytes, exit) = runtime.handle(InputEvent::Paste(s));
-                    reject_effects(&mut runtime)?;
-                    if let Some(output) = exit {
-                        stdout.write_all(&bytes)?;
-                        stdout.flush()?;
-                        return Ok(output);
-                    }
-                    bytes
+                if inputs.len() >= 64 {
+                    break;
                 }
-                Event::Mouse(m) => {
-                    let (bytes, exit) = runtime.handle(InputEvent::Mouse(m));
-                    reject_effects(&mut runtime)?;
-                    if let Some(output) = exit {
-                        stdout.write_all(&bytes)?;
-                        stdout.flush()?;
-                        return Ok(output);
-                    }
-                    bytes
-                }
-                Event::Resize(w, h) => {
-                    // Coalesce resize storms (see the tokio driver): drain
-                    // queued events, process keys in order, and handle one
-                    // resize at the latest size.
-                    let (mut w, mut h) = (w, h);
-                    let mut bytes = Vec::new();
-                    let mut exited = None;
-                    while crossterm::event::poll(Duration::ZERO)? {
-                        match crossterm::event::read()? {
-                            Event::Resize(nw, nh) => (w, h) = (nw, nh),
-                            Event::Key(k)
-                                if matches!(k.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
-                            {
-                                let (b, e) = runtime.handle(InputEvent::Key(k));
-                                reject_effects(&mut runtime)?;
-                                bytes.extend_from_slice(&b);
-                                if e.is_some() {
-                                    exited = e;
-                                    break;
-                                }
-                            }
-                            Event::Paste(s) => {
-                                let (b, e) = runtime.handle(InputEvent::Paste(s));
-                                reject_effects(&mut runtime)?;
-                                bytes.extend_from_slice(&b);
-                                if e.is_some() {
-                                    exited = e;
-                                    break;
-                                }
-                            }
-                            Event::Mouse(m) => {
-                                let (b, e) = runtime.handle(InputEvent::Mouse(m));
-                                reject_effects(&mut runtime)?;
-                                bytes.extend_from_slice(&b);
-                                if e.is_some() {
-                                    exited = e;
-                                    break;
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                    if let Some(output) = exited {
-                        stdout.write_all(&bytes)?;
-                        stdout.flush()?;
-                        return Ok(output);
-                    }
-                    let (resize_bytes, resize_exit) =
-                        resize_with_report(&mut runtime, w, h, options.screen);
-                    reject_effects(&mut runtime)?;
-                    bytes.extend_from_slice(&resize_bytes);
-                    if let Some(output) = resize_exit {
-                        stdout.write_all(&bytes)?;
-                        stdout.flush()?;
-                        return Ok(output);
-                    }
-                    bytes
-                }
-                _ => Vec::new(),
             }
+
+            let (mut bytes, mut exit) = runtime.handle_batch(inputs);
+            reject_effects(&mut runtime)?;
+            if exit.is_none()
+                && let Some((w, h)) = resize
+            {
+                let (resize_bytes, resize_exit) =
+                    resize_with_report(&mut runtime, w, h, options.screen);
+                reject_effects(&mut runtime)?;
+                bytes.extend_from_slice(&resize_bytes);
+                exit = resize_exit;
+            }
+            if let Some(output) = exit {
+                stdout.write_all(&bytes)?;
+                stdout.flush()?;
+                return Ok(output);
+            }
+            bytes
         } else {
             // Animation tick.
             runtime.present()

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -609,6 +609,16 @@ pub(crate) struct RawModeGuard {
 }
 
 impl RawModeGuard {
+    /// Hand mouse-capture teardown to the caller: returns whether capture
+    /// was on and marks it handled so `drop` won't disable or drain again.
+    /// The tokio driver needs this — its `EventStream`'s reader thread
+    /// holds crossterm's shared reader at drop time, so the guard's
+    /// `event::poll` drain would see nothing while in-flight reports leak
+    /// past it. The driver disables and drains through the stream instead.
+    pub(crate) fn take_mouse_capture(&mut self) -> bool {
+        std::mem::take(&mut self.mouse_capture)
+    }
+
     pub(crate) fn enable(
         keyboard: KeyboardProtocol,
         screen: ScreenMode,

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -312,6 +312,7 @@ pub enum ScreenMode {
 pub struct RunOptions {
     pub keyboard: KeyboardProtocol,
     pub screen: ScreenMode,
+    pub mouse_capture: bool,
 }
 
 impl RunOptions {
@@ -322,6 +323,15 @@ impl RunOptions {
 
     pub fn screen(mut self, screen: ScreenMode) -> Self {
         self.screen = screen;
+        self
+    }
+
+    /// Capture mouse events and deliver them as [`InputEvent::Mouse`]
+    /// through the keymap fallthrough. Off by default: capture takes over
+    /// the terminal's native selection/copy behavior, so only apps that
+    /// actually handle mouse events should request it.
+    pub fn mouse_capture(mut self, capture: bool) -> Self {
+        self.mouse_capture = capture;
         self
     }
 }
@@ -347,7 +357,7 @@ where
     let mut runtime = Runtime::new(app, width, height);
     let mut stdout = io::stdout().lock();
 
-    let _guard = RawModeGuard::enable(options.keyboard, options.screen)?;
+    let _guard = RawModeGuard::enable(options.keyboard, options.screen, options.mouse_capture)?;
     if options.screen != ScreenMode::AltScreen {
         normalize_start_column();
     }
@@ -380,6 +390,16 @@ where
                 }
                 Event::Paste(s) => {
                     let (bytes, exit) = runtime.handle(InputEvent::Paste(s));
+                    reject_effects(&mut runtime)?;
+                    if let Some(output) = exit {
+                        stdout.write_all(&bytes)?;
+                        stdout.flush()?;
+                        return Ok(output);
+                    }
+                    bytes
+                }
+                Event::Mouse(m) => {
+                    let (bytes, exit) = runtime.handle(InputEvent::Mouse(m));
                     reject_effects(&mut runtime)?;
                     if let Some(output) = exit {
                         stdout.write_all(&bytes)?;
@@ -576,10 +596,15 @@ fn keyboard_flags_to_push(
 pub(crate) struct RawModeGuard {
     keyboard_enhanced: bool,
     alt_screen: bool,
+    mouse_capture: bool,
 }
 
 impl RawModeGuard {
-    pub(crate) fn enable(keyboard: KeyboardProtocol, screen: ScreenMode) -> io::Result<Self> {
+    pub(crate) fn enable(
+        keyboard: KeyboardProtocol,
+        screen: ScreenMode,
+        mouse_capture: bool,
+    ) -> io::Result<Self> {
         crossterm::terminal::enable_raw_mode()?;
         let mut stdout = io::stdout();
 
@@ -594,6 +619,9 @@ impl RawModeGuard {
         }
 
         let _ = crossterm::execute!(stdout, crossterm::event::EnableBracketedPaste);
+        if mouse_capture {
+            let _ = crossterm::execute!(stdout, crossterm::event::EnableMouseCapture);
+        }
 
         // Only probe when the protocol asks for it — the silent-fallback
         // contract of KeyboardProtocol::Enhanced.
@@ -611,6 +639,7 @@ impl RawModeGuard {
         Ok(Self {
             keyboard_enhanced,
             alt_screen,
+            mouse_capture,
         })
     }
 }
@@ -620,6 +649,9 @@ impl Drop for RawModeGuard {
         let mut stdout = io::stdout();
         if self.keyboard_enhanced {
             let _ = crossterm::execute!(stdout, crossterm::event::PopKeyboardEnhancementFlags);
+        }
+        if self.mouse_capture {
+            let _ = crossterm::execute!(stdout, crossterm::event::DisableMouseCapture);
         }
         if self.alt_screen {
             let _ = crossterm::execute!(stdout, crossterm::terminal::LeaveAlternateScreen);

--- a/crates/eye_declare/src/text_area.rs
+++ b/crates/eye_declare/src/text_area.rs
@@ -95,6 +95,8 @@ impl TextAreaState {
                 }
             }
             InputEvent::Paste(s) => self.insert_str(s),
+            // Mouse (and future event kinds): not editing input.
+            _ => {}
         }
     }
 

--- a/crates/eye_declare/tests/app_headless.rs
+++ b/crates/eye_declare/tests/app_headless.rs
@@ -84,6 +84,7 @@ impl App for Echo {
                     _ => Msg::Typed('?'),
                 },
                 InputEvent::Paste(_) => Msg::Typed('P'),
+                _ => Msg::Typed('?'),
             })
     }
 }

--- a/crates/eye_declare/tests/capabilities.rs
+++ b/crates/eye_declare/tests/capabilities.rs
@@ -117,3 +117,111 @@ fn cursor_style_changes_emit_decscusr_exactly_once() {
     let (bytes, _) = rt.process(Msg::Style(CursorStyle::DefaultUserShape));
     assert!(contains(&bytes, b"\x1b[0 q"));
 }
+
+/// A two-mode app for batch-dispatch semantics: 'm' toggles the mode, 'x'
+/// logs a different char per mode.
+mod batch {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use eye_declare::{
+        App, Ctx, Element, Focus, FocusHandle, InputEvent, Keymap, Runtime, key, keymap, text,
+    };
+
+    #[derive(Clone)]
+    enum Msg {
+        ToggleMode,
+        Log(char),
+    }
+
+    struct Modal {
+        focus: FocusHandle,
+        mode: bool,
+        log: Vec<char>,
+    }
+
+    impl App for Modal {
+        type Msg = Msg;
+        type Output = ();
+
+        fn update(&mut self, msg: Msg, _ctx: &mut Ctx<'_, Self>) {
+            match msg {
+                Msg::ToggleMode => self.mode = !self.mode,
+                Msg::Log(c) => self.log.push(c),
+            }
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            text(format!("{:?}", self.log))
+        }
+
+        fn keymap(&self) -> Keymap<Msg> {
+            let km = keymap().on(key(KeyCode::Char('m')), Msg::ToggleMode);
+            if self.mode {
+                km.on(key(KeyCode::Char('x')), Msg::Log('B'))
+            } else {
+                km.on(key(KeyCode::Char('x')), Msg::Log('a'))
+            }
+            .fallthrough(&self.focus, |_| Msg::Log('?'))
+        }
+
+        fn on_resize(&self, _w: u16, _h: u16) -> Option<Msg> {
+            None
+        }
+    }
+
+    fn modal() -> Modal {
+        let focus = Focus::new();
+        let handle = focus.handle();
+        handle.focus();
+        Modal {
+            focus: handle,
+            mode: false,
+            log: Vec::new(),
+        }
+    }
+
+    fn press(c: char) -> InputEvent {
+        InputEvent::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+    }
+
+    fn count(haystack: &[u8], needle: &[u8]) -> usize {
+        haystack
+            .windows(needle.len())
+            .filter(|w| *w == needle)
+            .count()
+    }
+
+    #[test]
+    fn batch_dispatch_is_interleaved_with_updates() {
+        let mut rt = Runtime::new(modal(), 40, 24);
+        let _ = rt.startup();
+
+        // 'm' flips the mode mid-batch; the following 'x' must resolve
+        // under the NEW mode, exactly as if delivered one at a time.
+        let (_bytes, exit) = rt.handle_batch([press('x'), press('m'), press('x')]);
+        assert!(exit.is_none());
+        assert_eq!(rt.app().log, vec!['a', 'B']);
+    }
+
+    #[test]
+    fn a_batch_presents_exactly_once() {
+        let mut rt = Runtime::new(modal(), 40, 24);
+        let _ = rt.startup();
+
+        let (bytes, _) = rt.handle_batch((0..20).map(|_| press('x')));
+        // One synchronized-update frame for the whole burst.
+        assert_eq!(count(&bytes, b"\x1b[?2026h"), 1);
+        assert_eq!(rt.app().log.len(), 20);
+    }
+
+    #[test]
+    fn an_unmatched_batch_presents_nothing() {
+        let mut rt = Runtime::new(modal(), 40, 24);
+        let _ = rt.startup();
+        // Release events dispatch to nothing (no binding, fallthrough is
+        // for the focused handle — blur it first).
+        rt.app().focus.blur();
+        let (bytes, exit) = rt.handle_batch([press('z')]);
+        assert!(bytes.is_empty());
+        assert!(exit.is_none());
+    }
+}

--- a/docs/content/guide/input.md
+++ b/docs/content/guide/input.md
@@ -109,3 +109,26 @@ let options = RunOptions::default().keyboard(KeyboardProtocol::Custom {
     probe: false,
 });
 ```
+
+## Mouse
+
+With `RunOptions::default().mouse_capture(true)`, mouse events arrive as
+`InputEvent::Mouse` through the keymap [fallthrough](#fallthrough) —
+keymaps resolve key bindings only, so mouse handling is app logic like
+any other unclaimed event:
+
+```rust
+.fallthrough(&self.focus, |ev| match ev {
+    InputEvent::Mouse(m) => match m.kind {
+        MouseEventKind::ScrollUp => Msg::ScrollUp,
+        MouseEventKind::ScrollDown => Msg::ScrollDown,
+        _ => Msg::Noop,
+    },
+    // InputEvent is non-exhaustive; keep a wildcard arm.
+    _ => Msg::Noop,
+})
+```
+
+Capture is off by default because it takes over the terminal's native
+mouse behavior (text selection, copy). Leave it off unless the events
+buy the user something.

--- a/docs/content/reference/runtime.md
+++ b/docs/content/reference/runtime.md
@@ -40,6 +40,7 @@ restore the terminal on exit, including panic unwind.
 | ---------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `keyboard` | `KeyboardProtocol::Legacy` (default) / `Enhanced` / `Custom { flags, probe }` | `Enhanced` requests the kitty protocol's disambiguated escape codes (Shift+Enter vs Enter), falling back to legacy silently where unsupported. `Custom` pushes an explicit flag set; see [input](../../guide/input/). |
 | `screen`   | `ScreenMode::Inline` (default) / `AltScreen`                                | Where the app runs: the main screen (the timeline model), or the alternate screen for fullscreen apps.                                                                             |
+| `mouse_capture` | `bool` (default `false`)                                               | Capture mouse events and deliver them as `InputEvent::Mouse` through the keymap fallthrough. Capture takes over the terminal's native selection, so request it only if you handle the events. |
 
 The struct is `#[non_exhaustive]`; construct with `Default` and the
 setters.


### PR DESCRIPTION
Adds mouse support, sized for a 0.7.0 release: `InputEvent::Mouse`, delivered when the driver runs with `RunOptions::mouse_capture(true)`. Capture stays off by default — it takes over the terminal's native selection and copy, so only apps that handle the events should request it.

The delivery path needed no new machinery: keymaps resolve key bindings only, so mouse events reach the app through the existing fallthrough like any other unclaimed event. The motivating consumer is atuin's search TUI (wheel scrolling with invert-aware semantics); its keybinding layer picks the events up from the same fallthrough that feeds its key pipeline.

**Breaking:** `InputEvent` is now `#[non_exhaustive]` with the new variant, so downstream exhaustive matches need a wildcard arm — which is also what absorbs future event kinds without another major bump. (`CursorStyle` already shipped non-exhaustive in 0.6.5.) The book's input guide gains a Mouse section and the reference table the `mouse_capture` row.
