### PR TITLE
feat: durable persist effects and Mailbox handoff

### DIFF
--- a/crates/eye_declare/src/app.rs
+++ b/crates/eye_declare/src/app.rs
@@ -7,7 +7,7 @@ use futures_core::Stream;
 use crate::element::Element;
 use crate::input::Keymap;
 use crate::subscription::Subscriptions;
-use crate::task::{Effect, Task, spawn_effect, spawn_once_effect};
+use crate::task::{Effect, PersistTracker, Task, spawn_effect, spawn_once_effect};
 use crate::timeline::Timeline;
 
 /// An inline application. The implementing struct IS the model: `update`
@@ -78,6 +78,7 @@ pub struct Ctx<'a, A: App> {
     pub(crate) timeline: &'a mut Timeline,
     pub(crate) output: &'a mut Vec<u8>,
     pub(crate) effects: &'a mut Vec<Effect<A::Msg>>,
+    pub(crate) persists: &'a PersistTracker,
     pub(crate) exit: Option<A::Output>,
 }
 
@@ -112,6 +113,28 @@ impl<A: App> Ctx<'_, A> {
         let (effect, task) = spawn_once_effect(future);
         self.effects.push(effect);
         task
+    }
+
+    /// Fire-and-forget work the driver must not abandon: like
+    /// [`perform`](Ctx::perform) + [`Task::detach`], but tracked — the
+    /// driver waits for it at teardown before the run loop returns. For
+    /// effects with durability requirements (a database write, a file
+    /// save) where a quick exit would otherwise race the work against
+    /// process shutdown and silently lose it.
+    ///
+    /// No handle is returned: work that must complete is uncancellable by
+    /// definition. The future's message is delivered normally while the
+    /// app runs and dropped after it exits. Requires an async driver, like
+    /// [`spawn`](Ctx::spawn); the wait is bounded only if the driver's
+    /// options say so (see `RunOptions::persist_grace`).
+    pub fn persist(&mut self, future: impl Future<Output = A::Msg> + Send + 'static) {
+        let guard = self.persists.guard();
+        let (effect, task) = spawn_once_effect(async move {
+            let _guard = guard;
+            future.await
+        });
+        task.detach();
+        self.effects.push(effect);
     }
 
     /// End the run loop; it returns this value after teardown.

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -59,6 +59,16 @@ where
     stdout.flush()?;
     if let Some(output) = init_exit {
         shutdown_mouse_sync(&mut guard, &mut stdout);
+        // An init that persisted work and exited still gets its writes:
+        // spawn the queued effects and wait. (Cancellable effects queued
+        // alongside them start too, but their tasks die with the app —
+        // the pre-persist behavior of never spawning them only held when
+        // nothing needed spawning.)
+        let persists = runtime.persists();
+        if !persists.is_idle() {
+            spawn_effects(runtime.take_effects(), &tx);
+            wait_for_persists(&persists, options.persist_grace).await;
+        }
         return Ok(output);
     }
     spawn_effects(runtime.take_effects(), &tx);
@@ -183,8 +193,23 @@ where
         }
         if let Some(output) = exit {
             shutdown_mouse(&mut guard, &mut stdout, &mut events).await;
+            // The exiting update's effects were spawned above; wait for
+            // any persist work among them (and any still in flight from
+            // earlier updates) before abandoning the runtime.
+            wait_for_persists(&runtime.persists(), options.persist_grace).await;
             return Ok(output);
         }
+    }
+}
+
+/// Wait for [`Ctx::persist`](crate::Ctx::persist) work at teardown,
+/// bounded by the configured grace period.
+async fn wait_for_persists(persists: &crate::task::PersistTracker, grace: Option<Duration>) {
+    match grace {
+        Some(grace) => {
+            let _ = tokio::time::timeout(grace, persists.wait()).await;
+        }
+        None => persists.wait().await,
     }
 }
 

--- a/crates/eye_declare/src/driver_tokio.rs
+++ b/crates/eye_declare/src/driver_tokio.rs
@@ -90,7 +90,13 @@ where
     let mut pending: Vec<InputEvent> = Vec::new();
     let mut last_flush = tokio::time::Instant::now() - FRAME;
 
-    loop {
+    // The loop runs in an inner block so that every way out of it —
+    // a clean exit, stdin closing, or an I/O error from the terminal —
+    // flows through the persist wait below. An early `return` here would
+    // abandon tracked writes to process shutdown, which is exactly what
+    // `Ctx::persist` promises cannot happen.
+    let result: io::Result<A::Output> = async {
+        loop {
         let anim = runtime.animation_interval();
         let flush_at = (!pending.is_empty()).then(|| last_flush + FRAME);
 
@@ -184,22 +190,27 @@ where
             }
         };
 
-        spawn_effects(runtime.take_effects(), &tx);
-        subs.sync(runtime.app().subscriptions());
+            spawn_effects(runtime.take_effects(), &tx);
+            subs.sync(runtime.app().subscriptions());
 
-        if !bytes.is_empty() {
-            stdout.write_all(&bytes)?;
-            stdout.flush()?;
-        }
-        if let Some(output) = exit {
-            shutdown_mouse(&mut guard, &mut stdout, &mut events).await;
-            // The exiting update's effects were spawned above; wait for
-            // any persist work among them (and any still in flight from
-            // earlier updates) before abandoning the runtime.
-            wait_for_persists(&runtime.persists(), options.persist_grace).await;
-            return Ok(output);
+            if !bytes.is_empty() {
+                stdout.write_all(&bytes)?;
+                stdout.flush()?;
+            }
+            if let Some(output) = exit {
+                shutdown_mouse(&mut guard, &mut stdout, &mut events).await;
+                return Ok(output);
+            }
         }
     }
+    .await;
+
+    // The exiting update's effects were spawned before the loop returned;
+    // wait for any persist work among them (and any still in flight from
+    // earlier updates) before abandoning the runtime — on the error paths
+    // too, which is why this sits outside the block.
+    wait_for_persists(&runtime.persists(), options.persist_grace).await;
+    result
 }
 
 /// Wait for [`Ctx::persist`](crate::Ctx::persist) work at teardown,

--- a/crates/eye_declare/src/lib.rs
+++ b/crates/eye_declare/src/lib.rs
@@ -21,6 +21,7 @@ pub mod driver_tokio;
 pub mod element;
 pub mod focus;
 pub mod input;
+pub mod mailbox;
 #[cfg(feature = "markdown")]
 pub mod markdown;
 pub mod panel;
@@ -39,6 +40,7 @@ pub use element::{AnyElement, Element, ElementExt, Empty, Fluent, Padded, empty}
 pub use eye_declare_engine::escape::CursorStyle;
 pub use focus::{Focus, FocusHandle};
 pub use input::{InputEvent, Key, Keymap, key, keymap};
+pub use mailbox::Mailbox;
 #[cfg(feature = "markdown")]
 pub use markdown::{Markdown, MarkdownStyles, markdown};
 pub use panel::{Panel, panel};
@@ -46,7 +48,7 @@ pub use runtime::{KeyboardProtocol, RunOptions, Runtime, ScreenMode, run, run_wi
 pub use spinner::{Spinner, spinner};
 pub use stack::{Col, Row, Width, col, row};
 pub use subscription::Subscriptions;
-pub use task::{Effect, MsgStream, Task};
+pub use task::{Effect, MsgStream, PersistTracker, Task};
 pub use text::{Text, text};
 pub use text_area::{TextArea, TextAreaState, text_area};
 pub use timeline::Timeline;

--- a/crates/eye_declare/src/mailbox.rs
+++ b/crates/eye_declare/src/mailbox.rs
@@ -1,0 +1,117 @@
+//! Exactly-once handoff to an async consumer that might never run.
+//!
+//! The problem this solves: `update` wants to hand a value to spawned
+//! work, but [`Task`](crate::Task)s are cancel-on-drop — a keystroke that
+//! respawns the work cancels the previous task, and any value moved into
+//! it is silently lost. The classic symptom is a mode switch the UI shows
+//! but the backend never received, because the task carrying it was
+//! cancelled before it ran.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+/// A shared slot holding at most one value. [`post`](Mailbox::post) from
+/// `update`; [`take`](Mailbox::take) from whichever spawned task actually
+/// runs. A cancelled task that never ran leaves the value in place for
+/// the next taker, so the handoff survives any amount of task churn.
+///
+/// Posting replaces an undelivered value — the slot carries latest-wins
+/// state (a mode, a config, a target), not a queue.
+///
+/// Clones share the slot. Locking is poison-proof: a panic in another
+/// holder never turns `post`/`take` into a second panic.
+pub struct Mailbox<T> {
+    slot: Arc<Mutex<Option<T>>>,
+}
+
+impl<T> Mailbox<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Put a value in the slot, returning the undelivered value it
+    /// displaced, if any.
+    pub fn post(&self, value: T) -> Option<T> {
+        self.lock().replace(value)
+    }
+
+    /// Claim the value, leaving the slot empty. Returns `None` if there
+    /// is nothing to deliver (already taken, or never posted).
+    pub fn take(&self) -> Option<T> {
+        self.lock().take()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.lock().is_none()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<T>> {
+        self.slot.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+// Manual impls: derives would bound `T`, and sharing/emptiness need no
+// `T: Clone`/`T: Default`.
+impl<T> Clone for Mailbox<T> {
+    fn clone(&self) -> Self {
+        Self {
+            slot: Arc::clone(&self.slot),
+        }
+    }
+}
+
+impl<T> Default for Mailbox<T> {
+    fn default() -> Self {
+        Self {
+            slot: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for Mailbox<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mailbox")
+            .field("occupied", &!self.is_empty())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_claims_the_posted_value() {
+        let mailbox = Mailbox::new();
+        assert_eq!(mailbox.post(1), None);
+        assert_eq!(mailbox.take(), Some(1));
+        assert_eq!(mailbox.take(), None);
+    }
+
+    #[test]
+    fn posting_displaces_an_undelivered_value() {
+        let mailbox = Mailbox::new();
+        mailbox.post("old");
+        assert_eq!(mailbox.post("new"), Some("old"));
+        assert_eq!(mailbox.take(), Some("new"));
+    }
+
+    #[test]
+    fn a_consumer_that_never_runs_leaves_the_value_for_the_next() {
+        let mailbox = Mailbox::new();
+        mailbox.post(7);
+        // The first consumer clone is dropped without taking — the
+        // cancelled-task case.
+        drop(mailbox.clone());
+        assert_eq!(mailbox.clone().take(), Some(7));
+    }
+
+    #[test]
+    fn clones_share_the_slot() {
+        let a: Mailbox<u8> = Mailbox::new();
+        let b = a.clone();
+        a.post(9);
+        assert!(!b.is_empty());
+        assert_eq!(b.take(), Some(9));
+        assert!(a.is_empty());
+    }
+}

--- a/crates/eye_declare/src/runtime.rs
+++ b/crates/eye_declare/src/runtime.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use crate::app::{App, Ctx};
 use crate::element::Element;
 use crate::input::InputEvent;
-use crate::task::Effect;
+use crate::task::{Effect, PersistTracker};
 use crate::timeline::Timeline;
 
 /// The pure core of the run loop: dispatch → update → flush pushes →
@@ -27,6 +27,7 @@ pub struct Runtime<A: App> {
     /// An exit requested from [`App::init`], delivered via
     /// [`startup`](Runtime::startup).
     init_exit: Option<A::Output>,
+    persists: PersistTracker,
 }
 
 impl<A: App> Runtime<A>
@@ -40,10 +41,12 @@ where
         let mut timeline = Timeline::new(width, terminal_height);
         let mut pending = Vec::new();
         let mut effects = Vec::new();
+        let persists = PersistTracker::new();
         let mut ctx = Ctx {
             timeline: &mut timeline,
             output: &mut pending,
             effects: &mut effects,
+            persists: &persists,
             exit: None,
         };
         app.init(&mut ctx);
@@ -55,6 +58,7 @@ where
                 timeline: &mut timeline,
                 output: &mut pending,
                 effects: &mut effects,
+                persists: &persists,
                 exit: None,
             };
             app.update(msg, &mut ctx);
@@ -67,6 +71,7 @@ where
             effects,
             pending,
             init_exit,
+            persists,
         }
     }
 
@@ -171,6 +176,7 @@ where
             timeline: &mut self.timeline,
             output: bytes,
             effects: &mut self.effects,
+            persists: &self.persists,
             exit: None,
         };
         self.app.update(msg, &mut ctx);
@@ -182,6 +188,12 @@ where
     /// [`process`](Runtime::process).
     pub fn take_effects(&mut self) -> Vec<Effect<A::Msg>> {
         std::mem::take(&mut self.effects)
+    }
+
+    /// The tracker for [`Ctx::persist`] work. Drivers wait on it at
+    /// teardown so persist effects are never abandoned mid-flight.
+    pub fn persists(&self) -> PersistTracker {
+        self.persists.clone()
     }
 
     /// Re-present the live tail (also called on animation ticks).
@@ -348,6 +360,7 @@ pub struct RunOptions {
     pub keyboard: KeyboardProtocol,
     pub screen: ScreenMode,
     pub mouse_capture: bool,
+    pub persist_grace: Option<Duration>,
 }
 
 impl RunOptions {
@@ -367,6 +380,16 @@ impl RunOptions {
     /// actually handle mouse events should request it.
     pub fn mouse_capture(mut self, capture: bool) -> Self {
         self.mouse_capture = capture;
+        self
+    }
+
+    /// Cap how long the driver waits for [`Ctx::persist`](crate::Ctx::persist)
+    /// work at teardown. Default: no cap — persist effects are assumed
+    /// short. Set a grace period when a wedged resource (a stuck database,
+    /// an unreachable daemon) must not hang the exit indefinitely; work
+    /// still running when it elapses is abandoned.
+    pub fn persist_grace(mut self, grace: Duration) -> Self {
+        self.persist_grace = Some(grace);
         self
     }
 }

--- a/crates/eye_declare/src/task.rs
+++ b/crates/eye_declare/src/task.rs
@@ -1,4 +1,4 @@
-//! Spawned work and its cancellation story.
+//! Spawned work and its cancellation — and durability — story.
 //!
 //! [`Ctx::spawn`](crate::Ctx::spawn) collects [`Effect`]s during `update`;
 //! a driver (e.g. the tokio one) drains them via
@@ -7,11 +7,16 @@
 //! handle: **dropping it cancels the work**, so cancellation is a plain
 //! assignment (`self.streaming = None`).
 //!
-//! Everything here is executor-agnostic — cancellation is a hand-rolled
-//! waker future, so the core crate stays free of runtime dependencies.
+//! [`Ctx::persist`](crate::Ctx::persist) is the opposite end of the
+//! spectrum: uncancellable work the driver must wait for at teardown,
+//! tracked by [`PersistTracker`].
+//!
+//! Everything here is executor-agnostic — cancellation and the persist
+//! tracker are hand-rolled waker futures, so the core crate stays free of
+//! runtime dependencies.
 
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
@@ -93,6 +98,92 @@ impl Future for Cancelled {
         // Re-check after storing the waker to close the race with a
         // concurrent cancel() that ran between the check and the store.
         if self.cancel.is_cancelled() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+/// Counts in-flight [`Ctx::persist`](crate::Ctx::persist) work so a driver
+/// can wait for it at teardown instead of abandoning it — the whole point
+/// of `persist` over a detached [`Ctx::perform`](crate::Ctx::perform).
+///
+/// Cloning shares the counter. [`Runtime::persists`](crate::Runtime::persists)
+/// hands drivers a clone; [`wait`](PersistTracker::wait) resolves when no
+/// persist work remains. One waiter at a time — a later `wait` displaces
+/// an earlier one's waker (drivers are the only intended waiter).
+#[derive(Clone, Default)]
+pub struct PersistTracker {
+    state: Arc<PersistState>,
+}
+
+#[derive(Default)]
+struct PersistState {
+    count: AtomicUsize,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl PersistTracker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register one unit of persist work; dropping the guard completes it.
+    pub(crate) fn guard(&self) -> PersistGuard {
+        self.state.count.fetch_add(1, Ordering::SeqCst);
+        PersistGuard {
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Whether no persist work is in flight.
+    pub fn is_idle(&self) -> bool {
+        self.state.count.load(Ordering::SeqCst) == 0
+    }
+
+    /// Resolves when all persist work has completed. Requires the work's
+    /// effects to actually be driven — a persist queued but never spawned
+    /// keeps this pending forever.
+    pub fn wait(&self) -> PersistsDone {
+        PersistsDone {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+/// Held across a persist future; Drop marks the work complete even if the
+/// future panicked or was dropped by a dying executor.
+pub(crate) struct PersistGuard {
+    state: Arc<PersistState>,
+}
+
+impl Drop for PersistGuard {
+    fn drop(&mut self) {
+        if self.state.count.fetch_sub(1, Ordering::SeqCst) == 1
+            && let Some(waker) = self.state.waker.lock().unwrap().take()
+        {
+            waker.wake();
+        }
+    }
+}
+
+/// See [`PersistTracker::wait`].
+pub struct PersistsDone {
+    state: Arc<PersistState>,
+}
+
+impl Future for PersistsDone {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.state.count.load(Ordering::SeqCst) == 0 {
+            return Poll::Ready(());
+        }
+        *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
+        // Re-check after storing the waker to close the race with a
+        // concurrent final guard drop between the check and the store.
+        if self.state.count.load(Ordering::SeqCst) == 0 {
             Poll::Ready(())
         } else {
             Poll::Pending
@@ -187,5 +278,75 @@ mod tests {
         let Effect::Spawn { cancel, .. } = effect;
         task.detach();
         assert!(!cancel.is_cancelled());
+    }
+
+    fn poll_once<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+        let waker = Waker::noop();
+        Pin::new(future).poll(&mut Context::from_waker(waker))
+    }
+
+    #[test]
+    fn tracker_is_idle_until_guarded() {
+        let tracker = PersistTracker::new();
+        assert!(tracker.is_idle());
+        let guard = tracker.guard();
+        assert!(!tracker.is_idle());
+        drop(guard);
+        assert!(tracker.is_idle());
+    }
+
+    #[test]
+    fn wait_resolves_when_the_last_guard_drops() {
+        let tracker = PersistTracker::new();
+        let a = tracker.guard();
+        let b = tracker.guard();
+        let mut wait = tracker.wait();
+        assert_eq!(poll_once(&mut wait), Poll::Pending);
+        drop(a);
+        assert_eq!(poll_once(&mut wait), Poll::Pending);
+        drop(b);
+        assert_eq!(poll_once(&mut wait), Poll::Ready(()));
+    }
+
+    #[test]
+    fn wait_on_an_idle_tracker_is_immediate() {
+        let tracker = PersistTracker::new();
+        assert_eq!(poll_once(&mut tracker.wait()), Poll::Ready(()));
+    }
+
+    #[test]
+    fn the_final_guard_drop_wakes_the_waiter() {
+        use std::sync::atomic::AtomicUsize;
+
+        // A waker that counts wakes, so the test observes the wake itself
+        // rather than only the post-wake poll result.
+        static WAKES: AtomicUsize = AtomicUsize::new(0);
+        fn count_waker() -> Waker {
+            use std::task::{RawWaker, RawWakerVTable};
+            fn wake(_: *const ()) {
+                WAKES.fetch_add(1, Ordering::SeqCst);
+            }
+            fn clone(p: *const ()) -> RawWaker {
+                RawWaker::new(p, &VTABLE)
+            }
+            fn drop_raw(_: *const ()) {}
+            static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake, drop_raw);
+            // SAFETY: the vtable functions touch no data pointer.
+            unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+        }
+
+        let tracker = PersistTracker::new();
+        let guard = tracker.guard();
+        let mut wait = tracker.wait();
+        let waker = count_waker();
+        assert!(
+            Pin::new(&mut wait)
+                .poll(&mut Context::from_waker(&waker))
+                .is_pending()
+        );
+        let before = WAKES.load(Ordering::SeqCst);
+        drop(guard);
+        assert_eq!(WAKES.load(Ordering::SeqCst), before + 1);
+        assert_eq!(poll_once(&mut wait), Poll::Ready(()));
     }
 }

--- a/crates/eye_declare/src/task.rs
+++ b/crates/eye_declare/src/task.rs
@@ -17,7 +17,7 @@
 
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::task::{Context, Poll, Waker};
 
 use futures_core::Stream;
@@ -152,6 +152,15 @@ impl PersistTracker {
     }
 }
 
+impl PersistState {
+    // Poison-proof: this lock is taken from a Drop that runs on unwind
+    // paths, where a poisoned mutex would escalate into a double panic —
+    // and a stored waker is valid regardless of who panicked.
+    fn waker(&self) -> std::sync::MutexGuard<'_, Option<Waker>> {
+        self.waker.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
 /// Held across a persist future; Drop marks the work complete even if the
 /// future panicked or was dropped by a dying executor.
 pub(crate) struct PersistGuard {
@@ -161,7 +170,7 @@ pub(crate) struct PersistGuard {
 impl Drop for PersistGuard {
     fn drop(&mut self) {
         if self.state.count.fetch_sub(1, Ordering::SeqCst) == 1
-            && let Some(waker) = self.state.waker.lock().unwrap().take()
+            && let Some(waker) = self.state.waker().take()
         {
             waker.wake();
         }
@@ -180,7 +189,7 @@ impl Future for PersistsDone {
         if self.state.count.load(Ordering::SeqCst) == 0 {
             return Poll::Ready(());
         }
-        *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
+        *self.state.waker() = Some(cx.waker().clone());
         // Re-check after storing the waker to close the race with a
         // concurrent final guard drop between the check and the store.
         if self.state.count.load(Ordering::SeqCst) == 0 {

--- a/crates/eye_declare/tests/async_driver.rs
+++ b/crates/eye_declare/tests/async_driver.rs
@@ -195,3 +195,64 @@ async fn perform_delivers_one_message() {
     drop(tx);
     assert!(rx.recv().await.is_none());
 }
+
+/// The persist path end to end: work queued via `Ctx::persist` in the
+/// same update that exits still runs to completion — even with the
+/// message channel already closed, which is exactly the teardown case —
+/// and the tracker's `wait` resolves once it has.
+#[tokio::test]
+async fn persist_work_completes_after_exit() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Clone)]
+    struct Write;
+
+    struct Saver {
+        wrote: Arc<AtomicBool>,
+    }
+
+    impl App for Saver {
+        type Msg = Write;
+        type Output = ();
+
+        fn update(&mut self, Write: Write, ctx: &mut Ctx<'_, Self>) {
+            let wrote = Arc::clone(&self.wrote);
+            ctx.persist(async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                wrote.store(true, Ordering::SeqCst);
+                Write
+            });
+            ctx.exit(());
+        }
+
+        fn tail(&self) -> impl Element + '_ {
+            text("saving")
+        }
+    }
+
+    let wrote = Arc::new(AtomicBool::new(false));
+    let mut rt = Runtime::new(
+        Saver {
+            wrote: Arc::clone(&wrote),
+        },
+        20,
+        24,
+    );
+    let (_, exit) = rt.process(Write);
+    assert_eq!(exit, Some(()));
+
+    let persists = rt.persists();
+    assert!(!persists.is_idle(), "queued work is tracked immediately");
+
+    // The channel's receiver is dropped up front: after an exit nobody
+    // reads messages, and the work must complete regardless.
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    drop(rx);
+    spawn_effects(rt.take_effects(), &tx);
+
+    tokio::time::timeout(Duration::from_secs(1), persists.wait())
+        .await
+        .expect("persist work must finish and release the tracker");
+    assert!(wrote.load(Ordering::SeqCst), "the write actually ran");
+}

--- a/docs/content/guide/async.md
+++ b/docs/content/guide/async.md
@@ -59,6 +59,61 @@ Msg::Chunk(delta) => {
 }
 ```
 
+## Durable work
+
+Cancel-on-drop has an inverse hazard: work that must *not* die with the
+app. A delete the user confirmed, a file save, a config write — if the
+run loop exits while that future is in flight, a detached task dies with
+the process and the write is silently lost.
+
+`ctx.persist` is `perform` + `detach` for exactly that work: no `Task` is
+returned (work that must complete is uncancellable by definition), and
+the driver waits for every persist future at teardown, before the run
+loop returns:
+
+```rust
+Msg::Delete(entry) => {
+    self.entries.remove(&entry);           // optimistic UI
+    let store = self.store.clone();
+    ctx.persist(async move {
+        store.delete(entry).await;         // survives an immediate exit
+        Msg::DeleteDone
+    });
+}
+```
+
+The message still delivers normally while the app runs, and is dropped
+after exit. By default the teardown wait is unbounded; cap it with
+`RunOptions::persist_grace` when a wedged resource must not hang the
+exit. Custom drivers get the same via `Runtime::persists()` — spawn the
+final effects, then `.wait().await` the tracker.
+
+## Handing values to spawned work
+
+Moving a value *into* a spawned task couples its delivery to that task's
+survival: if a keystroke replaces (cancels) the task before it runs, the
+value is dropped with it. The classic symptom is a mode switch the UI
+shows but the backend never received.
+
+`Mailbox<T>` decouples them — a shared slot where `update` posts and
+whichever task actually runs takes:
+
+```rust
+struct Model { pending_engine: Mailbox<Engine>, /* … */ }
+
+// update: park the swap; any future query installs it.
+Msg::CycleMode => self.pending_engine.post(new_engine),
+
+// inside the spawned query, under whatever lock guards the backend:
+if let Some(engine) = pending_engine.take() {
+    backend.engine = engine;
+}
+```
+
+A cancelled task never reaches `take`, so the value simply waits for the
+next one. Posting replaces an undelivered value — the slot is
+latest-wins state, not a queue.
+
 ## Subscriptions
 
 Recurring inputs are declared, not managed. After every update the driver

--- a/docs/content/reference/runtime.md
+++ b/docs/content/reference/runtime.md
@@ -41,6 +41,7 @@ restore the terminal on exit, including panic unwind.
 | `keyboard` | `KeyboardProtocol::Legacy` (default) / `Enhanced` / `Custom { flags, probe }` | `Enhanced` requests the kitty protocol's disambiguated escape codes (Shift+Enter vs Enter), falling back to legacy silently where unsupported. `Custom` pushes an explicit flag set; see [input](../../guide/input/). |
 | `screen`   | `ScreenMode::Inline` (default) / `AltScreen`                                | Where the app runs: the main screen (the timeline model), or the alternate screen for fullscreen apps.                                                                             |
 | `mouse_capture` | `bool` (default `false`)                                               | Capture mouse events and deliver them as `InputEvent::Mouse` through the keymap fallthrough. Capture takes over the terminal's native selection, so request it only if you handle the events. |
+| `persist_grace` | `Option<Duration>` (default `None`)                                    | Cap the teardown wait for `ctx.persist` work. `None` waits until it completes; set a grace period when a wedged resource must not hang the exit. See [async](../../guide/async/). |
 
 The struct is `#[non_exhaustive]`; construct with `Default` and the
 setters.


### PR DESCRIPTION
Two additions distilled from dogfooding cancel-on-drop at scale in atuin's eye-declare search TUI. Cancel-on-drop is the right default, and it creates exactly two failure shapes that every effectful app will eventually hit; this closes both at the framework level.

**`Ctx::persist(future)`** — `perform` + `detach` for work that must not die with the app: a confirmed delete, a file save, a config write. No `Task` is returned (work that must complete is uncancellable by definition), and the driver waits on the new `PersistTracker` at teardown before the run loop returns — so an exit immediately after the effect can no longer race the write against process shutdown. Today every app has to hand-roll this (atuin currently does it with a `TaskTracker` around the run loop); after this, `ctx.persist` is the whole story. `RunOptions::persist_grace` bounds the wait for wedged resources; custom drivers reach the tracker via `Runtime::persists()`. Works from `init` too, including an init that immediately exits.

**`Mailbox<T>`** — a shared latest-wins slot for handing a value to spawned work without coupling delivery to any one task's survival. Posting from `update`, taking from whichever task actually runs: a cancelled task never takes, so the value waits for the next one. This is the general form of the atuin engine-swap fix, where a mode change moved into a query task was silently dropped when a keystroke cancelled it.

The `Effect` shape is untouched — custom drivers keep compiling — and both additions are executor-agnostic in the core crate (the tracker is the same hand-rolled waker pattern as `Cancel`). Guide and reference docs updated; the follow-up on the atuin side is swapping its `TaskTracker` dance for `ctx.persist` and `Querying`'s hand-rolled slot for `Mailbox` once this publishes.
