### PR TITLE
fix: stop teardown drains at the first non-mouse event

### DIFF
--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -198,6 +198,15 @@ where
 /// stream's reader thread owns crossterm's shared reader, so synchronous
 /// `event::poll` sees nothing while the reports flow into the stream.
 /// Bounded: quiet for 5ms or 50ms total.
+///
+/// The spray is contiguous, so the first non-mouse event ends the drain:
+/// bytes not yet read stay in the tty for the shell. The cap is coarser
+/// than one event, though — crossterm reads the tty in chunks (up to
+/// 1KiB) and queues everything it parses, so whatever shared a chunk
+/// with that first non-mouse event is consumed along with it and cannot
+/// be handed back (ttys have no peek, and TIOCSTI is disabled on modern
+/// kernels). A true byte-granular drain requires owning the input path
+/// instead of reading through crossterm.
 async fn shutdown_mouse(
     guard: &mut RawModeGuard,
     stdout: &mut impl Write,
@@ -215,8 +224,8 @@ async fn shutdown_mouse(
         )
         .await
         {
-            Ok(Some(_)) => {}
-            // Quiet, or the stream ended: done.
+            Ok(Some(Ok(crossterm::event::Event::Mouse(_)))) => {}
+            // Quiet, a non-mouse event, a read error, or stream end: done.
             _ => break,
         }
     }
@@ -224,6 +233,7 @@ async fn shutdown_mouse(
 
 /// The pre-loop exit (`App::init` exited): no stream exists yet, so the
 /// synchronous drain works — no reader thread is holding the source.
+/// Stops at the first non-mouse event, like [`shutdown_mouse`].
 fn shutdown_mouse_sync(guard: &mut RawModeGuard, stdout: &mut impl Write) {
     if !guard.take_mouse_capture() {
         return;
@@ -233,7 +243,12 @@ fn shutdown_mouse_sync(guard: &mut RawModeGuard, stdout: &mut impl Write) {
     while std::time::Instant::now() < deadline
         && matches!(crossterm::event::poll(Duration::from_millis(5)), Ok(true))
     {
-        let _ = crossterm::event::read();
+        if !matches!(
+            crossterm::event::read(),
+            Ok(crossterm::event::Event::Mouse(_))
+        ) {
+            break;
+        }
     }
 }
 

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -676,7 +676,11 @@ impl Drop for RawModeGuard {
             // in the parent shell's input as escape-sequence garbage — and
             // has been seen to wedge fragile emulators outright. Drain
             // until quiet, bounded, while raw mode is still on. Costs up to
-            // 50ms at teardown, only for capture-enabled apps.
+            // 50ms at teardown, only for capture-enabled apps. The spray is
+            // contiguous, so the first non-mouse event ends the drain,
+            // leaving unread bytes in the tty for the shell — though
+            // crossterm's chunked reads mean anything it already buffered
+            // is lost with it (see shutdown_mouse in the tokio driver).
             let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
             while std::time::Instant::now() < deadline
                 && matches!(
@@ -684,7 +688,12 @@ impl Drop for RawModeGuard {
                     Ok(true)
                 )
             {
-                let _ = crossterm::event::read();
+                if !matches!(
+                    crossterm::event::read(),
+                    Ok(crossterm::event::Event::Mouse(_))
+                ) {
+                    break;
+                }
             }
         }
         if self.alt_screen {


### PR DESCRIPTION
Dogfooding atuin's eye-declare search surfaced this: all three teardown drains (async driver shutdown, init-exit shutdown, and the `RawModeGuard` drop fallback) read and discard *every* event type for up to 50ms, so keystrokes typed immediately after an app exits can be silently eaten.

The spray of stale mouse reports is contiguous, so the drain now stops at the first non-mouse event, leaving everything not yet read in the tty for the shell.

**Correction from review:** the cap is one crossterm buffer chunk, not one event. Crossterm reads the tty up to 1 KiB per syscall and queues every event it parses, so anything sharing a chunk with the first non-mouse event is consumed with it and cannot be handed back — ttys have no peek, and `TIOCSTI` is disabled on modern kernels. This PR is still a strict improvement (it stops all subsequent chunk reads, and the drain only continues through a *dense* spray — a 5ms gap ends it, so only keys typed into the spray are at risk), but a true byte-granular drain requires eye owning the input path instead of reading through crossterm. That design — which also addresses the CPR startup-latency and reader-thread-lock issues, with a PTY regression harness — is tracked as ATU-580.
