### PR TITLE
docs: the book no longer claims inline-only rendering

### DIFF
--- a/docs/content/getting-started/introduction.md
+++ b/docs/content/getting-started/introduction.md
@@ -58,12 +58,23 @@ messages from tasks ─┼─▶ update(&mut model, msg, ctx) ─▶ ctx.push(bl
 The model is a plain struct. `update` takes `&mut self`; `tail` takes
 `&self`. The borrow checker enforces the discipline for free.
 
-## What it's not
+## Inline first, fullscreen too
 
-eye-declare renders inline only. If you want a full-screen, alternate-screen
-application, use [Ratatui](https://ratatui.rs) directly — eye-declare is
-built on Ratatui's primitives and hands you its `Buffer` and `Style` types,
-but it deliberately does not do full-screen layout.
+The timeline is the reason eye-declare exists, and inline is its native
+mode. But the same app can take over the whole terminal:
+`ScreenMode::AltScreen` runs it on the alternate screen, with the tail as
+the entire screen — same model, same `update`, same `tail`, sized to the
+terminal via `App::on_resize`. An app can even choose per invocation, the
+way a shell-history search runs inline at a configured height but goes
+fullscreen on a short terminal. The
+[runtime reference](../../reference/runtime/#fullscreen-the-alt-screen)
+covers what changes — mostly that scrollback, and with it `ctx.push`,
+stops meaning anything.
+
+What eye-declare still isn't: a component-tree framework. It's built on
+[Ratatui](https://ratatui.rs)'s primitives and hands you its `Buffer` and
+`Style` types — Ratatui widgets render directly into elements — but state
+lives in your model, not in a retained tree, in either screen mode.
 
 Continue to [installation](../installation/), or read
 [the timeline](../../guide/the-timeline/) for the semantics that follow from

--- a/docs/content/guide/the-timeline.md
+++ b/docs/content/guide/the-timeline.md
@@ -72,3 +72,13 @@ happens to your shell prompt history. Only the live tail is erased and
 re-rendered at the new width. If a piece of output should stay
 width-responsive for a while, keep it in the tail longer; push it when that
 stops mattering.
+
+## When there is no timeline
+
+Everything above describes inline mode. On the
+[alternate screen](../../reference/runtime/#fullscreen-the-alt-screen)
+(`ScreenMode::AltScreen`) there is no scrollback to commit into: the tail
+*is* the screen, sized to the terminal via `App::on_resize`, and `ctx.push`
+loses its meaning. The model, `update`, and `tail` are unchanged — a
+fullscreen eye-declare app is an inline app whose tail grew to fill the
+terminal.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,17 +1,19 @@
 ---
 title: eye-declare
-description: Inline terminal UIs for Rust
+description: Inline-first terminal UIs for Rust
 ---
 
 # eye-declare
 
-A library for building inline terminal UIs in Rust: interfaces that live in
-your terminal's normal flow, where finished output scrolls into native
-scrollback and only a small live region updates in place.
+A library for building inline-first terminal UIs in Rust: interfaces that
+live in your terminal's normal flow, where finished output scrolls into
+native scrollback and only a small live region updates in place.
 
 eye-declare is built for CLI tools, AI agents, and interactive prompts: the
 programs where output accumulates and history should stay visible, exactly as
-if the program had printed it.
+if the program had printed it. When an app needs the whole terminal instead,
+the same model runs fullscreen on the
+[alternate screen](/book/reference/runtime/#fullscreen-the-alt-screen).
 
 ## Rust Docs
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,14 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>eye-declare: inline UIs are timelines, not trees</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-<style>
-/* ============================================================
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>eye-declare: inline UIs are timelines, not trees</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap"
+            rel="stylesheet"
+        />
+        <style>
+            /* ============================================================
    eye-declare explainer — Atuin brand
    Dark, terminal-native page: DM Sans (light) for prose,
    Space Mono for labels and code, slate hairlines, hex motifs.
@@ -17,867 +20,2152 @@
      blue  = view   (the live tail)
    Gold marks "work happening" (diffing, lit pipeline stages).
    ============================================================ */
-:root {
-  color-scheme: dark;
-  --bg: #101620;
-  --surface: #11161c;            /* cards sit slightly below the page */
-  --surface2: #1a212b;
-  --line: rgba(44, 82, 104, 0.38);
-  --line-strong: rgba(44, 82, 104, 0.66);
-  --text: #e8f0e9;
-  --text-dim: #8fa1a8;
-  --text-faint: #5a6870;
-  --effect: #38c85a;             /* green: push / committed / effects */
-  --effect-bright: #70de90;
-  --effect-soft: rgba(56, 200, 90, 0.1);
-  --effect-border: rgba(56, 200, 90, 0.34);
-  --view: #56b4e0;               /* blue: tail / view / live */
-  --view-bright: #8ccdee;
-  --view-soft: rgba(86, 180, 224, 0.1);
-  --view-border: rgba(86, 180, 224, 0.4);
-  --gold: #f2d08a;
-  --gold-soft: rgba(242, 208, 138, 0.1);
-  --gold-border: rgba(242, 208, 138, 0.5);
-  --term-bg: #1f1f1f;
-  --term-bg2: #262626;
-  --term-border: rgba(44, 82, 104, 0.64);
-  --term-fg: #d8d0bc;
-  --term-dim: #8c8278;
-  --term-effect: #38c85a;        /* green, on the terminal's dark */
-  --term-view: #5cb9e4;          /* blue, on the terminal's dark */
-  --term-green: #c4d86f;
-  --term-red: #f06d5f;
-  --shadow: 0 22px 60px rgba(0, 0, 0, 0.38);
-  --font-head: "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
-  --font-body: "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
-  --font-mono: "Space Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-}
-* { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-  background: radial-gradient(900px 420px at 50% -120px, rgba(56, 200, 90, 0.06), transparent 70%) var(--bg);
-  color: var(--text);
-  font-family: var(--font-body);
-  font-size: 16px;
-  font-weight: 300;
-  line-height: 1.68;
-  padding: 0 40px 80px;
-  border-top: 1px solid var(--effect-border);
-  counter-reset: fig;
-  /* the hero hex pattern intentionally bleeds past the content edge;
+            :root {
+                color-scheme: dark;
+                --bg: #101620;
+                --surface: #11161c; /* cards sit slightly below the page */
+                --surface2: #1a212b;
+                --line: rgba(44, 82, 104, 0.38);
+                --line-strong: rgba(44, 82, 104, 0.66);
+                --text: #e8f0e9;
+                --text-dim: #8fa1a8;
+                --text-faint: #5a6870;
+                --effect: #38c85a; /* green: push / committed / effects */
+                --effect-bright: #70de90;
+                --effect-soft: rgba(56, 200, 90, 0.1);
+                --effect-border: rgba(56, 200, 90, 0.34);
+                --view: #56b4e0; /* blue: tail / view / live */
+                --view-bright: #8ccdee;
+                --view-soft: rgba(86, 180, 224, 0.1);
+                --view-border: rgba(86, 180, 224, 0.4);
+                --gold: #f2d08a;
+                --gold-soft: rgba(242, 208, 138, 0.1);
+                --gold-border: rgba(242, 208, 138, 0.5);
+                --term-bg: #1f1f1f;
+                --term-bg2: #262626;
+                --term-border: rgba(44, 82, 104, 0.64);
+                --term-fg: #d8d0bc;
+                --term-dim: #8c8278;
+                --term-effect: #38c85a; /* green, on the terminal's dark */
+                --term-view: #5cb9e4; /* blue, on the terminal's dark */
+                --term-green: #c4d86f;
+                --term-red: #f06d5f;
+                --shadow: 0 22px 60px rgba(0, 0, 0, 0.38);
+                --font-head: "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+                --font-body: "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+                --font-mono: "Space Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+            }
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+            html {
+                scroll-behavior: smooth;
+            }
+            body {
+                background: radial-gradient(
+                        900px 420px at 50% -120px,
+                        rgba(56, 200, 90, 0.06),
+                        transparent 70%
+                    )
+                    var(--bg);
+                color: var(--text);
+                font-family: var(--font-body);
+                font-size: 16px;
+                font-weight: 300;
+                line-height: 1.68;
+                padding: 0 40px 80px;
+                border-top: 1px solid var(--effect-border);
+                counter-reset: fig;
+                /* the hero hex pattern intentionally bleeds past the content edge;
      clip (not hidden) so the sticky TOC keeps working */
-  overflow-x: clip;
-}
-::selection { background: rgba(56, 200, 90, 0.3); }
-:focus-visible { outline: 2px solid var(--effect); outline-offset: 3px; }
-.wrap {
-  max-width: 1280px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 190px minmax(0, 1fr);
-  gap: 0 44px;
-}
-.main { min-width: 0; }
+                overflow-x: clip;
+            }
+            ::selection {
+                background: rgba(56, 200, 90, 0.3);
+            }
+            :focus-visible {
+                outline: 2px solid var(--effect);
+                outline-offset: 3px;
+            }
+            .wrap {
+                max-width: 1280px;
+                margin: 0 auto;
+                display: grid;
+                grid-template-columns: 190px minmax(0, 1fr);
+                gap: 0 44px;
+            }
+            .main {
+                min-width: 0;
+            }
 
-/* ---------- TOC ---------- */
-.toc {
-  position: sticky; top: 0; align-self: start;
-  padding: 26px 0 14px; grid-row: 1 / -1;
-  max-height: 100dvh; overflow-y: auto;
-  counter-reset: toc -1;
-}
-.toc::-webkit-scrollbar { width: 3px; }
-.toc::-webkit-scrollbar-thumb { background: var(--line-strong); }
-.toc-title {
-  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
-  text-transform: uppercase; letter-spacing: 2px; color: var(--effect);
-  padding-bottom: 8px; margin-bottom: 6px; border-bottom: 1px solid var(--effect-border);
-}
-.toc a {
-  display: flex; gap: 9px; align-items: baseline;
-  font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim);
-  text-decoration: none; padding: 5px 2px;
-  border-bottom: 1px solid var(--line);
-  transition: color .15s, background .15s;
-  line-height: 1.4;
-}
-.toc a::before {
-  counter-increment: toc;
-  content: counter(toc, decimal-leading-zero);
-  font-weight: 700; color: var(--text-faint);
-  flex-shrink: 0; transition: color .15s;
-}
-.toc a:hover { color: var(--text); background: var(--surface2); }
-.toc a:hover::before { color: var(--text-dim); }
-.toc a.active { color: var(--text); }
-.toc a.active::before { color: var(--effect); }
+            /* ---------- TOC ---------- */
+            .toc {
+                position: sticky;
+                top: 0;
+                align-self: start;
+                padding: 26px 0 14px;
+                grid-row: 1 / -1;
+                max-height: 100dvh;
+                overflow-y: auto;
+                counter-reset: toc -1;
+            }
+            .toc::-webkit-scrollbar {
+                width: 3px;
+            }
+            .toc::-webkit-scrollbar-thumb {
+                background: var(--line-strong);
+            }
+            .toc-title {
+                font-family: var(--font-mono);
+                font-size: 10px;
+                font-weight: 700;
+                text-transform: uppercase;
+                letter-spacing: 2px;
+                color: var(--effect);
+                padding-bottom: 8px;
+                margin-bottom: 6px;
+                border-bottom: 1px solid var(--effect-border);
+            }
+            .toc a {
+                display: flex;
+                gap: 9px;
+                align-items: baseline;
+                font-family: var(--font-mono);
+                font-size: 11.5px;
+                color: var(--text-dim);
+                text-decoration: none;
+                padding: 5px 2px;
+                border-bottom: 1px solid var(--line);
+                transition:
+                    color 0.15s,
+                    background 0.15s;
+                line-height: 1.4;
+            }
+            .toc a::before {
+                counter-increment: toc;
+                content: counter(toc, decimal-leading-zero);
+                font-weight: 700;
+                color: var(--text-faint);
+                flex-shrink: 0;
+                transition: color 0.15s;
+            }
+            .toc a:hover {
+                color: var(--text);
+                background: var(--surface2);
+            }
+            .toc a:hover::before {
+                color: var(--text-dim);
+            }
+            .toc a.active {
+                color: var(--text);
+            }
+            .toc a.active::before {
+                color: var(--effect);
+            }
 
-/* ---------- Typography & prose ---------- */
-h1, h2, h3 { font-family: var(--font-head); line-height: 1.12; color: var(--text); }
-h1 { font-size: clamp(44px, 6vw, 72px); font-weight: 300; letter-spacing: -0.03em; }
-h2 { font-size: clamp(25px, 2.8vw, 33px); font-weight: 300; letter-spacing: -0.02em; }
-h3 { font-size: 18px; font-weight: 500; letter-spacing: -0.01em; }
-p { max-width: 72ch; }
-p + p { margin-top: 12px; }
-a { color: var(--effect); text-decoration-thickness: 1px; text-underline-offset: 3px; }
-a:hover { color: var(--effect-bright); }
-strong { font-weight: 600; color: var(--text); }
-.prose em { font-style: italic; }
-code {
-  font-family: var(--font-mono); font-size: 0.85em;
-  background: var(--surface2); border: 1px solid var(--line);
-  border-radius: 4px;
-  padding: 1px 6px 2px; overflow-wrap: anywhere;
-}
-.sec {
-  margin-top: 84px;
-  scroll-margin-top: 20px;
-}
-.sec-head {
-  display: flex; align-items: baseline; gap: 14px; margin-bottom: 14px;
-  border-top: 1px solid var(--line-strong); padding-top: 16px;
-}
-.sec-num {
-  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
-  color: var(--effect); background: var(--effect-soft);
-  border: 1px solid var(--effect-border); border-radius: 4px;
-  padding: 2px 9px 3px;
-  letter-spacing: 1.5px; flex-shrink: 0; transform: translateY(-3px);
-}
-.lede { font-size: 17px; color: var(--text-dim); margin-bottom: 22px; max-width: 74ch; }
-.lede strong { color: var(--text); }
+            /* ---------- Typography & prose ---------- */
+            h1,
+            h2,
+            h3 {
+                font-family: var(--font-head);
+                line-height: 1.12;
+                color: var(--text);
+            }
+            h1 {
+                font-size: clamp(44px, 6vw, 72px);
+                font-weight: 300;
+                letter-spacing: -0.03em;
+            }
+            h2 {
+                font-size: clamp(25px, 2.8vw, 33px);
+                font-weight: 300;
+                letter-spacing: -0.02em;
+            }
+            h3 {
+                font-size: 18px;
+                font-weight: 500;
+                letter-spacing: -0.01em;
+            }
+            p {
+                max-width: 72ch;
+            }
+            p + p {
+                margin-top: 12px;
+            }
+            a {
+                color: var(--effect);
+                text-decoration-thickness: 1px;
+                text-underline-offset: 3px;
+            }
+            a:hover {
+                color: var(--effect-bright);
+            }
+            strong {
+                font-weight: 600;
+                color: var(--text);
+            }
+            .prose em {
+                font-style: italic;
+            }
+            code {
+                font-family: var(--font-mono);
+                font-size: 0.85em;
+                background: var(--surface2);
+                border: 1px solid var(--line);
+                border-radius: 4px;
+                padding: 1px 6px 2px;
+                overflow-wrap: anywhere;
+            }
+            .sec {
+                margin-top: 84px;
+                scroll-margin-top: 20px;
+            }
+            .sec-head {
+                display: flex;
+                align-items: baseline;
+                gap: 14px;
+                margin-bottom: 14px;
+                border-top: 1px solid var(--line-strong);
+                padding-top: 16px;
+            }
+            .sec-num {
+                font-family: var(--font-mono);
+                font-size: 11px;
+                font-weight: 700;
+                color: var(--effect);
+                background: var(--effect-soft);
+                border: 1px solid var(--effect-border);
+                border-radius: 4px;
+                padding: 2px 9px 3px;
+                letter-spacing: 1.5px;
+                flex-shrink: 0;
+                transform: translateY(-3px);
+            }
+            .lede {
+                font-size: 17px;
+                color: var(--text-dim);
+                margin-bottom: 22px;
+                max-width: 74ch;
+            }
+            .lede strong {
+                color: var(--text);
+            }
 
-/* Semantic inline tags used throughout prose */
-.chip {
-  display: inline-block; font-family: var(--font-mono); font-size: 12px; font-weight: 400;
-  padding: 0 8px 1px; white-space: nowrap; border: 1px solid; border-radius: 4px;
-}
-.chip.effect { background: var(--effect-soft); color: var(--effect-bright); border-color: var(--effect-border); }
-.chip.view { background: var(--view-soft); color: var(--view-bright); border-color: var(--view-border); }
+            /* Semantic inline tags used throughout prose */
+            .chip {
+                display: inline-block;
+                font-family: var(--font-mono);
+                font-size: 12px;
+                font-weight: 400;
+                padding: 0 8px 1px;
+                white-space: nowrap;
+                border: 1px solid;
+                border-radius: 4px;
+            }
+            .chip.effect {
+                background: var(--effect-soft);
+                color: var(--effect-bright);
+                border-color: var(--effect-border);
+            }
+            .chip.view {
+                background: var(--view-soft);
+                color: var(--view-bright);
+                border-color: var(--view-border);
+            }
 
-/* ---------- Hero / document header ---------- */
-.hero { position: relative; padding-top: 30px; }
-.hero::before {
-  /* bleed exactly the body gutter (40px, 22px on mobile): any further and
+            /* ---------- Hero / document header ---------- */
+            .hero {
+                position: relative;
+                padding-top: 30px;
+            }
+            .hero::before {
+                /* bleed exactly the body gutter (40px, 22px on mobile): any further and
      the page reports horizontal overflow, which mobile emulation shrinks to fit */
-  content: ""; position: absolute; inset: -30px -40px auto; height: 540px;
-  z-index: -1; pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg width='108' height='186' viewBox='0 0 108 186' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M54 0 108 31V93L54 124 0 93V31L54 0Z M54 124V186' fill='none' stroke='%2316252F' stroke-width='1.35' stroke-linecap='square' stroke-linejoin='miter' opacity='0.82'/%3E%3C/svg%3E");
-  background-position: center -2px;
-  background-size: 108px 186px;
-  mask-image: linear-gradient(to bottom, #000 0, rgba(0, 0, 0, 0.65) 55%, transparent 95%);
-  -webkit-mask-image: linear-gradient(to bottom, #000 0, rgba(0, 0, 0, 0.65) 55%, transparent 95%);
-  opacity: 0.8;
-}
-.doc-head {
-  display: flex; flex-wrap: wrap;
-  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
-  border: 1px solid var(--line-strong); border-left: none; border-right: none;
-  margin-bottom: 26px;
-  background: rgba(16, 22, 32, 0.72);
-}
-.doc-head .dh-item {
-  padding: 6px 16px 6px 0; margin-right: 16px;
-  border-right: 1px solid var(--line);
-  letter-spacing: 0.4px;
-}
-.doc-head .dh-item:last-child { border-right: none; margin-right: 0; }
-.doc-head b {
-  display: block; font-weight: 700; font-size: 9px; letter-spacing: 1.6px;
-  text-transform: uppercase; color: var(--effect);
-}
-.hero h1 .accent { color: var(--effect); }
-.hero-tag {
-  font-size: 18.5px; color: var(--text-dim); margin-top: 12px; max-width: 66ch;
-}
-.hero-tag strong { color: var(--text); }
-.hero-defn {
-  margin: 26px 0 30px; display: flex; flex-wrap: wrap; gap: 0;
-  font-family: var(--font-head); font-size: clamp(17px, 2vw, 20px); font-weight: 500;
-  border: 1px solid var(--line-strong); border-radius: 10px; overflow: hidden;
-  width: fit-content; max-width: 100%;
-}
-.hero-defn .half {
-  padding: 10px 18px 12px;
-  border-left: 1px solid var(--line-strong);
-}
-.hero-defn .half:first-child { border-left: none; }
-.hero-defn .half small {
-  display: block; font-family: var(--font-mono); font-weight: 400; font-size: 10.5px;
-  letter-spacing: 1.4px; text-transform: uppercase; margin-bottom: 2px;
-}
-.hero-defn .half.e { background: rgba(56, 200, 90, 0.08); }
-.hero-defn .half.v { background: rgba(86, 180, 224, 0.08); }
-.hero-defn .half.e small { color: var(--effect); }
-.hero-defn .half.v small { color: var(--view); }
+                content: "";
+                position: absolute;
+                inset: -30px -40px auto;
+                height: 540px;
+                z-index: -1;
+                pointer-events: none;
+                background-image: url("data:image/svg+xml,%3Csvg width='108' height='186' viewBox='0 0 108 186' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M54 0 108 31V93L54 124 0 93V31L54 0Z M54 124V186' fill='none' stroke='%2316252F' stroke-width='1.35' stroke-linecap='square' stroke-linejoin='miter' opacity='0.82'/%3E%3C/svg%3E");
+                background-position: center -2px;
+                background-size: 108px 186px;
+                mask-image: linear-gradient(
+                    to bottom,
+                    #000 0,
+                    rgba(0, 0, 0, 0.65) 55%,
+                    transparent 95%
+                );
+                -webkit-mask-image: linear-gradient(
+                    to bottom,
+                    #000 0,
+                    rgba(0, 0, 0, 0.65) 55%,
+                    transparent 95%
+                );
+                opacity: 0.8;
+            }
+            .doc-head {
+                display: flex;
+                flex-wrap: wrap;
+                font-family: var(--font-mono);
+                font-size: 11px;
+                color: var(--text-dim);
+                border: 1px solid var(--line-strong);
+                border-left: none;
+                border-right: none;
+                margin-bottom: 26px;
+                background: rgba(16, 22, 32, 0.72);
+            }
+            .doc-head .dh-item {
+                padding: 6px 16px 6px 0;
+                margin-right: 16px;
+                border-right: 1px solid var(--line);
+                letter-spacing: 0.4px;
+            }
+            .doc-head .dh-item:last-child {
+                border-right: none;
+                margin-right: 0;
+            }
+            .doc-head b {
+                display: block;
+                font-weight: 700;
+                font-size: 9px;
+                letter-spacing: 1.6px;
+                text-transform: uppercase;
+                color: var(--effect);
+            }
+            .hero h1 .accent {
+                color: var(--effect);
+            }
+            .hero-tag {
+                font-size: 18.5px;
+                color: var(--text-dim);
+                margin-top: 12px;
+                max-width: 66ch;
+            }
+            .hero-tag strong {
+                color: var(--text);
+            }
+            .hero-defn {
+                margin: 26px 0 30px;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0;
+                font-family: var(--font-head);
+                font-size: clamp(17px, 2vw, 20px);
+                font-weight: 500;
+                border: 1px solid var(--line-strong);
+                border-radius: 10px;
+                overflow: hidden;
+                width: fit-content;
+                max-width: 100%;
+            }
+            .hero-defn .half {
+                padding: 10px 18px 12px;
+                border-left: 1px solid var(--line-strong);
+            }
+            .hero-defn .half:first-child {
+                border-left: none;
+            }
+            .hero-defn .half small {
+                display: block;
+                font-family: var(--font-mono);
+                font-weight: 400;
+                font-size: 10.5px;
+                letter-spacing: 1.4px;
+                text-transform: uppercase;
+                margin-bottom: 2px;
+            }
+            .hero-defn .half.e {
+                background: rgba(56, 200, 90, 0.08);
+            }
+            .hero-defn .half.v {
+                background: rgba(86, 180, 224, 0.08);
+            }
+            .hero-defn .half.e small {
+                color: var(--effect);
+            }
+            .hero-defn .half.v small {
+                color: var(--view);
+            }
 
-/* ---------- Terminal windows: numbered plates ---------- */
-.term {
-  background: var(--term-bg); border: 1px solid var(--term-border);
-  border-radius: 8px; overflow: hidden;
-  box-shadow: var(--shadow);
-  font-family: var(--font-mono); font-size: 13px; line-height: 1.55;
-  color: var(--term-fg);
-}
-.term-bar {
-  display: flex; align-items: center; gap: 10px;
-  background: #171d27; border-bottom: 1px solid var(--line-strong);
-  padding: 6px 12px;
-}
-.term-bar::before {
-  counter-increment: fig;
-  content: "FIG. " counter(fig, decimal-leading-zero);
-  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
-  letter-spacing: 1.2px; color: #06100a; background: var(--effect);
-  border-radius: 3px;
-  padding: 1px 8px 2px; flex-shrink: 0;
-}
-.term-dot { display: none; }
-.term-title {
-  font-size: 11px; color: var(--text-dim);
-  letter-spacing: 0.6px; text-transform: uppercase;
-}
-.term-ctl { margin-left: auto; display: flex; gap: 6px; }
-.term-btn {
-  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
-  background: transparent; border: 1px solid var(--line-strong); border-radius: 4px;
-  padding: 1px 9px; cursor: pointer; transition: color .15s, background .15s, border-color .15s;
-}
-.term-btn:hover { color: var(--effect-bright); border-color: var(--effect-border); background: var(--effect-soft); }
-.term-body { padding: 14px 16px 16px; }
-.term-scroll { overflow-y: auto; display: flex; flex-direction: column; }
-.term-scroll::-webkit-scrollbar { width: 6px; }
-.term-scroll::-webkit-scrollbar-thumb { background: #3a3a3a; }
-.term .dim { color: var(--term-dim); }
-.term .grn { color: var(--term-green); }
-.term .amb { color: var(--term-effect); }
-.term .tel { color: var(--term-view); }
-.term .red { color: var(--term-red); }
-.term .b { font-weight: 700; }
+            /* ---------- Terminal windows: numbered plates ---------- */
+            .term {
+                background: var(--term-bg);
+                border: 1px solid var(--term-border);
+                border-radius: 8px;
+                overflow: hidden;
+                box-shadow: var(--shadow);
+                font-family: var(--font-mono);
+                font-size: 13px;
+                line-height: 1.55;
+                color: var(--term-fg);
+            }
+            .term-bar {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                background: #171d27;
+                border-bottom: 1px solid var(--line-strong);
+                padding: 6px 12px;
+            }
+            .term-bar::before {
+                counter-increment: fig;
+                content: "FIG. " counter(fig, decimal-leading-zero);
+                font-family: var(--font-mono);
+                font-size: 10px;
+                font-weight: 700;
+                letter-spacing: 1.2px;
+                color: #06100a;
+                background: var(--effect);
+                border-radius: 3px;
+                padding: 1px 8px 2px;
+                flex-shrink: 0;
+            }
+            .term-dot {
+                display: none;
+            }
+            .term-title {
+                font-size: 11px;
+                color: var(--text-dim);
+                letter-spacing: 0.6px;
+                text-transform: uppercase;
+            }
+            .term-ctl {
+                margin-left: auto;
+                display: flex;
+                gap: 6px;
+            }
+            .term-btn {
+                font-family: var(--font-mono);
+                font-size: 11px;
+                color: var(--text-dim);
+                background: transparent;
+                border: 1px solid var(--line-strong);
+                border-radius: 4px;
+                padding: 1px 9px;
+                cursor: pointer;
+                transition:
+                    color 0.15s,
+                    background 0.15s,
+                    border-color 0.15s;
+            }
+            .term-btn:hover {
+                color: var(--effect-bright);
+                border-color: var(--effect-border);
+                background: var(--effect-soft);
+            }
+            .term-body {
+                padding: 14px 16px 16px;
+            }
+            .term-scroll {
+                overflow-y: auto;
+                display: flex;
+                flex-direction: column;
+            }
+            .term-scroll::-webkit-scrollbar {
+                width: 6px;
+            }
+            .term-scroll::-webkit-scrollbar-thumb {
+                background: #3a3a3a;
+            }
+            .term .dim {
+                color: var(--term-dim);
+            }
+            .term .grn {
+                color: var(--term-green);
+            }
+            .term .amb {
+                color: var(--term-effect);
+            }
+            .term .tel {
+                color: var(--term-view);
+            }
+            .term .red {
+                color: var(--term-red);
+            }
+            .term .b {
+                font-weight: 700;
+            }
 
-/* Committed blocks vs the live tail, inside demo terminals */
-.blk { padding: 2px 10px; border-left: 3px solid transparent; white-space: pre-wrap; overflow-wrap: break-word; }
-.blk.committed { border-left-color: rgba(56, 200, 90, 0.0); }
-.blk.just-committed { animation: sealFlash 1.1s ease-out; }
-@keyframes sealFlash {
-  0% { border-left-color: var(--term-effect); background: rgba(56, 200, 90, 0.16); }
-  100% { border-left-color: rgba(56, 200, 90, 0.0); background: transparent; }
-}
-.tailzone {
-  position: relative; margin-top: 6px; padding: 8px 10px 6px;
-  border-left: 3px solid var(--term-view);
-  background: rgba(92, 185, 228, 0.06);
-  min-height: 30px;
-  white-space: pre-wrap; overflow-wrap: break-word;
-}
-.tailzone .tail-badge {
-  position: absolute; top: -9px; right: 8px;
-  font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase;
-  color: var(--term-view); background: var(--term-bg);
-  border: 1px solid rgba(92, 185, 228, 0.45); border-radius: 3px; padding: 1px 8px;
-}
-.tailzone.gone { border-left-color: transparent; background: transparent; }
-.tailzone.gone .tail-badge { display: none; }
+            /* Committed blocks vs the live tail, inside demo terminals */
+            .blk {
+                padding: 2px 10px;
+                border-left: 3px solid transparent;
+                white-space: pre-wrap;
+                overflow-wrap: break-word;
+            }
+            .blk.committed {
+                border-left-color: rgba(56, 200, 90, 0);
+            }
+            .blk.just-committed {
+                animation: sealFlash 1.1s ease-out;
+            }
+            @keyframes sealFlash {
+                0% {
+                    border-left-color: var(--term-effect);
+                    background: rgba(56, 200, 90, 0.16);
+                }
+                100% {
+                    border-left-color: rgba(56, 200, 90, 0);
+                    background: transparent;
+                }
+            }
+            .tailzone {
+                position: relative;
+                margin-top: 6px;
+                padding: 8px 10px 6px;
+                border-left: 3px solid var(--term-view);
+                background: rgba(92, 185, 228, 0.06);
+                min-height: 30px;
+                white-space: pre-wrap;
+                overflow-wrap: break-word;
+            }
+            .tailzone .tail-badge {
+                position: absolute;
+                top: -9px;
+                right: 8px;
+                font-size: 9px;
+                letter-spacing: 1.2px;
+                text-transform: uppercase;
+                color: var(--term-view);
+                background: var(--term-bg);
+                border: 1px solid rgba(92, 185, 228, 0.45);
+                border-radius: 3px;
+                padding: 1px 8px;
+            }
+            .tailzone.gone {
+                border-left-color: transparent;
+                background: transparent;
+            }
+            .tailzone.gone .tail-badge {
+                display: none;
+            }
 
-/* Fake input widget rendered inside demo tails */
-.tin {
-  border: 1px solid rgba(92, 185, 228, 0.5); border-radius: 4px;
-  padding: 5px 10px; margin-top: 4px; color: var(--term-fg);
-  display: flex; gap: 8px; align-items: baseline;
-}
-.tin .ph { color: var(--term-dim); font-style: italic; }
-.tin-foot { font-size: 10.5px; color: var(--term-dim); text-align: right; margin-top: 3px; }
-.cursor {
-  display: inline-block; width: 8px; height: 1.15em; vertical-align: text-bottom;
-  background: var(--term-view); animation: blink 1.1s steps(1) infinite;
-}
-@keyframes blink { 50% { opacity: 0; } }
+            /* Fake input widget rendered inside demo tails */
+            .tin {
+                border: 1px solid rgba(92, 185, 228, 0.5);
+                border-radius: 4px;
+                padding: 5px 10px;
+                margin-top: 4px;
+                color: var(--term-fg);
+                display: flex;
+                gap: 8px;
+                align-items: baseline;
+            }
+            .tin .ph {
+                color: var(--term-dim);
+                font-style: italic;
+            }
+            .tin-foot {
+                font-size: 10.5px;
+                color: var(--term-dim);
+                text-align: right;
+                margin-top: 3px;
+            }
+            .cursor {
+                display: inline-block;
+                width: 8px;
+                height: 1.15em;
+                vertical-align: text-bottom;
+                background: var(--term-view);
+                animation: blink 1.1s steps(1) infinite;
+            }
+            @keyframes blink {
+                50% {
+                    opacity: 0;
+                }
+            }
 
-.term-legend {
-  display: flex; flex-wrap: wrap; gap: 10px 22px; margin-top: 12px;
-  font-size: 13px; color: var(--text-dim);
-}
-.term-legend .key { display: flex; align-items: center; gap: 8px; }
-.term-legend .swatch { width: 12px; height: 12px; flex-shrink: 0; border-radius: 2px; }
-.term-legend .swatch.e { background: var(--term-effect); }
-.term-legend .swatch.v { background: var(--term-view); }
+            .term-legend {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 10px 22px;
+                margin-top: 12px;
+                font-size: 13px;
+                color: var(--text-dim);
+            }
+            .term-legend .key {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+            .term-legend .swatch {
+                width: 12px;
+                height: 12px;
+                flex-shrink: 0;
+                border-radius: 2px;
+            }
+            .term-legend .swatch.e {
+                background: var(--term-effect);
+            }
+            .term-legend .swatch.v {
+                background: var(--term-view);
+            }
 
-.demo-note {
-  font-size: 13px; color: var(--text-dim); margin-top: 10px; font-style: italic;
-}
+            .demo-note {
+                font-size: 13px;
+                color: var(--text-dim);
+                margin-top: 10px;
+                font-style: italic;
+            }
 
-/* ---------- Cards & panels ---------- */
-.card {
-  background: var(--surface); border: 1px solid var(--line-strong);
-  border-radius: 12px;
-  padding: 16px 18px;
-  min-width: 0;
-}
-.grid2 { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 16px; }
-.grid4 { display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 14px; }
+            /* ---------- Cards & panels ---------- */
+            .card {
+                background: var(--surface);
+                border: 1px solid var(--line-strong);
+                border-radius: 12px;
+                padding: 16px 18px;
+                min-width: 0;
+            }
+            .grid2 {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 16px;
+            }
+            .grid4 {
+                display: grid;
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                gap: 14px;
+            }
 
-/* Code blocks */
-pre.code {
-  background: var(--term-bg); color: var(--term-fg);
-  border: 1px solid var(--term-border); border-radius: 8px;
-  padding: 14px 16px; overflow-x: auto;
-  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.58;
-}
-pre.code .kw { color: #c792ea; } pre.code .fn { color: #82aaff; }
-pre.code .st { color: #a8cc7c; } pre.code .cm { color: #7d8894; font-style: italic; }
-pre.code .ty { color: #ffcb6b; } pre.code .pe { color: var(--term-effect); font-weight: 700; }
-pre.code .pv { color: var(--term-view); font-weight: 700; }
-pre.code .hl-line { background: rgba(56, 200, 90, 0.12); border-left: 3px solid var(--term-effect); padding: 2px 7px 2px 6px; margin-left: -9px; }
-pre.code .hl-line.v { background: rgba(92, 185, 228, 0.11); border-left-color: var(--term-view); }
-pre.code .ghost { opacity: 0.32; }
+            /* Code blocks */
+            pre.code {
+                background: var(--term-bg);
+                color: var(--term-fg);
+                border: 1px solid var(--term-border);
+                border-radius: 8px;
+                padding: 14px 16px;
+                overflow-x: auto;
+                font-family: var(--font-mono);
+                font-size: 12.5px;
+                line-height: 1.58;
+            }
+            pre.code .kw {
+                color: #c792ea;
+            }
+            pre.code .fn {
+                color: #82aaff;
+            }
+            pre.code .st {
+                color: #a8cc7c;
+            }
+            pre.code .cm {
+                color: #7d8894;
+                font-style: italic;
+            }
+            pre.code .ty {
+                color: #ffcb6b;
+            }
+            pre.code .pe {
+                color: var(--term-effect);
+                font-weight: 700;
+            }
+            pre.code .pv {
+                color: var(--term-view);
+                font-weight: 700;
+            }
+            pre.code .hl-line {
+                background: rgba(56, 200, 90, 0.12);
+                border-left: 3px solid var(--term-effect);
+                padding: 2px 7px 2px 6px;
+                margin-left: -9px;
+            }
+            pre.code .hl-line.v {
+                background: rgba(92, 185, 228, 0.11);
+                border-left-color: var(--term-view);
+            }
+            pre.code .ghost {
+                opacity: 0.32;
+            }
 
-button.ctl {
-  font-family: var(--font-mono); font-size: 12px; font-weight: 400;
-  color: var(--text); background: rgba(56, 200, 90, 0.06);
-  border: 1px solid var(--effect-border); border-radius: 8px;
-  padding: 6px 14px; cursor: pointer;
-  transition: background .12s, color .12s, filter .12s;
-}
-button.ctl:hover { background: rgba(56, 200, 90, 0.14); }
-button.ctl:active { background: var(--effect); color: #06100a; }
-button.ctl.primary { background: var(--effect); border-color: var(--effect); color: #06100a; font-weight: 700; }
-button.ctl.primary:hover { filter: brightness(1.08); }
-button.ctl:disabled { opacity: 0.45; cursor: default; }
+            button.ctl {
+                font-family: var(--font-mono);
+                font-size: 12px;
+                font-weight: 400;
+                color: var(--text);
+                background: rgba(56, 200, 90, 0.06);
+                border: 1px solid var(--effect-border);
+                border-radius: 8px;
+                padding: 6px 14px;
+                cursor: pointer;
+                transition:
+                    background 0.12s,
+                    color 0.12s,
+                    filter 0.12s;
+            }
+            button.ctl:hover {
+                background: rgba(56, 200, 90, 0.14);
+            }
+            button.ctl:active {
+                background: var(--effect);
+                color: #06100a;
+            }
+            button.ctl.primary {
+                background: var(--effect);
+                border-color: var(--effect);
+                color: #06100a;
+                font-weight: 700;
+            }
+            button.ctl.primary:hover {
+                filter: brightness(1.08);
+            }
+            button.ctl:disabled {
+                opacity: 0.45;
+                cursor: default;
+            }
 
-@media (max-width: 1000px) {
-  body { padding: 0 22px 60px; }
-  .wrap { grid-template-columns: minmax(0, 1fr); }
-  .toc {
-    position: sticky; top: 0; z-index: 200; max-height: none;
-    display: flex; gap: 4px; align-items: center; overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    background: rgba(16, 22, 32, 0.94); backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--line-strong);
-    padding: 8px 22px; margin: 0 -22px; grid-row: auto;
-  }
-  .toc::-webkit-scrollbar { display: none; }
-  .toc-title { display: none; }
-  .toc a { white-space: nowrap; flex-shrink: 0; border-bottom: 2px solid transparent; padding: 6px 8px; font-size: 10.5px; gap: 6px; }
-  .toc a.active { border-bottom-color: var(--effect); background: var(--surface); }
-  .main { padding-top: 20px; }
-  .sec { scroll-margin-top: 56px; margin-top: 56px; }
-  .grid2, .grid4 { grid-template-columns: minmax(0, 1fr); }
-  .doc-head .dh-item { padding-right: 12px; margin-right: 12px; }
-  .hero::before { left: -22px; right: -22px; }
-}
-@media (max-width: 800px) {
-  /* Stack the doc-metadata strip: label + value per row */
-  .doc-head { flex-direction: column; }
-  .doc-head .dh-item {
-    display: flex; align-items: baseline; gap: 10px;
-    padding: 5px 0; margin-right: 0;
-    border-right: none; border-top: 1px solid var(--line);
-  }
-  .doc-head .dh-item:first-child { border-top: none; }
-  .doc-head b { flex-shrink: 0; min-width: 84px; }
-  /* Effect/view definition halves stack full-width so content fills the border */
-  .hero-defn { width: 100%; }
-  .hero-defn .half { flex: 1 1 100%; border-left: none; border-top: 1px solid var(--line-strong); }
-  .hero-defn .half:first-child { border-top: none; }
-  /* The shape of an app: scenario buttons and flow boxes go top-to-bottom */
-  .loop-tr { flex: 1 1 100%; }
-  .frow { flex-direction: column; }
-  /* Burst demo stacks; the arrow points down */
-  .burst { flex-direction: column; gap: 12px; }
-  .burst-glyph { display: inline-block; margin: 10px 0 4px; transform: rotate(90deg); }
-}
-@media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-  .cursor { animation: none; }
-  .blk.just-committed { animation: none; }
-}
-/* ---------- Trees vs timelines ---------- */
-.vs-controls { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 16px; }
-.tree { font-family: var(--font-mono); font-size: 12.5px; }
-.tnode {
-  border: 1px solid var(--line-strong); border-radius: 6px;
-  padding: 5px 10px; margin: 6px 0; background: var(--surface2);
-  position: relative; transition: border-color .2s, background .2s;
-}
-.tnode .tag {
-  position: absolute; top: -8px; right: 6px; font-size: 9px; letter-spacing: 1px;
-  text-transform: uppercase; color: var(--gold); background: var(--surface);
-  border: 1px solid var(--gold-border); border-radius: 3px; padding: 0 6px;
-  opacity: 0; transition: opacity .15s;
-}
-.tnode.diffing { border-color: var(--gold-border); background: var(--gold-soft); }
-.tnode.diffing > .tag { opacity: 1; }
-.tnode .kids { margin-left: 18px; border-left: 1px dashed var(--line-strong); padding-left: 12px; }
-.tl-mini { font-family: var(--font-mono); font-size: 12.5px; display: flex; flex-direction: column; gap: 6px; }
-.tl-blk {
-  border-left: 3px solid var(--effect); background: var(--surface2);
-  border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
-  border-radius: 0 6px 6px 0;
-  padding: 4px 10px; color: var(--text-dim);
-}
-.tl-blk.flash { animation: lightSeal 1s ease-out; }
-@keyframes lightSeal { 0% { background: rgba(56, 200, 90, 0.2); } 100% { background: var(--surface2); } }
-.tl-tail {
-  border-left: 3px solid var(--view); background: var(--view-soft);
-  border-radius: 0 6px 6px 0;
-  padding: 4px 10px; position: relative;
-  transition: background .2s;
-}
-.tl-tail.rerender { animation: tailFlash .6s ease-out; }
-@keyframes tailFlash { 0% { background: rgba(86, 180, 224, 0.3); } 100% { background: var(--view-soft); } }
-.tl-tail .tag {
-  position: absolute; top: -8px; right: 6px; font-size: 9px; letter-spacing: 1px;
-  text-transform: uppercase; color: var(--view); background: var(--surface);
-  border: 1px solid var(--view-border); border-radius: 3px; padding: 0 6px;
-}
-.vs-caption { font-size: 13.5px; color: var(--text-dim); margin-top: 12px; min-height: 3em; }
-.vs-caption strong { color: var(--text); }
-.vs-title {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: 1.6px; text-transform: uppercase;
-  color: var(--effect); font-weight: 700;
-  border-bottom: 1px solid var(--line-strong); padding-bottom: 6px; margin-bottom: 12px;
-}
+            @media (max-width: 1000px) {
+                body {
+                    padding: 0 22px 60px;
+                }
+                .wrap {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+                .toc {
+                    position: sticky;
+                    top: 0;
+                    z-index: 200;
+                    max-height: none;
+                    display: flex;
+                    gap: 4px;
+                    align-items: center;
+                    overflow-x: auto;
+                    -webkit-overflow-scrolling: touch;
+                    background: rgba(16, 22, 32, 0.94);
+                    backdrop-filter: blur(12px);
+                    border-bottom: 1px solid var(--line-strong);
+                    padding: 8px 22px;
+                    margin: 0 -22px;
+                    grid-row: auto;
+                }
+                .toc::-webkit-scrollbar {
+                    display: none;
+                }
+                .toc-title {
+                    display: none;
+                }
+                .toc a {
+                    white-space: nowrap;
+                    flex-shrink: 0;
+                    border-bottom: 2px solid transparent;
+                    padding: 6px 8px;
+                    font-size: 10.5px;
+                    gap: 6px;
+                }
+                .toc a.active {
+                    border-bottom-color: var(--effect);
+                    background: var(--surface);
+                }
+                .main {
+                    padding-top: 20px;
+                }
+                .sec {
+                    scroll-margin-top: 56px;
+                    margin-top: 56px;
+                }
+                .grid2,
+                .grid4 {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+                .doc-head .dh-item {
+                    padding-right: 12px;
+                    margin-right: 12px;
+                }
+                .hero::before {
+                    left: -22px;
+                    right: -22px;
+                }
+            }
+            @media (max-width: 800px) {
+                /* Stack the doc-metadata strip: label + value per row */
+                .doc-head {
+                    flex-direction: column;
+                }
+                .doc-head .dh-item {
+                    display: flex;
+                    align-items: baseline;
+                    gap: 10px;
+                    padding: 5px 0;
+                    margin-right: 0;
+                    border-right: none;
+                    border-top: 1px solid var(--line);
+                }
+                .doc-head .dh-item:first-child {
+                    border-top: none;
+                }
+                .doc-head b {
+                    flex-shrink: 0;
+                    min-width: 84px;
+                }
+                /* Effect/view definition halves stack full-width so content fills the border */
+                .hero-defn {
+                    width: 100%;
+                }
+                .hero-defn .half {
+                    flex: 1 1 100%;
+                    border-left: none;
+                    border-top: 1px solid var(--line-strong);
+                }
+                .hero-defn .half:first-child {
+                    border-top: none;
+                }
+                /* The shape of an app: scenario buttons and flow boxes go top-to-bottom */
+                .loop-tr {
+                    flex: 1 1 100%;
+                }
+                .frow {
+                    flex-direction: column;
+                }
+                /* Burst demo stacks; the arrow points down */
+                .burst {
+                    flex-direction: column;
+                    gap: 12px;
+                }
+                .burst-glyph {
+                    display: inline-block;
+                    margin: 10px 0 4px;
+                    transform: rotate(90deg);
+                }
+            }
+            @media (prefers-reduced-motion: reduce) {
+                html {
+                    scroll-behavior: auto;
+                }
+                .cursor {
+                    animation: none;
+                }
+                .blk.just-committed {
+                    animation: none;
+                }
+            }
+            /* ---------- Trees vs timelines ---------- */
+            .vs-controls {
+                display: flex;
+                gap: 10px;
+                flex-wrap: wrap;
+                margin-bottom: 16px;
+            }
+            .tree {
+                font-family: var(--font-mono);
+                font-size: 12.5px;
+            }
+            .tnode {
+                border: 1px solid var(--line-strong);
+                border-radius: 6px;
+                padding: 5px 10px;
+                margin: 6px 0;
+                background: var(--surface2);
+                position: relative;
+                transition:
+                    border-color 0.2s,
+                    background 0.2s;
+            }
+            .tnode .tag {
+                position: absolute;
+                top: -8px;
+                right: 6px;
+                font-size: 9px;
+                letter-spacing: 1px;
+                text-transform: uppercase;
+                color: var(--gold);
+                background: var(--surface);
+                border: 1px solid var(--gold-border);
+                border-radius: 3px;
+                padding: 0 6px;
+                opacity: 0;
+                transition: opacity 0.15s;
+            }
+            .tnode.diffing {
+                border-color: var(--gold-border);
+                background: var(--gold-soft);
+            }
+            .tnode.diffing > .tag {
+                opacity: 1;
+            }
+            .tnode .kids {
+                margin-left: 18px;
+                border-left: 1px dashed var(--line-strong);
+                padding-left: 12px;
+            }
+            .tl-mini {
+                font-family: var(--font-mono);
+                font-size: 12.5px;
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+            }
+            .tl-blk {
+                border-left: 3px solid var(--effect);
+                background: var(--surface2);
+                border-top: 1px solid var(--line);
+                border-bottom: 1px solid var(--line);
+                border-radius: 0 6px 6px 0;
+                padding: 4px 10px;
+                color: var(--text-dim);
+            }
+            .tl-blk.flash {
+                animation: lightSeal 1s ease-out;
+            }
+            @keyframes lightSeal {
+                0% {
+                    background: rgba(56, 200, 90, 0.2);
+                }
+                100% {
+                    background: var(--surface2);
+                }
+            }
+            .tl-tail {
+                border-left: 3px solid var(--view);
+                background: var(--view-soft);
+                border-radius: 0 6px 6px 0;
+                padding: 4px 10px;
+                position: relative;
+                transition: background 0.2s;
+            }
+            .tl-tail.rerender {
+                animation: tailFlash 0.6s ease-out;
+            }
+            @keyframes tailFlash {
+                0% {
+                    background: rgba(86, 180, 224, 0.3);
+                }
+                100% {
+                    background: var(--view-soft);
+                }
+            }
+            .tl-tail .tag {
+                position: absolute;
+                top: -8px;
+                right: 6px;
+                font-size: 9px;
+                letter-spacing: 1px;
+                text-transform: uppercase;
+                color: var(--view);
+                background: var(--surface);
+                border: 1px solid var(--view-border);
+                border-radius: 3px;
+                padding: 0 6px;
+            }
+            .vs-caption {
+                font-size: 13.5px;
+                color: var(--text-dim);
+                margin-top: 12px;
+                min-height: 3em;
+            }
+            .vs-caption strong {
+                color: var(--text);
+            }
+            .vs-title {
+                font-family: var(--font-mono);
+                font-size: 10px;
+                letter-spacing: 1.6px;
+                text-transform: uppercase;
+                color: var(--effect);
+                font-weight: 700;
+                border-bottom: 1px solid var(--line-strong);
+                padding-bottom: 6px;
+                margin-bottom: 12px;
+            }
 
-/* ---------- App-shape diagram ---------- */
-.flowd { display: flex; flex-direction: column; gap: 0; margin-top: 8px; }
-.frow { display: flex; gap: 12px; flex-wrap: wrap; align-items: stretch; }
-.dbox {
-  border: 1px solid var(--line-strong); background: var(--surface); border-radius: 8px;
-  padding: 10px 14px; font-family: var(--font-mono); font-size: 13px;
-  transition: border-color .2s, background .2s, box-shadow .2s; min-width: 0; flex: 1;
-  overflow-wrap: anywhere;
-}
-.dbox small { display: block; font-family: var(--font-body); font-size: 12px; color: var(--text-dim); margin-top: 3px; line-height: 1.45; }
-.dbox.lit { border-color: var(--gold-border); background: var(--gold-soft); box-shadow: 0 0 0 1px rgba(242, 208, 138, 0.28); }
-.dbox.e.lit { border-color: var(--effect-border); background: var(--effect-soft); box-shadow: 0 0 0 1px rgba(56, 200, 90, 0.3); }
-.dbox.v.lit { border-color: var(--view-border); background: var(--view-soft); box-shadow: 0 0 0 1px rgba(86, 180, 224, 0.3); }
-.dbox .sig { font-weight: 700; }
-.farrow {
-  text-align: center; color: var(--text-dim); font-family: var(--font-mono);
-  font-size: 15px; padding: 6px 0; display: flex; align-items: center; justify-content: center; gap: 10px;
-}
-.farrow .lbl { font-size: 11.5px; letter-spacing: 0.5px; }
-.floop {
-  font-family: var(--font-mono); font-size: 11.5px; color: var(--effect-bright);
-  border: 1px dashed var(--effect-border); border-radius: 6px; padding: 4px 10px;
-  align-self: center; margin-top: 8px; background: var(--effect-soft);
-  max-width: 100%; overflow-wrap: anywhere; text-align: center;
-}
+            /* ---------- App-shape diagram ---------- */
+            .flowd {
+                display: flex;
+                flex-direction: column;
+                gap: 0;
+                margin-top: 8px;
+            }
+            .frow {
+                display: flex;
+                gap: 12px;
+                flex-wrap: wrap;
+                align-items: stretch;
+            }
+            .dbox {
+                border: 1px solid var(--line-strong);
+                background: var(--surface);
+                border-radius: 8px;
+                padding: 10px 14px;
+                font-family: var(--font-mono);
+                font-size: 13px;
+                transition:
+                    border-color 0.2s,
+                    background 0.2s,
+                    box-shadow 0.2s;
+                min-width: 0;
+                flex: 1;
+                overflow-wrap: anywhere;
+            }
+            .dbox small {
+                display: block;
+                font-family: var(--font-body);
+                font-size: 12px;
+                color: var(--text-dim);
+                margin-top: 3px;
+                line-height: 1.45;
+            }
+            .dbox.lit {
+                border-color: var(--gold-border);
+                background: var(--gold-soft);
+                box-shadow: 0 0 0 1px rgba(242, 208, 138, 0.28);
+            }
+            .dbox.e.lit {
+                border-color: var(--effect-border);
+                background: var(--effect-soft);
+                box-shadow: 0 0 0 1px rgba(56, 200, 90, 0.3);
+            }
+            .dbox.v.lit {
+                border-color: var(--view-border);
+                background: var(--view-soft);
+                box-shadow: 0 0 0 1px rgba(86, 180, 224, 0.3);
+            }
+            .dbox .sig {
+                font-weight: 700;
+            }
+            .farrow {
+                text-align: center;
+                color: var(--text-dim);
+                font-family: var(--font-mono);
+                font-size: 15px;
+                padding: 6px 0;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 10px;
+            }
+            .farrow .lbl {
+                font-size: 11.5px;
+                letter-spacing: 0.5px;
+            }
+            .floop {
+                font-family: var(--font-mono);
+                font-size: 11.5px;
+                color: var(--effect-bright);
+                border: 1px dashed var(--effect-border);
+                border-radius: 6px;
+                padding: 4px 10px;
+                align-self: center;
+                margin-top: 8px;
+                background: var(--effect-soft);
+                max-width: 100%;
+                overflow-wrap: anywhere;
+                text-align: center;
+            }
 
-/* ---------- Seal stepper ---------- */
-.stepper { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: 18px; align-items: start; }
-@media (max-width: 1000px) { .stepper { grid-template-columns: minmax(0, 1fr); } }
-.step-ctl { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-.step-dots { display: flex; gap: 7px; }
-.sdot { width: 10px; height: 10px; border-radius: 2px; background: #2c5268; transition: background .2s, transform .2s; border: none; padding: 0; cursor: pointer; }
-.sdot:hover { background: var(--gold); }
-.sdot.on { background: var(--effect); transform: scale(1.25); }
-.step-label { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); margin-left: auto; margin-bottom: 14px; }
-.step-note { font-size: 14px; margin-top: 12px; min-height: 4.5em; color: var(--text-dim); }
-.step-note strong { color: var(--text); }
-.step-note .stat {
-  display: inline-block; font-family: var(--font-mono); font-size: 12px;
-  background: var(--surface2); border: 1px solid var(--line); border-radius: 4px;
-  padding: 1px 8px; margin-top: 6px; color: var(--text);
-}
+            /* ---------- Seal stepper ---------- */
+            .stepper {
+                display: grid;
+                grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+                gap: 18px;
+                align-items: start;
+            }
+            @media (max-width: 1000px) {
+                .stepper {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+            }
+            .step-ctl {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                margin-bottom: 14px;
+            }
+            .step-dots {
+                display: flex;
+                gap: 7px;
+            }
+            .sdot {
+                width: 10px;
+                height: 10px;
+                border-radius: 2px;
+                background: #2c5268;
+                transition:
+                    background 0.2s,
+                    transform 0.2s;
+                border: none;
+                padding: 0;
+                cursor: pointer;
+            }
+            .sdot:hover {
+                background: var(--gold);
+            }
+            .sdot.on {
+                background: var(--effect);
+                transform: scale(1.25);
+            }
+            .step-label {
+                font-family: var(--font-mono);
+                font-size: 12px;
+                color: var(--text-dim);
+                margin-left: auto;
+                margin-bottom: 14px;
+            }
+            .step-note {
+                font-size: 14px;
+                margin-top: 12px;
+                min-height: 4.5em;
+                color: var(--text-dim);
+            }
+            .step-note strong {
+                color: var(--text);
+            }
+            .step-note .stat {
+                display: inline-block;
+                font-family: var(--font-mono);
+                font-size: 12px;
+                background: var(--surface2);
+                border: 1px solid var(--line);
+                border-radius: 4px;
+                padding: 1px 8px;
+                margin-top: 6px;
+                color: var(--text);
+            }
 
-/* ---------- Dissolved cards ---------- */
-.dis-card h3 { margin-bottom: 7px; font-size: 16.5px; }
-.dis-card p { font-size: 13.8px; color: var(--text-dim); }
-.dis-card p code { font-size: 0.92em; }
-.dis-strike {
-  display: flex; align-items: center; gap: 8px;
-  font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim);
-  background: var(--surface2); border: 1px dashed var(--line-strong); border-radius: 6px;
-  padding: 8px 10px; margin-bottom: 12px;
-  overflow-wrap: anywhere; min-height: 44px;
-}
-.dis-strike code {
-  background: none; border: none; padding: 0; font-size: 11.5px; white-space: normal;
-  text-decoration: line-through; text-decoration-color: var(--effect);
-  text-decoration-thickness: 2px;
-}
-.dis-strike .stamp {
-  margin-left: auto; flex-shrink: 0; font-size: 8.5px; letter-spacing: 1px;
-  text-transform: uppercase; font-weight: 700; color: var(--effect);
-  border: 1.5px solid var(--effect-border); border-radius: 3px; padding: 1px 6px;
-  background: var(--effect-soft);
-  transform: rotate(-5deg);
-}
-/* ---------- Loop narration ---------- */
-.loop-nar {
-  border: 1px solid var(--line); border-left: 3px solid var(--gold); border-radius: 0 8px 8px 0;
-  background: var(--surface);
-  padding: 10px 15px; font-size: 14.5px;
-  color: var(--text-dim); margin-bottom: 16px; min-height: 3.4em; max-width: none;
-  transition: border-color .2s;
-}
-.loop-nar strong { color: var(--text); }
-.loop-ctl { display: flex; align-items: center; gap: 10px; margin-top: 11px; padding-top: 9px; border-top: 1px dashed var(--line); }
-.loop-auto {
-  margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--gold);
-  border: 1px dashed var(--gold-border); border-radius: 4px;
-  padding: 2px 11px; cursor: pointer;
-  /* the button doubles as a progress bar toward the next auto-advance */
-  background: linear-gradient(90deg, rgba(242, 208, 138, 0.24) var(--p, 0%), transparent var(--p, 0%));
-}
-.loop-auto:hover { border-style: solid; }
-.farrow.lit { color: var(--gold); font-weight: 700; }
-.floop.lit { background: var(--effect-soft); border-style: solid; box-shadow: 0 0 0 1px var(--effect-border); }
-.fk-panel.focused { border-color: var(--term-view); box-shadow: 0 0 0 1px rgba(92, 185, 228, 0.35); }
-.fk-panel.focused .fk-title { color: var(--term-view); }
-/* ---------- Elements playground ---------- */
-.play { display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(0, 1fr); gap: 18px; align-items: start; }
-@media (max-width: 1000px) { .play { grid-template-columns: minmax(0, 1fr); } }
-.model-card { margin-bottom: 14px; }
-.model-card .mc-title {
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: 1.6px; text-transform: uppercase;
-  color: var(--effect); font-weight: 700;
-  border-bottom: 1px solid var(--line-strong); padding-bottom: 6px; margin-bottom: 10px;
-}
-.mrow { display: flex; align-items: center; gap: 12px; padding: 7px 0; border-top: 1px dashed var(--line); font-family: var(--font-mono); font-size: 13px; flex-wrap: wrap; }
-.mrow:first-of-type { border-top: none; }
-.mrow .mname { color: var(--text); min-width: 190px; }
-.mrow .mval { color: var(--effect-bright); font-weight: 700; }
-.mrow .mctl { margin-left: auto; display: flex; align-items: center; gap: 6px; }
-.switch { position: relative; width: 40px; height: 22px; cursor: pointer; }
-.switch input { opacity: 0; width: 0; height: 0; }
-.switch .sl {
-  position: absolute; inset: 0; background: var(--surface2); border: 1px solid var(--line-strong); border-radius: 100px; transition: background .2s, border-color .2s;
-}
-.switch .sl::before {
-  content: ""; position: absolute; width: 12px; height: 12px; border-radius: 50%;
-  background: var(--text-dim); top: 4px; left: 4px; transition: transform .2s, background .2s;
-}
-.switch input:checked + .sl { background: var(--view-soft); border-color: var(--view-border); }
-.switch input:checked + .sl::before { transform: translateX(18px); background: var(--view); }
-.mini-btn {
-  font-family: var(--font-mono); font-size: 14px; width: 26px; height: 26px;
-  border: 1px solid var(--line-strong); border-radius: 6px; background: var(--surface2); color: var(--text);
-  cursor: pointer; line-height: 1;
-}
-.mini-btn:hover { background: var(--surface); }
-.mini-btn:active { background: var(--effect); border-color: var(--effect); color: #06100a; }
-.mtext {
-  font-family: var(--font-mono); font-size: 13px; padding: 4px 9px;
-  border: 1px solid var(--line-strong); border-radius: 6px; background: var(--bg);
-  color: var(--text); width: 260px; max-width: 100%;
-}
-.mtext:focus { outline: 2px solid var(--view); outline-offset: 1px; }
-.frame-stat { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); margin-top: 10px; }
-.frame-stat b { color: var(--view); font-weight: 700; }
-/* fake rendered widgets inside the playground tail */
-.fk-spin { color: var(--term-view); padding: 0 0 6px; }
-.fk-panel {
-  position: relative; border: 1px solid var(--term-dim); border-radius: 4px;
-  padding: 8px 12px; margin: 6px 0 2px;
-}
-.fk-panel .fk-title {
-  position: absolute; top: -9px; left: 10px; font-size: 11px;
-  color: var(--term-fg); background: var(--term-bg); padding: 0 6px;
-}
-.fk-panel .fk-foot {
-  position: absolute; bottom: -9px; right: 10px; font-size: 10.5px;
-  color: var(--term-dim); background: var(--term-bg); padding: 0 6px;
-}
-.fk-hit { color: var(--term-dim); padding-top: 3px; }
-.fk-hit b { color: var(--term-fg); font-weight: 400; }
-.tailzone.rr { animation: tailRerender .45s ease-out; }
-@keyframes tailRerender { 0% { background: rgba(92, 185, 228, 0.2); } 100% { background: rgba(92, 185, 228, 0.06); } }
+            /* ---------- Dissolved cards ---------- */
+            .dis-card h3 {
+                margin-bottom: 7px;
+                font-size: 16.5px;
+            }
+            .dis-card p {
+                font-size: 13.8px;
+                color: var(--text-dim);
+            }
+            .dis-card p code {
+                font-size: 0.92em;
+            }
+            .dis-strike {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                font-family: var(--font-mono);
+                font-size: 11.5px;
+                color: var(--text-dim);
+                background: var(--surface2);
+                border: 1px dashed var(--line-strong);
+                border-radius: 6px;
+                padding: 8px 10px;
+                margin-bottom: 12px;
+                overflow-wrap: anywhere;
+                min-height: 44px;
+            }
+            .dis-strike code {
+                background: none;
+                border: none;
+                padding: 0;
+                font-size: 11.5px;
+                white-space: normal;
+                text-decoration: line-through;
+                text-decoration-color: var(--effect);
+                text-decoration-thickness: 2px;
+            }
+            .dis-strike .stamp {
+                margin-left: auto;
+                flex-shrink: 0;
+                font-size: 8.5px;
+                letter-spacing: 1px;
+                text-transform: uppercase;
+                font-weight: 700;
+                color: var(--effect);
+                border: 1.5px solid var(--effect-border);
+                border-radius: 3px;
+                padding: 1px 6px;
+                background: var(--effect-soft);
+                transform: rotate(-5deg);
+            }
+            /* ---------- Loop narration ---------- */
+            .loop-nar {
+                border: 1px solid var(--line);
+                border-left: 3px solid var(--gold);
+                border-radius: 0 8px 8px 0;
+                background: var(--surface);
+                padding: 10px 15px;
+                font-size: 14.5px;
+                color: var(--text-dim);
+                margin-bottom: 16px;
+                min-height: 3.4em;
+                max-width: none;
+                transition: border-color 0.2s;
+            }
+            .loop-nar strong {
+                color: var(--text);
+            }
+            .loop-ctl {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                margin-top: 11px;
+                padding-top: 9px;
+                border-top: 1px dashed var(--line);
+            }
+            .loop-auto {
+                margin-left: auto;
+                font-family: var(--font-mono);
+                font-size: 11px;
+                color: var(--gold);
+                border: 1px dashed var(--gold-border);
+                border-radius: 4px;
+                padding: 2px 11px;
+                cursor: pointer;
+                /* the button doubles as a progress bar toward the next auto-advance */
+                background: linear-gradient(
+                    90deg,
+                    rgba(242, 208, 138, 0.24) var(--p, 0%),
+                    transparent var(--p, 0%)
+                );
+            }
+            .loop-auto:hover {
+                border-style: solid;
+            }
+            .farrow.lit {
+                color: var(--gold);
+                font-weight: 700;
+            }
+            .floop.lit {
+                background: var(--effect-soft);
+                border-style: solid;
+                box-shadow: 0 0 0 1px var(--effect-border);
+            }
+            .fk-panel.focused {
+                border-color: var(--term-view);
+                box-shadow: 0 0 0 1px rgba(92, 185, 228, 0.35);
+            }
+            .fk-panel.focused .fk-title {
+                color: var(--term-view);
+            }
+            /* ---------- Elements playground ---------- */
+            .play {
+                display: grid;
+                grid-template-columns: minmax(0, 1.08fr) minmax(0, 1fr);
+                gap: 18px;
+                align-items: start;
+            }
+            @media (max-width: 1000px) {
+                .play {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+            }
+            .model-card {
+                margin-bottom: 14px;
+            }
+            .model-card .mc-title {
+                font-family: var(--font-mono);
+                font-size: 10px;
+                letter-spacing: 1.6px;
+                text-transform: uppercase;
+                color: var(--effect);
+                font-weight: 700;
+                border-bottom: 1px solid var(--line-strong);
+                padding-bottom: 6px;
+                margin-bottom: 10px;
+            }
+            .mrow {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 7px 0;
+                border-top: 1px dashed var(--line);
+                font-family: var(--font-mono);
+                font-size: 13px;
+                flex-wrap: wrap;
+            }
+            .mrow:first-of-type {
+                border-top: none;
+            }
+            .mrow .mname {
+                color: var(--text);
+                min-width: 190px;
+            }
+            .mrow .mval {
+                color: var(--effect-bright);
+                font-weight: 700;
+            }
+            .mrow .mctl {
+                margin-left: auto;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+            .switch {
+                position: relative;
+                width: 40px;
+                height: 22px;
+                cursor: pointer;
+            }
+            .switch input {
+                opacity: 0;
+                width: 0;
+                height: 0;
+            }
+            .switch .sl {
+                position: absolute;
+                inset: 0;
+                background: var(--surface2);
+                border: 1px solid var(--line-strong);
+                border-radius: 100px;
+                transition:
+                    background 0.2s,
+                    border-color 0.2s;
+            }
+            .switch .sl::before {
+                content: "";
+                position: absolute;
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: var(--text-dim);
+                top: 4px;
+                left: 4px;
+                transition:
+                    transform 0.2s,
+                    background 0.2s;
+            }
+            .switch input:checked + .sl {
+                background: var(--view-soft);
+                border-color: var(--view-border);
+            }
+            .switch input:checked + .sl::before {
+                transform: translateX(18px);
+                background: var(--view);
+            }
+            .mini-btn {
+                font-family: var(--font-mono);
+                font-size: 14px;
+                width: 26px;
+                height: 26px;
+                border: 1px solid var(--line-strong);
+                border-radius: 6px;
+                background: var(--surface2);
+                color: var(--text);
+                cursor: pointer;
+                line-height: 1;
+            }
+            .mini-btn:hover {
+                background: var(--surface);
+            }
+            .mini-btn:active {
+                background: var(--effect);
+                border-color: var(--effect);
+                color: #06100a;
+            }
+            .mtext {
+                font-family: var(--font-mono);
+                font-size: 13px;
+                padding: 4px 9px;
+                border: 1px solid var(--line-strong);
+                border-radius: 6px;
+                background: var(--bg);
+                color: var(--text);
+                width: 260px;
+                max-width: 100%;
+            }
+            .mtext:focus {
+                outline: 2px solid var(--view);
+                outline-offset: 1px;
+            }
+            .frame-stat {
+                font-family: var(--font-mono);
+                font-size: 12px;
+                color: var(--text-dim);
+                margin-top: 10px;
+            }
+            .frame-stat b {
+                color: var(--view);
+                font-weight: 700;
+            }
+            /* fake rendered widgets inside the playground tail */
+            .fk-spin {
+                color: var(--term-view);
+                padding: 0 0 6px;
+            }
+            .fk-panel {
+                position: relative;
+                border: 1px solid var(--term-dim);
+                border-radius: 4px;
+                padding: 8px 12px;
+                margin: 6px 0 2px;
+            }
+            .fk-panel .fk-title {
+                position: absolute;
+                top: -9px;
+                left: 10px;
+                font-size: 11px;
+                color: var(--term-fg);
+                background: var(--term-bg);
+                padding: 0 6px;
+            }
+            .fk-panel .fk-foot {
+                position: absolute;
+                bottom: -9px;
+                right: 10px;
+                font-size: 10.5px;
+                color: var(--term-dim);
+                background: var(--term-bg);
+                padding: 0 6px;
+            }
+            .fk-hit {
+                color: var(--term-dim);
+                padding-top: 3px;
+            }
+            .fk-hit b {
+                color: var(--term-fg);
+                font-weight: 400;
+            }
+            .tailzone.rr {
+                animation: tailRerender 0.45s ease-out;
+            }
+            @keyframes tailRerender {
+                0% {
+                    background: rgba(92, 185, 228, 0.2);
+                }
+                100% {
+                    background: rgba(92, 185, 228, 0.06);
+                }
+            }
 
-/* ---------- Keymap dispatch ---------- */
-.kbrow { display: flex; flex-wrap: wrap; gap: 9px; margin: 14px 0 6px; }
-.keycap {
-  font-family: var(--font-mono); font-size: 13px; font-weight: 400;
-  background: var(--surface2); color: var(--text);
-  border: 1px solid var(--line-strong); border-bottom-width: 3px; border-radius: 6px;
-  padding: 5px 13px; cursor: pointer; transition: transform .08s, border-color .15s, background .12s;
-}
-.keycap:hover { background: var(--surface); border-color: var(--effect-border); }
-.keycap:active { transform: translateY(2px); border-bottom-width: 1px; }
-.keycap:disabled { opacity: 0.5; cursor: default; }
-.kseg { display: inline-flex; border: 1px solid var(--line-strong); border-radius: 6px; overflow: hidden; }
-.kseg button {
-  font-family: var(--font-mono); font-size: 12px; padding: 5px 12px; border: none;
-  background: var(--surface2); color: var(--text-dim); cursor: pointer;
-}
-.kseg button.on { background: var(--view); color: #06121a; font-weight: 700; }
-.tierboard { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
-.tier {
-  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
-  border: 1px solid var(--line-strong); border-radius: 8px; padding: 9px 14px;
-  background: var(--surface); font-family: var(--font-mono); font-size: 12.8px;
-  transition: border-color .18s, background .18s, opacity .3s;
-}
-.tier .tname { font-weight: 700; color: var(--text); min-width: 150px; }
-.tier .tbind { color: var(--text-dim); }
-.tier .tstate { margin-left: auto; font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); opacity: 0; transition: opacity .15s; }
-.tier.checking { border-color: var(--gold-border); background: var(--gold-soft); }
-.tier.checking .tstate { opacity: 1; }
-.tier.pass .tstate { opacity: 1; }
-.tier.claim { border-color: var(--view-border); background: var(--view-soft); }
-.tier.claim .tstate { opacity: 1; color: var(--view-bright); font-weight: 700; }
-.tier.ghost { opacity: 0.42; border-style: dashed; }
-.kresult {
-  margin-top: 12px; font-family: var(--font-mono); font-size: 13.5px;
-  border: 1px solid var(--line); border-left: 3px solid var(--line-strong); border-radius: 0 8px 8px 0;
-  padding: 8px 14px;
-  background: var(--surface); min-height: 2.6em; transition: border-color .2s, background .2s;
-}
-.kresult.got { border-left-color: var(--view); background: var(--view-soft); }
-.kresult.drop { border-left-color: var(--line-strong); color: var(--text-dim); }
-.kresult small { display: block; font-family: var(--font-body); font-size: 12.5px; color: var(--text-dim); margin-top: 2px; }
+            /* ---------- Keymap dispatch ---------- */
+            .kbrow {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 9px;
+                margin: 14px 0 6px;
+            }
+            .keycap {
+                font-family: var(--font-mono);
+                font-size: 13px;
+                font-weight: 400;
+                background: var(--surface2);
+                color: var(--text);
+                border: 1px solid var(--line-strong);
+                border-bottom-width: 3px;
+                border-radius: 6px;
+                padding: 5px 13px;
+                cursor: pointer;
+                transition:
+                    transform 0.08s,
+                    border-color 0.15s,
+                    background 0.12s;
+            }
+            .keycap:hover {
+                background: var(--surface);
+                border-color: var(--effect-border);
+            }
+            .keycap:active {
+                transform: translateY(2px);
+                border-bottom-width: 1px;
+            }
+            .keycap:disabled {
+                opacity: 0.5;
+                cursor: default;
+            }
+            .kseg {
+                display: inline-flex;
+                border: 1px solid var(--line-strong);
+                border-radius: 6px;
+                overflow: hidden;
+            }
+            .kseg button {
+                font-family: var(--font-mono);
+                font-size: 12px;
+                padding: 5px 12px;
+                border: none;
+                background: var(--surface2);
+                color: var(--text-dim);
+                cursor: pointer;
+            }
+            .kseg button.on {
+                background: var(--view);
+                color: #06121a;
+                font-weight: 700;
+            }
+            .tierboard {
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+                margin-top: 14px;
+            }
+            .tier {
+                display: flex;
+                align-items: baseline;
+                gap: 12px;
+                flex-wrap: wrap;
+                border: 1px solid var(--line-strong);
+                border-radius: 8px;
+                padding: 9px 14px;
+                background: var(--surface);
+                font-family: var(--font-mono);
+                font-size: 12.8px;
+                transition:
+                    border-color 0.18s,
+                    background 0.18s,
+                    opacity 0.3s;
+            }
+            .tier .tname {
+                font-weight: 700;
+                color: var(--text);
+                min-width: 150px;
+            }
+            .tier .tbind {
+                color: var(--text-dim);
+            }
+            .tier .tstate {
+                margin-left: auto;
+                font-size: 11px;
+                letter-spacing: 1px;
+                text-transform: uppercase;
+                color: var(--text-dim);
+                opacity: 0;
+                transition: opacity 0.15s;
+            }
+            .tier.checking {
+                border-color: var(--gold-border);
+                background: var(--gold-soft);
+            }
+            .tier.checking .tstate {
+                opacity: 1;
+            }
+            .tier.pass .tstate {
+                opacity: 1;
+            }
+            .tier.claim {
+                border-color: var(--view-border);
+                background: var(--view-soft);
+            }
+            .tier.claim .tstate {
+                opacity: 1;
+                color: var(--view-bright);
+                font-weight: 700;
+            }
+            .tier.ghost {
+                opacity: 0.42;
+                border-style: dashed;
+            }
+            .kresult {
+                margin-top: 12px;
+                font-family: var(--font-mono);
+                font-size: 13.5px;
+                border: 1px solid var(--line);
+                border-left: 3px solid var(--line-strong);
+                border-radius: 0 8px 8px 0;
+                padding: 8px 14px;
+                background: var(--surface);
+                min-height: 2.6em;
+                transition:
+                    border-color 0.2s,
+                    background 0.2s;
+            }
+            .kresult.got {
+                border-left-color: var(--view);
+                background: var(--view-soft);
+            }
+            .kresult.drop {
+                border-left-color: var(--line-strong);
+                color: var(--text-dim);
+            }
+            .kresult small {
+                display: block;
+                font-family: var(--font-body);
+                font-size: 12.5px;
+                color: var(--text-dim);
+                margin-top: 2px;
+            }
 
-/* ---------- Async / cancel ---------- */
-.async-grid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: 18px; align-items: start; }
-@media (max-width: 1000px) { .async-grid { grid-template-columns: minmax(0, 1fr); } }
-.task-val { font-weight: 700; transition: color .2s; }
-.task-val.some { color: var(--view); }
-.task-val.none { color: var(--term-red); }
-.msglog { margin-top: 12px; font-family: var(--font-mono); font-size: 12px; display: flex; flex-direction: column; gap: 3px; }
-.msglog .mlt { font-size: 10.5px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 3px; font-weight: 700; }
-.mline { color: var(--text-dim); border-left: 2px solid var(--line); padding-left: 10px; }
-.mline.new { color: var(--text); border-left-color: var(--view); }
-.mline.stale { text-decoration: line-through; color: var(--text-faint); border-left-color: var(--gold-border); }
-.mline.stale::after { content: " ← stale, ignored"; text-decoration: none; color: var(--gold); font-size: 11px; }
-/* ---------- Performance ---------- */
-.stat-grid { display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 0; margin: 6px 0 20px; border: 1px solid var(--line-strong); border-radius: 12px; overflow: hidden; }
-@media (max-width: 1000px) { .stat-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
-.stat {
-  background: var(--surface); border-right: 1px solid var(--line-strong);
-  padding: 14px 16px 12px;
-}
-.stat:last-child { border-right: none; }
-@media (max-width: 1000px) {
-  .stat:nth-child(2n) { border-right: none; }
-  .stat:nth-child(-n+2) { border-bottom: 1px solid var(--line-strong); }
-}
-.stat .sv { font-family: var(--font-mono); font-size: 27px; font-weight: 400; letter-spacing: -0.04em; line-height: 1.15; color: var(--text); }
-.stat .sv small { font-size: 15px; font-weight: 400; color: var(--text-dim); }
-.stat .sk { font-family: var(--font-mono); font-size: 10px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--effect); font-weight: 700; margin-bottom: 6px; }
-.stat .sd { font-size: 12.8px; color: var(--text-dim); margin-top: 5px; line-height: 1.5; }
-.burst { display: flex; align-items: center; justify-content: center; gap: 26px; flex-wrap: wrap; margin-top: 4px; }
-.burst-dots { display: grid; grid-template-columns: repeat(16, 9px); gap: 4px; }
-.bdot { width: 9px; height: 9px; border-radius: 2px; background: var(--gold); opacity: 0.75; }
-.burst-arrow { font-family: var(--font-mono); color: var(--text-dim); font-size: 13px; text-align: center; }
-.burst-frame {
-  border: 2px solid var(--view-border); border-radius: 8px; padding: 10px 18px;
-  font-family: var(--font-mono); font-size: 13px; background: var(--view-soft); color: var(--view-bright);
-  font-weight: 700; text-align: center;
-}
-.burst-frame small { display: block; font-weight: 400; font-size: 11px; color: var(--text-dim); }
+            /* ---------- Async / cancel ---------- */
+            .async-grid {
+                display: grid;
+                grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+                gap: 18px;
+                align-items: start;
+            }
+            @media (max-width: 1000px) {
+                .async-grid {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+            }
+            .task-val {
+                font-weight: 700;
+                transition: color 0.2s;
+            }
+            .task-val.some {
+                color: var(--view);
+            }
+            .task-val.none {
+                color: var(--term-red);
+            }
+            .msglog {
+                margin-top: 12px;
+                font-family: var(--font-mono);
+                font-size: 12px;
+                display: flex;
+                flex-direction: column;
+                gap: 3px;
+            }
+            .msglog .mlt {
+                font-size: 10.5px;
+                letter-spacing: 1.4px;
+                text-transform: uppercase;
+                color: var(--text-dim);
+                margin-bottom: 3px;
+                font-weight: 700;
+            }
+            .mline {
+                color: var(--text-dim);
+                border-left: 2px solid var(--line);
+                padding-left: 10px;
+            }
+            .mline.new {
+                color: var(--text);
+                border-left-color: var(--view);
+            }
+            .mline.stale {
+                text-decoration: line-through;
+                color: var(--text-faint);
+                border-left-color: var(--gold-border);
+            }
+            .mline.stale::after {
+                content: " ← stale, ignored";
+                text-decoration: none;
+                color: var(--gold);
+                font-size: 11px;
+            }
+            /* ---------- Performance ---------- */
+            .stat-grid {
+                display: grid;
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                gap: 0;
+                margin: 6px 0 20px;
+                border: 1px solid var(--line-strong);
+                border-radius: 12px;
+                overflow: hidden;
+            }
+            @media (max-width: 1000px) {
+                .stat-grid {
+                    grid-template-columns: repeat(2, minmax(0, 1fr));
+                }
+            }
+            .stat {
+                background: var(--surface);
+                border-right: 1px solid var(--line-strong);
+                padding: 14px 16px 12px;
+            }
+            .stat:last-child {
+                border-right: none;
+            }
+            @media (max-width: 1000px) {
+                .stat:nth-child(2n) {
+                    border-right: none;
+                }
+                .stat:nth-child(-n + 2) {
+                    border-bottom: 1px solid var(--line-strong);
+                }
+            }
+            .stat .sv {
+                font-family: var(--font-mono);
+                font-size: 27px;
+                font-weight: 400;
+                letter-spacing: -0.04em;
+                line-height: 1.15;
+                color: var(--text);
+            }
+            .stat .sv small {
+                font-size: 15px;
+                font-weight: 400;
+                color: var(--text-dim);
+            }
+            .stat .sk {
+                font-family: var(--font-mono);
+                font-size: 10px;
+                letter-spacing: 1.4px;
+                text-transform: uppercase;
+                color: var(--effect);
+                font-weight: 700;
+                margin-bottom: 6px;
+            }
+            .stat .sd {
+                font-size: 12.8px;
+                color: var(--text-dim);
+                margin-top: 5px;
+                line-height: 1.5;
+            }
+            .burst {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 26px;
+                flex-wrap: wrap;
+                margin-top: 4px;
+            }
+            .burst-dots {
+                display: grid;
+                grid-template-columns: repeat(16, 9px);
+                gap: 4px;
+            }
+            .bdot {
+                width: 9px;
+                height: 9px;
+                border-radius: 2px;
+                background: var(--gold);
+                opacity: 0.75;
+            }
+            .burst-arrow {
+                font-family: var(--font-mono);
+                color: var(--text-dim);
+                font-size: 13px;
+                text-align: center;
+            }
+            .burst-frame {
+                border: 2px solid var(--view-border);
+                border-radius: 8px;
+                padding: 10px 18px;
+                font-family: var(--font-mono);
+                font-size: 13px;
+                background: var(--view-soft);
+                color: var(--view-bright);
+                font-weight: 700;
+                text-align: center;
+            }
+            .burst-frame small {
+                display: block;
+                font-weight: 400;
+                font-size: 11px;
+                color: var(--text-dim);
+            }
 
-/* ---------- Testing & footer ---------- */
-.test-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: 18px; align-items: start; }
-@media (max-width: 1000px) { .test-grid { grid-template-columns: minmax(0, 1fr); } }
-.footer {
-  margin-top: 90px; border-top: 1px solid var(--line-strong); padding-top: 26px;
-}
-.foot-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 16px; margin-top: 18px; counter-reset: appendix; }
-@media (max-width: 1000px) { .foot-grid { grid-template-columns: minmax(0, 1fr); } }
-.foot-card h3 { font-size: 13px; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 1px; font-family: var(--font-mono); font-weight: 700; }
-.foot-card h3::before {
-  counter-increment: appendix;
-  content: counter(appendix, upper-alpha);
-  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
-  background: var(--effect); color: #06100a; border-radius: 3px; padding: 0 6px; margin-right: 8px;
-  vertical-align: 1px;
-}
-.foot-card ul { list-style: none; }
-.foot-card li { font-size: 13.5px; padding: 3px 0; color: var(--text-dim); }
-.foot-card li code { white-space: normal; }
-.install {
-  font-family: var(--font-mono); font-size: 14px; background: var(--term-bg); color: var(--term-fg);
-  border: 1px solid var(--term-border); border-radius: 8px; padding: 12px 16px; display: inline-block; margin-top: 10px;
-}
-.install .dim { color: var(--term-dim); }
-.colophon { margin-top: 34px; font-size: 12.5px; color: var(--text-dim); font-style: italic; max-width: none; }
-.colophon::after {
-  content: "· END OF DOCUMENT ·";
-  display: block; font-style: normal; font-family: var(--font-mono);
-  font-size: 10px; letter-spacing: 3px; color: var(--text-faint);
-  text-align: center; margin-top: 30px; border-top: 1px solid var(--line); padding-top: 14px;
-}
-</style>
-</head>
-<body>
-<div class="wrap">
+            /* ---------- Testing & footer ---------- */
+            .test-grid {
+                display: grid;
+                grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+                gap: 18px;
+                align-items: start;
+            }
+            @media (max-width: 1000px) {
+                .test-grid {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+            }
+            .footer {
+                margin-top: 90px;
+                border-top: 1px solid var(--line-strong);
+                padding-top: 26px;
+            }
+            .foot-grid {
+                display: grid;
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+                gap: 16px;
+                margin-top: 18px;
+                counter-reset: appendix;
+            }
+            @media (max-width: 1000px) {
+                .foot-grid {
+                    grid-template-columns: minmax(0, 1fr);
+                }
+            }
+            .foot-card h3 {
+                font-size: 13px;
+                margin-bottom: 8px;
+                text-transform: uppercase;
+                letter-spacing: 1px;
+                font-family: var(--font-mono);
+                font-weight: 700;
+            }
+            .foot-card h3::before {
+                counter-increment: appendix;
+                content: counter(appendix, upper-alpha);
+                font-family: var(--font-mono);
+                font-size: 11px;
+                font-weight: 700;
+                background: var(--effect);
+                color: #06100a;
+                border-radius: 3px;
+                padding: 0 6px;
+                margin-right: 8px;
+                vertical-align: 1px;
+            }
+            .foot-card ul {
+                list-style: none;
+            }
+            .foot-card li {
+                font-size: 13.5px;
+                padding: 3px 0;
+                color: var(--text-dim);
+            }
+            .foot-card li code {
+                white-space: normal;
+            }
+            .install {
+                font-family: var(--font-mono);
+                font-size: 14px;
+                background: var(--term-bg);
+                color: var(--term-fg);
+                border: 1px solid var(--term-border);
+                border-radius: 8px;
+                padding: 12px 16px;
+                display: inline-block;
+                margin-top: 10px;
+            }
+            .install .dim {
+                color: var(--term-dim);
+            }
+            .colophon {
+                margin-top: 34px;
+                font-size: 12.5px;
+                color: var(--text-dim);
+                font-style: italic;
+                max-width: none;
+            }
+            .colophon::after {
+                content: "· END OF DOCUMENT ·";
+                display: block;
+                font-style: normal;
+                font-family: var(--font-mono);
+                font-size: 10px;
+                letter-spacing: 3px;
+                color: var(--text-faint);
+                text-align: center;
+                margin-top: 30px;
+                border-top: 1px solid var(--line);
+                padding-top: 14px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrap">
+            <nav class="toc" id="toc">
+                <div class="toc-title">eye-declare</div>
+                <a href="#idea">The idea</a>
+                <a href="#models">Trees vs. timelines</a>
+                <a href="#loop">The shape of an app</a>
+                <a href="#seal">The seal pattern</a>
+                <a href="#dissolved">What disappears</a>
+                <a href="#elements">Elements</a>
+                <a href="#keymap">Keys are data</a>
+                <a href="#async">Async &amp; cancel</a>
+                <a href="#perf">Performance</a>
+                <a href="#testing">Testing</a>
+                <a href="#start">Get started</a>
+            </nav>
 
-<nav class="toc" id="toc">
-  <div class="toc-title">eye-declare</div>
-  <a href="#idea">The idea</a>
-  <a href="#models">Trees vs. timelines</a>
-  <a href="#loop">The shape of an app</a>
-  <a href="#seal">The seal pattern</a>
-  <a href="#dissolved">What disappears</a>
-  <a href="#elements">Elements</a>
-  <a href="#keymap">Keys are data</a>
-  <a href="#async">Async &amp; cancel</a>
-  <a href="#perf">Performance</a>
-  <a href="#testing">Testing</a>
-  <a href="#start">Get started</a>
-</nav>
+            <div class="main">
+                <!-- ================= HERO ================= -->
+                <header class="hero" id="idea">
+                    <div class="doc-head">
+                        <span class="dh-item"><b>name</b> eye-declare</span>
+                        <span class="dh-item"
+                            ><b>origin</b> the <a href="https://atuin.sh/">Atuin</a> team</span
+                        >
+                        <span class="dh-item"
+                            ><b>docs</b>
+                            <a href="https://docs.rs/eye_declare">docs.rs/eye_declare</a></span
+                        >
+                        <span class="dh-item"
+                            ><b>book</b> <a href="/book/">eye-declare.rs/book</a></span
+                        >
+                        <span class="dh-item"
+                            ><b>repo</b>
+                            <a href="https://github.com/atuinsh/eye-declare"
+                                >atuinsh/eye-declare</a
+                            ></span
+                        >
+                    </div>
+                    <h1>eye<span class="accent" style="margin: 0 4px">-</span>declare</h1>
+                    <p class="hero-tag">
+                        Inline terminal UIs: the kind that
+                        <strong>share the terminal with your shell</strong>. Finished output scrolls
+                        into native scrollback like anything else <code>println!</code> ever
+                        printed; only a small live region keeps changing. Built for CLI tools, AI
+                        agents, and interactive prompts.
+                    </p>
 
-<div class="main">
+                    <div class="hero-defn">
+                        <div class="half e">
+                            <small>effect · ctx.push</small>Committed output is an effect.
+                        </div>
+                        <div class="half v">
+                            <small>view · tail(&amp;self)</small>The live tail is a view.
+                        </div>
+                    </div>
 
-<!-- ================= HERO ================= -->
-<header class="hero" id="idea">
-  <div class="doc-head">
-    <span class="dh-item"><b>name</b> eye-declare</span>
-    <span class="dh-item"><b>origin</b> the <a href="https://atuin.sh/">Atuin</a> team</span>
-    <span class="dh-item"><b>docs</b> <a href="https://docs.rs/eye_declare">docs.rs/eye_declare</a></span>
-    <span class="dh-item"><b>book</b> <a href="/book/">eye-declare.rs/book</a></span>
-    <span class="dh-item"><b>repo</b> <a href="https://github.com/atuinsh/eye-declare">atuinsh/eye-declare</a></span>
-  </div>
-  <h1>eye<span class="accent" style="margin: 0 4px;">-</span>declare</h1>
-  <p class="hero-tag">Inline terminal UIs: the kind that <strong>share the terminal with your shell</strong>.
-  Finished output scrolls into native scrollback like anything else <code>println!</code> ever printed;
-  only a small live region keeps changing. Built for CLI tools, AI agents, and interactive prompts.</p>
+                    <div class="term" id="hero-term">
+                        <div class="term-bar">
+                            <span class="term-dot r"></span><span class="term-dot y"></span
+                            ><span class="term-dot g"></span>
+                            <span class="term-title">zsh · a streaming agent, inline</span>
+                            <div class="term-ctl">
+                                <button class="term-btn" id="hero-play">⏸ pause</button>
+                                <button class="term-btn" id="hero-restart">↻ restart</button>
+                            </div>
+                        </div>
+                        <div class="term-body">
+                            <div class="term-scroll" id="hero-scroll" style="height: 380px">
+                                <div id="hero-scrollback"></div>
+                                <div class="tailzone" id="hero-tail">
+                                    <span class="tail-badge">live tail</span>
+                                    <div id="hero-tail-content"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="term-legend">
+                        <span class="key"
+                            ><span class="swatch e"></span
+                            ><span
+                                ><strong>committed</strong>: rendered once via
+                                <code>ctx.push</code>, then owned by the terminal. Scroll up; it's
+                                just output.</span
+                            ></span
+                        >
+                        <span class="key"
+                            ><span class="swatch v"></span
+                            ><span
+                                ><strong>live tail</strong>: a pure view of the model, replaced
+                                wholesale every frame.</span
+                            ></span
+                        >
+                    </div>
+                </header>
 
-  <div class="hero-defn">
-    <div class="half e"><small>effect · ctx.push</small>Committed output is an effect.</div>
-    <div class="half v"><small>view · tail(&amp;self)</small>The live tail is a view.</div>
-  </div>
+                <section style="margin-top: 3rem; text-align: center">
+                    <p style="max-width: 100%">To get started, run</p>
+                    <div class="install">$ <span class="dim">cargo add</span> eye_declare</div>
+                    <p style="max-width: 100%; margin-top: 14px">
+                        Or, <a href="#models">read on to learn more</a>
+                    </p>
+                </section>
 
-  <div class="term" id="hero-term">
-    <div class="term-bar">
-      <span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span>
-      <span class="term-title">zsh · a streaming agent, inline</span>
-      <div class="term-ctl">
-        <button class="term-btn" id="hero-play">⏸ pause</button>
-        <button class="term-btn" id="hero-restart">↻ restart</button>
-      </div>
-    </div>
-    <div class="term-body">
-      <div class="term-scroll" id="hero-scroll" style="height: 380px;">
-        <div id="hero-scrollback"></div>
-        <div class="tailzone" id="hero-tail"><span class="tail-badge">live tail</span><div id="hero-tail-content"></div></div>
-      </div>
-    </div>
-  </div>
-  <div class="term-legend">
-    <span class="key"><span class="swatch e"></span><span><strong>committed</strong>: rendered once via <code>ctx.push</code>, then owned by the terminal. Scroll up; it's just output.</span></span>
-    <span class="key"><span class="swatch v"></span><span><strong>live tail</strong>: a pure view of the model, replaced wholesale every frame.</span></span>
-  </div>
-</header>
+                <!-- ================= TREES VS TIMELINES ================= -->
+                <section class="sec" id="models">
+                    <div class="sec-head">
+                        <span class="sec-num">01</span>
+                        <h2>Most TUI libraries model a screen. Inline apps aren't screens.</h2>
+                    </div>
+                    <p class="lede">
+                        A full-screen app owns a fixed canvas, so a
+                        <strong>retained tree</strong> that gets re-rendered and reconciled makes
+                        sense. An inline app is different. Its output is an
+                        <strong>append-only log with a small live edge</strong>, and modeling that
+                        as a tree means dragging along machinery the shape never needed. Poke both
+                        models below and watch what each one has to do.
+                    </p>
 
-<section style="margin-top: 3rem; text-align: center">
-  <p style="max-width: 100%">To get started, run</p>
-  <div class="install">$ <span class="dim">cargo add</span> eye_declare</div>
-  <p style="max-width: 100%; margin-top: 14px;">Or, <a href="#models">read on to learn more</a></p>
-</section>
+                    <div class="vs-controls">
+                        <button class="ctl primary" id="vs-change">⚡ a keystroke arrives</button>
+                        <button class="ctl" id="vs-finish">✓ a block finishes</button>
+                    </div>
 
-<!-- ================= TREES VS TIMELINES ================= -->
-<section class="sec" id="models">
-  <div class="sec-head"><span class="sec-num">01</span><h2>Most TUI libraries model a screen. Inline apps aren't screens.</h2></div>
-  <p class="lede">A full-screen app owns a fixed canvas, so a <strong>retained tree</strong> that gets re-rendered
-  and reconciled makes sense. An inline app is different. Its output is an <strong>append-only log with a small live edge</strong>,
-  and modeling that as a tree means dragging along machinery the shape never needed.
-  Poke both models below and watch what each one has to do.</p>
+                    <div class="grid2">
+                        <div class="card">
+                            <div class="vs-title">the screen model: a retained tree</div>
+                            <div class="tree" id="vs-tree">
+                                <div class="tnode">
+                                    <span class="tag">diff</span>&lt;App&gt;
+                                    <div class="kids">
+                                        <div class="tnode">
+                                            <span class="tag">diff</span>&lt;Header/&gt;
+                                        </div>
+                                        <div class="tnode">
+                                            <span class="tag">diff</span>&lt;Chat&gt;
+                                            <div class="kids" id="vs-tree-msgs">
+                                                <div class="tnode">
+                                                    <span class="tag">diff</span>&lt;Turn key=1/&gt;
+                                                </div>
+                                                <div class="tnode">
+                                                    <span class="tag">diff</span>&lt;Turn key=2/&gt;
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="tnode">
+                                            <span class="tag">diff</span>&lt;Composer/&gt;
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="vs-caption" id="vs-cap-l">
+                                The framework retains every turn you've ever rendered. Keys,
+                                identity, dirty flags: it reconciles all of it to discover that
+                                almost nothing changed.
+                            </div>
+                        </div>
+                        <div class="card">
+                            <div class="vs-title">the timeline: committed blocks + a live tail</div>
+                            <div class="tl-mini" id="vs-tl">
+                                <div class="tl-blk">❯ hello</div>
+                                <div class="tl-blk">Hi! Ask me anything.</div>
+                                <div class="tl-tail" id="vs-tail">
+                                    <span class="tag">tail</span
+                                    ><span id="vs-tail-text">❯ how does this wor█</span>
+                                </div>
+                            </div>
+                            <div class="vs-caption" id="vs-cap-r">
+                                Committed blocks are terminal output; the library holds no memory of
+                                them at all. Only the tail is live, and it's rebuilt from scratch
+                                every frame.
+                            </div>
+                        </div>
+                    </div>
+                    <p class="demo-note">
+                        Fair's fair: real retained-tree frameworks memoize and skip subtrees rather
+                        than rebuilding naively. But keys, memo boundaries, and dirty flags are
+                        exactly the machinery <em>you</em> maintain to make that work. The
+                        timeline's claim is that the machinery has nothing to do, so it doesn't
+                        exist.
+                    </p>
+                </section>
 
-  <div class="vs-controls">
-    <button class="ctl primary" id="vs-change">⚡ a keystroke arrives</button>
-    <button class="ctl" id="vs-finish">✓ a block finishes</button>
-  </div>
+                <!-- ================= THE LOOP ================= -->
+                <section class="sec" id="loop">
+                    <div class="sec-head">
+                        <span class="sec-num">02</span>
+                        <h2>The shape of an app</h2>
+                    </div>
+                    <p class="lede">
+                        If you've written Elm, iced, or Redux, this is that architecture with one
+                        addition: the timeline. Your model is a plain struct.
+                        <code>update</code> takes <code>&amp;mut self</code> and
+                        <code>tail</code> takes <code>&amp;self</code>, so
+                        <strong>the borrow checker enforces the discipline for free.</strong>
+                    </p>
 
-  <div class="grid2">
-    <div class="card">
-      <div class="vs-title">the screen model: a retained tree</div>
-      <div class="tree" id="vs-tree">
-        <div class="tnode"><span class="tag">diff</span>&lt;App&gt;
-          <div class="kids">
-            <div class="tnode"><span class="tag">diff</span>&lt;Header/&gt;</div>
-            <div class="tnode"><span class="tag">diff</span>&lt;Chat&gt;
-              <div class="kids" id="vs-tree-msgs">
-                <div class="tnode"><span class="tag">diff</span>&lt;Turn key=1/&gt;</div>
-                <div class="tnode"><span class="tag">diff</span>&lt;Turn key=2/&gt;</div>
-              </div>
-            </div>
-            <div class="tnode"><span class="tag">diff</span>&lt;Composer/&gt;</div>
-          </div>
-        </div>
-      </div>
-      <div class="vs-caption" id="vs-cap-l">The framework retains every turn you've ever rendered. Keys, identity,
-      dirty flags: it reconciles all of it to discover that almost nothing changed.</div>
-    </div>
-    <div class="card">
-      <div class="vs-title">the timeline: committed blocks + a live tail</div>
-      <div class="tl-mini" id="vs-tl">
-        <div class="tl-blk">❯ hello</div>
-        <div class="tl-blk">Hi! Ask me anything.</div>
-        <div class="tl-tail" id="vs-tail"><span class="tag">tail</span><span id="vs-tail-text">❯ how does this wor█</span></div>
-      </div>
-      <div class="vs-caption" id="vs-cap-r">Committed blocks are terminal output; the library holds no memory of
-      them at all. Only the tail is live, and it's rebuilt from scratch every frame.</div>
-    </div>
-  </div>
-  <p class="demo-note">Fair's fair: real retained-tree frameworks memoize and skip subtrees rather than
-  rebuilding naively. But keys, memo boundaries, and dirty flags are exactly the machinery <em>you</em>
-  maintain to make that work. The timeline's claim is that the machinery has nothing to do, so it doesn't exist.</p>
-</section>
+                    <div style="display: flex; gap: 10px; margin-bottom: 12px; flex-wrap: wrap">
+                        <button class="ctl loop-tr" data-tr="0">
+                            1 · the user submits a prompt
+                        </button>
+                        <button class="ctl loop-tr" data-tr="1">2 · a chunk arrives</button>
+                        <button class="ctl loop-tr" data-tr="2">3 · the stream ends</button>
+                    </div>
+                    <div class="loop-nar">
+                        <div id="loop-nar">
+                            The three traces above tell one story: a prompt is submitted, the reply
+                            streams in, the turn seals. Press them in order and follow each message
+                            through the loop.
+                        </div>
+                        <div class="loop-ctl" id="loop-ctl">
+                            <button
+                                class="mini-btn"
+                                id="loop-prev"
+                                aria-label="previous step"
+                                disabled
+                            >
+                                ‹
+                            </button>
+                            <div class="step-dots" id="loop-dots"></div>
+                            <button class="mini-btn" id="loop-next" aria-label="next step" disabled>
+                                ›
+                            </button>
+                            <button class="loop-auto" id="loop-auto" hidden>
+                                ⏵ auto-advancing · click to pause
+                            </button>
+                        </div>
+                    </div>
 
-<!-- ================= THE LOOP ================= -->
-<section class="sec" id="loop">
-  <div class="sec-head"><span class="sec-num">02</span><h2>The shape of an app</h2></div>
-  <p class="lede">If you've written Elm, iced, or Redux, this is that architecture with one addition: the timeline.
-  Your model is a plain struct. <code>update</code> takes <code>&amp;mut self</code> and <code>tail</code> takes
-  <code>&amp;self</code>, so <strong>the borrow checker enforces the discipline for free.</strong></p>
+                    <div class="flowd" id="loopd">
+                        <div class="frow">
+                            <div class="dbox" id="lb-ev">
+                                <span class="sig">terminal events</span
+                                ><small
+                                    >keys resolve to messages through your
+                                    <code>Keymap</code></small
+                                >
+                            </div>
+                            <div class="dbox" id="lb-task">
+                                <span class="sig">task messages</span
+                                ><small
+                                    >streams spawned with <code>ctx.spawn</code> feed items
+                                    back</small
+                                >
+                            </div>
+                            <div class="dbox" id="lb-sub">
+                                <span class="sig">subscription ticks</span
+                                ><small>recurring input, declared from the model</small>
+                            </div>
+                        </div>
+                        <div class="farrow" id="lb-msg">▼ <span class="lbl">Msg</span></div>
+                        <div class="frow">
+                            <div class="dbox" id="lb-update" style="flex: 1.4">
+                                <span class="sig">update(&amp;mut model, msg, ctx)</span
+                                ><small
+                                    >the only place state changes: plain Rust, a
+                                    <code>match</code> on your <code>Msg</code></small
+                                >
+                            </div>
+                            <div class="dbox e" id="lb-push">
+                                <span class="sig">ctx.push(block) →</span
+                                ><small
+                                    ><strong>effect:</strong> render once, commit to scrollback.
+                                    Irreversible, like <code>println!</code></small
+                                >
+                            </div>
+                            <div class="dbox e" id="lb-spawn">
+                                <span class="sig">ctx.spawn(stream) ⟳</span
+                                ><small
+                                    ><strong>effect:</strong> async work whose items come back as
+                                    messages ↰</small
+                                >
+                            </div>
+                        </div>
+                        <div class="farrow" id="lb-batch">
+                            ▼ <span class="lbl">then, once per batch</span>
+                        </div>
+                        <div class="frow">
+                            <div class="dbox v" id="lb-tail">
+                                <span class="sig">tail(&amp;self)</span
+                                ><small
+                                    ><strong>view:</strong> pure function of the model; rebuilt
+                                    wholesale</small
+                                >
+                            </div>
+                            <div class="dbox v" id="lb-diff">
+                                <span class="sig">diff</span
+                                ><small
+                                    >identical tails diff to zero bytes; that's the whole
+                                    optimization</small
+                                >
+                            </div>
+                            <div class="dbox v" id="lb-term">
+                                <span class="sig">terminal</span
+                                ><small
+                                    >minimal escape sequences; the engine owns cursor
+                                    discipline</small
+                                >
+                            </div>
+                        </div>
+                        <div class="floop" id="lb-loop">
+                            ⟳ ctx.spawn's stream items (and one queued straggler after a cancel)
+                            re-enter as messages at the top
+                        </div>
+                    </div>
+                </section>
 
-  <div style="display:flex; gap:10px; margin-bottom:12px; flex-wrap:wrap;">
-    <button class="ctl loop-tr" data-tr="0">1 · the user submits a prompt</button>
-    <button class="ctl loop-tr" data-tr="1">2 · a chunk arrives</button>
-    <button class="ctl loop-tr" data-tr="2">3 · the stream ends</button>
-  </div>
-  <div class="loop-nar">
-    <div id="loop-nar">The three traces above tell one story: a prompt is submitted, the reply
-    streams in, the turn seals. Press them in order and follow each message through the loop.</div>
-    <div class="loop-ctl" id="loop-ctl">
-      <button class="mini-btn" id="loop-prev" aria-label="previous step" disabled>‹</button>
-      <div class="step-dots" id="loop-dots"></div>
-      <button class="mini-btn" id="loop-next" aria-label="next step" disabled>›</button>
-      <button class="loop-auto" id="loop-auto" hidden>⏵ auto-advancing · click to pause</button>
-    </div>
-  </div>
+                <!-- ================= SEAL ================= -->
+                <section class="sec" id="seal">
+                    <div class="sec-head">
+                        <span class="sec-num">03</span>
+                        <h2>
+                            Push is
+                            <code style="font-size: 0.7em; vertical-align: middle">println!</code>
+                            for elements, and sealing is nearly free
+                        </h2>
+                    </div>
+                    <p class="lede">
+                        The characteristic move of a streaming app: content lives in the
+                        <span class="chip view">tail</span> while it's changing, and is pushed to
+                        the <span class="chip effect">timeline</span> the moment it can no longer
+                        change. Step through one streamed turn:
+                    </p>
 
-  <div class="flowd" id="loopd">
-    <div class="frow">
-      <div class="dbox" id="lb-ev"><span class="sig">terminal events</span><small>keys resolve to messages through your <code>Keymap</code></small></div>
-      <div class="dbox" id="lb-task"><span class="sig">task messages</span><small>streams spawned with <code>ctx.spawn</code> feed items back</small></div>
-      <div class="dbox" id="lb-sub"><span class="sig">subscription ticks</span><small>recurring input, declared from the model</small></div>
-    </div>
-    <div class="farrow" id="lb-msg">▼ <span class="lbl">Msg</span></div>
-    <div class="frow">
-      <div class="dbox" id="lb-update" style="flex:1.4;"><span class="sig">update(&amp;mut model, msg, ctx)</span><small>the only place state changes: plain Rust, a <code>match</code> on your <code>Msg</code></small></div>
-      <div class="dbox e" id="lb-push"><span class="sig">ctx.push(block) →</span><small><strong>effect:</strong> render once, commit to scrollback. Irreversible, like <code>println!</code></small></div>
-      <div class="dbox e" id="lb-spawn"><span class="sig">ctx.spawn(stream) ⟳</span><small><strong>effect:</strong> async work whose items come back as messages ↰</small></div>
-    </div>
-    <div class="farrow" id="lb-batch">▼ <span class="lbl">then, once per batch</span></div>
-    <div class="frow">
-      <div class="dbox v" id="lb-tail"><span class="sig">tail(&amp;self)</span><small><strong>view:</strong> pure function of the model; rebuilt wholesale</small></div>
-      <div class="dbox v" id="lb-diff"><span class="sig">diff</span><small>identical tails diff to zero bytes; that's the whole optimization</small></div>
-      <div class="dbox v" id="lb-term"><span class="sig">terminal</span><small>minimal escape sequences; the engine owns cursor discipline</small></div>
-    </div>
-    <div class="floop" id="lb-loop">⟳ ctx.spawn's stream items (and one queued straggler after a cancel) re-enter as messages at the top</div>
-  </div>
-</section>
+                    <div class="step-ctl">
+                        <button class="ctl" id="seal-prev">← prev</button>
+                        <button class="ctl primary" id="seal-next">next →</button>
+                        <div class="step-dots" id="seal-dots"></div>
+                    </div>
+                    <div class="step-label" id="seal-lbl"></div>
 
-<!-- ================= SEAL ================= -->
-<section class="sec" id="seal">
-  <div class="sec-head"><span class="sec-num">03</span><h2>Push is <code style="font-size:0.7em; vertical-align:middle;">println!</code> for elements, and sealing is nearly free</h2></div>
-  <p class="lede">The characteristic move of a streaming app: content lives in the <span class="chip view">tail</span>
-  while it's changing, and is pushed to the <span class="chip effect">timeline</span> the moment it can no longer change.
-  Step through one streamed turn:</p>
-
-  <div class="step-ctl">
-    <button class="ctl" id="seal-prev">← prev</button>
-    <button class="ctl primary" id="seal-next">next →</button>
-    <div class="step-dots" id="seal-dots"></div>
-  </div>
-  <div class="step-label" id="seal-lbl"></div>
-
-  <div class="stepper">
-    <div>
-      <pre class="code" id="seal-code"><span data-sl="all"><span class="kw">match</span> msg {</span>
+                    <div class="stepper">
+                        <div>
+                            <pre
+                                class="code"
+                                id="seal-code"
+                            ><span data-sl="all"><span class="kw">match</span> msg {</span>
 <span data-sl="1,2">    <span class="ty">Msg</span>::Chunk(delta) <span class="kw">=&gt;</span> <span class="kw">self</span>.reply.push_str(&amp;delta),</span>
 <span data-sl="3">    <span class="ty">Msg</span>::StreamDone <span class="kw">=&gt;</span> {</span>
 <span data-sl="3">        <span class="kw">let</span> reply = std::mem::take(&amp;<span class="kw">mut self</span>.reply);</span>
@@ -891,86 +2179,162 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
 <span data-sl="0,1,2">            c.child(spinner(<span class="st">"Thinking…"</span>)))</span>
 <span data-sl="0,1,2">        .child(text(<span class="kw">self</span>.reply.as_str()))</span>
 <span data-sl="all">}</span></pre>
-      <div class="step-note" id="seal-note"></div>
-    </div>
-    <div>
-      <div class="term">
-        <div class="term-bar">
-          <span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span>
-          <span class="term-title">one turn, frame by frame</span>
-        </div>
-        <div class="term-body">
-          <div class="term-scroll" style="height: 190px;">
-            <div id="seal-scrollback"><div class="blk committed"><span class="dim">❯</span> <span class="tel">why is sealing cheap?</span></div></div>
-            <div class="tailzone" id="seal-tail"><span class="tail-badge">live tail</span><div id="seal-tail-content"></div></div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+                            <div class="step-note" id="seal-note"></div>
+                        </div>
+                        <div>
+                            <div class="term">
+                                <div class="term-bar">
+                                    <span class="term-dot r"></span><span class="term-dot y"></span
+                                    ><span class="term-dot g"></span>
+                                    <span class="term-title">one turn, frame by frame</span>
+                                </div>
+                                <div class="term-body">
+                                    <div class="term-scroll" style="height: 190px">
+                                        <div id="seal-scrollback">
+                                            <div class="blk committed">
+                                                <span class="dim">❯</span>
+                                                <span class="tel">why is sealing cheap?</span>
+                                            </div>
+                                        </div>
+                                        <div class="tailzone" id="seal-tail">
+                                            <span class="tail-badge">live tail</span>
+                                            <div id="seal-tail-content"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-<!-- ================= DISSOLVED ================= -->
-<section class="sec" id="dissolved">
-  <div class="sec-head"><span class="sec-num">04</span><h2>What this dissolves</h2></div>
-  <p class="lede">Because blocks render exactly once and the tail re-renders wholesale, whole categories of
-  framework machinery have <strong>nothing to do</strong>, so they don't exist here.</p>
-  <div class="grid4">
-    <div class="card dis-card">
-      <div class="dis-strike"><code>row_view(t).key(t.id)</code><span class="stamp">not needed</span></div>
-      <h3>Reconciliation &amp; keys</h3>
-      <p>No retained tree, so nothing is ever matched up across frames. Mapped children need no
-      identity annotations; there's no diff to keep stable.</p>
-    </div>
-    <div class="card dis-card">
-      <div class="dis-strike"><code>mark_dirty(Region::Tail)</code><span class="stamp">not needed</span></div>
-      <h3>Dirty tracking</h3>
-      <p>The tail is rebuilt every frame, unconditionally. Identical tails diff to zero bytes at the
-      terminal layer. That's the optimization, and it needs nothing from you.</p>
-    </div>
-    <div class="card dis-card">
-      <div class="dis-strike"><code>ui.state::&lt;TextArea&gt;(id)</code><span class="stamp">not needed</span></div>
-      <h3>Framework-owned state</h3>
-      <p>Your model is the only state. A text area's contents and a select's cursor are plain fields you
-      own and mutate in <code>update</code>. Strict Elm, no exceptions.</p>
-    </div>
-    <div class="card dis-card">
-      <div class="dis-strike"><code>focus_registry().request(id)</code><span class="stamp">not needed</span></div>
-      <h3>Hidden focus registry</h3>
-      <p>Focus is a value in your model (<code>FocusHandle</code>). What a key does is always derivable
-      from your state, never from what the framework last focused.</p>
-    </div>
-  </div>
-</section>
+                <!-- ================= DISSOLVED ================= -->
+                <section class="sec" id="dissolved">
+                    <div class="sec-head">
+                        <span class="sec-num">04</span>
+                        <h2>What this dissolves</h2>
+                    </div>
+                    <p class="lede">
+                        Because blocks render exactly once and the tail re-renders wholesale, whole
+                        categories of framework machinery have <strong>nothing to do</strong>, so
+                        they don't exist here.
+                    </p>
+                    <div class="grid4">
+                        <div class="card dis-card">
+                            <div class="dis-strike">
+                                <code>row_view(t).key(t.id)</code
+                                ><span class="stamp">not needed</span>
+                            </div>
+                            <h3>Reconciliation &amp; keys</h3>
+                            <p>
+                                No retained tree, so nothing is ever matched up across frames.
+                                Mapped children need no identity annotations; there's no diff to
+                                keep stable.
+                            </p>
+                        </div>
+                        <div class="card dis-card">
+                            <div class="dis-strike">
+                                <code>mark_dirty(Region::Tail)</code
+                                ><span class="stamp">not needed</span>
+                            </div>
+                            <h3>Dirty tracking</h3>
+                            <p>
+                                The tail is rebuilt every frame, unconditionally. Identical tails
+                                diff to zero bytes at the terminal layer. That's the optimization,
+                                and it needs nothing from you.
+                            </p>
+                        </div>
+                        <div class="card dis-card">
+                            <div class="dis-strike">
+                                <code>ui.state::&lt;TextArea&gt;(id)</code
+                                ><span class="stamp">not needed</span>
+                            </div>
+                            <h3>Framework-owned state</h3>
+                            <p>
+                                Your model is the only state. A text area's contents and a select's
+                                cursor are plain fields you own and mutate in <code>update</code>.
+                                Strict Elm, no exceptions.
+                            </p>
+                        </div>
+                        <div class="card dis-card">
+                            <div class="dis-strike">
+                                <code>focus_registry().request(id)</code
+                                ><span class="stamp">not needed</span>
+                            </div>
+                            <h3>Hidden focus registry</h3>
+                            <p>
+                                Focus is a value in your model (<code>FocusHandle</code>). What a
+                                key does is always derivable from your state, never from what the
+                                framework last focused.
+                            </p>
+                        </div>
+                    </div>
+                </section>
 
-<!-- ================= ELEMENTS ================= -->
-<section class="sec" id="elements">
-  <div class="sec-head"><span class="sec-num">05</span><h2>Elements: plain Rust values, no DSL, no messages</h2></div>
-  <p class="lede">Views are built with fluent builders: full rust-analyzer support, and conditionals are ordinary
-  <code>if</code> statements and iterators. Elements describe <strong>pixels only</strong>; message emission lives entirely
-  in the keymap. Below, <strong>you are the model</strong>: mutate the fields and watch <code>tail()</code>
-  re-run. No dirty tracking decides what to update; the whole tail is simply rebuilt.</p>
+                <!-- ================= ELEMENTS ================= -->
+                <section class="sec" id="elements">
+                    <div class="sec-head">
+                        <span class="sec-num">05</span>
+                        <h2>Elements: plain Rust values, no DSL, no messages</h2>
+                    </div>
+                    <p class="lede">
+                        Views are built with fluent builders: full rust-analyzer support, and
+                        conditionals are ordinary <code>if</code> statements and iterators. Elements
+                        describe <strong>pixels only</strong>; message emission lives entirely in
+                        the keymap. Below, <strong>you are the model</strong>: mutate the fields and
+                        watch <code>tail()</code> re-run. No dirty tracking decides what to update;
+                        the whole tail is simply rebuilt.
+                    </p>
 
-  <div class="play">
-    <div>
-      <div class="card model-card">
-        <div class="mc-title">the model: plain fields you own</div>
-        <div class="mrow">
-          <span class="mname">streaming: <span style="color:var(--text-dim)">bool</span></span>
-          <span class="mval" id="pg-streaming-val">false</span>
-          <span class="mctl"><label class="switch"><input type="checkbox" id="pg-streaming"><span class="sl"></span></label></span>
-        </div>
-        <div class="mrow">
-          <span class="mname">results: <span style="color:var(--text-dim)">Vec&lt;Hit&gt;</span></span>
-          <span class="mval">len = <span id="pg-results-val">2</span></span>
-          <span class="mctl"><button class="mini-btn" id="pg-res-minus">−</button><button class="mini-btn" id="pg-res-plus">+</button></span>
-        </div>
-        <div class="mrow">
-          <span class="mname">input: <span style="color:var(--text-dim)">TextAreaState</span></span>
-          <span class="mctl"><input class="mtext" id="pg-input" type="text" placeholder="type here: this is the model" maxlength="38"></span>
-        </div>
-      </div>
-      <pre class="code">
+                    <div class="play">
+                        <div>
+                            <div class="card model-card">
+                                <div class="mc-title">the model: plain fields you own</div>
+                                <div class="mrow">
+                                    <span class="mname"
+                                        >streaming:
+                                        <span style="color: var(--text-dim)">bool</span></span
+                                    >
+                                    <span class="mval" id="pg-streaming-val">false</span>
+                                    <span class="mctl"
+                                        ><label class="switch"
+                                            ><input type="checkbox" id="pg-streaming" /><span
+                                                class="sl"
+                                            ></span></label
+                                    ></span>
+                                </div>
+                                <div class="mrow">
+                                    <span class="mname"
+                                        >results:
+                                        <span style="color: var(--text-dim)"
+                                            >Vec&lt;Hit&gt;</span
+                                        ></span
+                                    >
+                                    <span class="mval"
+                                        >len = <span id="pg-results-val">2</span></span
+                                    >
+                                    <span class="mctl"
+                                        ><button class="mini-btn" id="pg-res-minus">−</button
+                                        ><button class="mini-btn" id="pg-res-plus">+</button></span
+                                    >
+                                </div>
+                                <div class="mrow">
+                                    <span class="mname"
+                                        >input:
+                                        <span style="color: var(--text-dim)"
+                                            >TextAreaState</span
+                                        ></span
+                                    >
+                                    <span class="mctl"
+                                        ><input
+                                            class="mtext"
+                                            id="pg-input"
+                                            type="text"
+                                            placeholder="type here: this is the model"
+                                            maxlength="38"
+                                    /></span>
+                                </div>
+                            </div>
+                            <pre class="code">
 <span class="kw">fn</span> <span class="fn">tail</span>(&amp;<span class="kw">self</span>) -&gt; <span class="kw">impl</span> <span class="ty">Element</span> + <span class="kw">'_</span> {
     <span class="kw">let</span> input = text_area(&amp;<span class="kw">self</span>.input)
         .track_focus(&amp;<span class="kw">self</span>.focus);
@@ -983,26 +2347,38 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
             .footer(<span class="st">"[Enter] Send"</span>))
         .children(<span class="kw">self</span>.results.iter().map(hit_row))
 }</pre>
-    </div>
-    <div>
-      <div class="term">
-        <div class="term-bar">
-          <span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span>
-          <span class="term-title">what tail(&amp;self) renders</span>
-        </div>
-        <div class="term-body">
-          <div class="term-scroll" style="height: 252px;">
-            <div class="blk committed dim">❯ previous turns live up here, committed</div>
-            <div class="tailzone" id="pg-tail"><span class="tail-badge">live tail</span><div id="pg-tail-content"></div></div>
-          </div>
-        </div>
-      </div>
-      <div class="frame-stat">tail() calls: <b id="pg-frames">1</b> · retained between frames: <b>nothing</b> · unchanged tails diff to <b>0 bytes</b></div>
-      <div class="frame-stat" style="margin-top:4px;">click into the input field; <b>track_focus</b> drives the cursor and the panel's border</div>
-    </div>
-  </div>
-  <div class="grid2" style="margin-top:18px; align-items:center;">
-    <pre class="code">
+                        </div>
+                        <div>
+                            <div class="term">
+                                <div class="term-bar">
+                                    <span class="term-dot r"></span><span class="term-dot y"></span
+                                    ><span class="term-dot g"></span>
+                                    <span class="term-title">what tail(&amp;self) renders</span>
+                                </div>
+                                <div class="term-body">
+                                    <div class="term-scroll" style="height: 252px">
+                                        <div class="blk committed dim">
+                                            ❯ previous turns live up here, committed
+                                        </div>
+                                        <div class="tailzone" id="pg-tail">
+                                            <span class="tail-badge">live tail</span>
+                                            <div id="pg-tail-content"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="frame-stat">
+                                tail() calls: <b id="pg-frames">1</b> · retained between frames:
+                                <b>nothing</b> · unchanged tails diff to <b>0 bytes</b>
+                            </div>
+                            <div class="frame-stat" style="margin-top: 4px">
+                                click into the input field; <b>track_focus</b> drives the cursor and
+                                the panel's border
+                            </div>
+                        </div>
+                    </div>
+                    <div class="grid2" style="margin-top: 18px; align-items: center">
+                        <pre class="code">
 <span class="kw">pub trait</span> <span class="ty">Element</span> {
     <span class="cm">// Exact height at this width. Cheap and honest:</span>
     <span class="cm">// no probe rendering.</span>
@@ -1013,27 +2389,38 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
     <span class="cm">// Hardware-cursor position, if this element wants it.</span>
     <span class="kw">fn</span> <span class="fn">cursor</span>(&amp;<span class="kw">self</span>, area: <span class="ty">Rect</span>) -&gt; <span class="ty">Option</span>&lt;(<span class="ty">u16</span>, <span class="ty">u16</span>)&gt; { <span class="ty">None</span> }
 }</pre>
-    <div class="card">
-      <h3 style="margin-bottom:6px;">That's the whole trait</h3>
-      <p style="font-size:13.8px; color:var(--text-dim);">Note what's absent: no message type parameter, no
-      lifecycle, no state. Custom elements implement this directly; expensive ones (like the built-in
-      <code>markdown()</code>) cache their parse in a <code>RefCell</code> that dies with the frame,
-      so there's no invalidation story to manage. <code>animated()</code> covers view-only time dependence, like a
-      spinner glyph; time that should change your <em>model</em> arrives as messages through subscriptions.</p>
-    </div>
-  </div>
-</section>
+                        <div class="card">
+                            <h3 style="margin-bottom: 6px">That's the whole trait</h3>
+                            <p style="font-size: 13.8px; color: var(--text-dim)">
+                                Note what's absent: no message type parameter, no lifecycle, no
+                                state. Custom elements implement this directly; expensive ones (like
+                                the built-in <code>markdown()</code>) cache their parse in a
+                                <code>RefCell</code> that dies with the frame, so there's no
+                                invalidation story to manage. <code>animated()</code> covers
+                                view-only time dependence, like a spinner glyph; time that should
+                                change your <em>model</em> arrives as messages through
+                                subscriptions.
+                            </p>
+                        </div>
+                    </div>
+                </section>
 
-<!-- ================= KEYMAP ================= -->
-<section class="sec" id="keymap">
-  <div class="sec-head"><span class="sec-num">06</span><h2>There are no event handlers. Keys are data.</h2></div>
-  <p class="lede">Every update, your app rebuilds a <code>Keymap</code>, a plain value, from the model.
-  Conditional bindings are just <code>if</code> statements, so a stale handler from a state you've left is
-  <strong>structurally impossible</strong>. Set the model's state, then press a key and watch it fall through
-  the four dispatch tiers.</p>
+                <!-- ================= KEYMAP ================= -->
+                <section class="sec" id="keymap">
+                    <div class="sec-head">
+                        <span class="sec-num">06</span>
+                        <h2>There are no event handlers. Keys are data.</h2>
+                    </div>
+                    <p class="lede">
+                        Every update, your app rebuilds a <code>Keymap</code>, a plain value, from
+                        the model. Conditional bindings are just <code>if</code> statements, so a
+                        stale handler from a state you've left is
+                        <strong>structurally impossible</strong>. Set the model's state, then press
+                        a key and watch it fall through the four dispatch tiers.
+                    </p>
 
-  <div class="grid2" style="align-items:start;">
-    <pre class="code" id="km-code">
+                    <div class="grid2" style="align-items: start">
+                        <pre class="code" id="km-code">
 <span class="kw">fn</span> <span class="fn">keymap</span>(&amp;<span class="kw">self</span>) -&gt; <span class="ty">Keymap</span>&lt;<span class="ty">Msg</span>&gt; {
     <span class="kw">let mut</span> km = keymap()
         .on_override(key(<span class="ty">Char</span>(<span class="st">'c'</span>)).ctrl(), <span class="ty">Msg</span>::Quit);
@@ -1043,73 +2430,165 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
     km.on(key(<span class="ty">Esc</span>), <span class="ty">Msg</span>::Cancel)
       .fallthrough(&amp;<span class="kw">self</span>.input, <span class="ty">Msg</span>::Input)
 }</pre>
-    <div>
-      <div class="mrow" style="border:none; padding-top:0;">
-        <span style="font-family:var(--font-mono); font-size:12.5px; color:var(--text-dim);">focus:</span>
-        <span class="kseg"><button id="km-foc-input" class="on">input</button><button id="km-foc-list">list</button></span>
-        <span style="font-family:var(--font-mono); font-size:12.5px; color:var(--text-dim); margin-left:14px;">self.busy:</span>
-        <label class="switch"><input type="checkbox" id="km-busy"><span class="sl"></span></label>
-      </div>
-      <div class="kbrow">
-        <button class="keycap km-key" data-key="ctrlc">Ctrl+C</button>
-        <button class="keycap km-key" data-key="enter">Enter</button>
-        <button class="keycap km-key" data-key="esc">Esc</button>
-        <button class="keycap km-key" data-key="s">s <span style="color:var(--text-dim); font-weight:400;">(any char)</span></button>
-        <button class="keycap km-key" data-key="tab">Tab</button>
-        <button class="keycap km-key" data-key="paste">paste "hi"</button>
-      </div>
-      <div class="tierboard">
-        <div class="tier" id="tier-1"><span class="tname">1 · on_override</span><span class="tbind">Ctrl+C → Msg::Quit</span><span class="tstate">·</span></div>
-        <div class="tier" id="tier-2"><span class="tname">2 · in_scope(&amp;input)</span><span class="tbind" id="tier-2-bind">Enter → Msg::Submit</span><span class="tstate">·</span></div>
-        <div class="tier" id="tier-3"><span class="tname">3 · on (global)</span><span class="tbind">Esc → Msg::Cancel</span><span class="tstate">·</span></div>
-        <div class="tier" id="tier-4"><span class="tname">4 · fallthrough(&amp;input)</span><span class="tbind">everything unclaimed → Msg::Input(ev)</span><span class="tstate">·</span></div>
-      </div>
-      <div class="kresult" id="km-result">press a key ↑<small>first match wins, top tier first</small></div>
-    </div>
-  </div>
-  <p style="margin-top:18px; color:var(--text-dim); font-size:14.5px; max-width:74ch;">Tier 4 is how a text input receives
-  ordinary typing without the framework owning any editing logic: unclaimed keys <em>and pastes</em> become
-  <code>Msg::Input(ev)</code>, and your <code>update</code> hands them to <code>TextAreaState::handle</code>,
-  which deliberately ignores policy keys like Enter, Tab, and Esc. Those belong to your keymap.</p>
-</section>
+                        <div>
+                            <div class="mrow" style="border: none; padding-top: 0">
+                                <span
+                                    style="
+                                        font-family: var(--font-mono);
+                                        font-size: 12.5px;
+                                        color: var(--text-dim);
+                                    "
+                                    >focus:</span
+                                >
+                                <span class="kseg"
+                                    ><button id="km-foc-input" class="on">input</button
+                                    ><button id="km-foc-list">list</button></span
+                                >
+                                <span
+                                    style="
+                                        font-family: var(--font-mono);
+                                        font-size: 12.5px;
+                                        color: var(--text-dim);
+                                        margin-left: 14px;
+                                    "
+                                    >self.busy:</span
+                                >
+                                <label class="switch"
+                                    ><input type="checkbox" id="km-busy" /><span class="sl"></span
+                                ></label>
+                            </div>
+                            <div class="kbrow">
+                                <button class="keycap km-key" data-key="ctrlc">Ctrl+C</button>
+                                <button class="keycap km-key" data-key="enter">Enter</button>
+                                <button class="keycap km-key" data-key="esc">Esc</button>
+                                <button class="keycap km-key" data-key="s">
+                                    s
+                                    <span style="color: var(--text-dim); font-weight: 400"
+                                        >(any char)</span
+                                    >
+                                </button>
+                                <button class="keycap km-key" data-key="tab">Tab</button>
+                                <button class="keycap km-key" data-key="paste">paste "hi"</button>
+                            </div>
+                            <div class="tierboard">
+                                <div class="tier" id="tier-1">
+                                    <span class="tname">1 · on_override</span
+                                    ><span class="tbind">Ctrl+C → Msg::Quit</span
+                                    ><span class="tstate">·</span>
+                                </div>
+                                <div class="tier" id="tier-2">
+                                    <span class="tname">2 · in_scope(&amp;input)</span
+                                    ><span class="tbind" id="tier-2-bind">Enter → Msg::Submit</span
+                                    ><span class="tstate">·</span>
+                                </div>
+                                <div class="tier" id="tier-3">
+                                    <span class="tname">3 · on (global)</span
+                                    ><span class="tbind">Esc → Msg::Cancel</span
+                                    ><span class="tstate">·</span>
+                                </div>
+                                <div class="tier" id="tier-4">
+                                    <span class="tname">4 · fallthrough(&amp;input)</span
+                                    ><span class="tbind">everything unclaimed → Msg::Input(ev)</span
+                                    ><span class="tstate">·</span>
+                                </div>
+                            </div>
+                            <div class="kresult" id="km-result">
+                                press a key ↑<small>first match wins, top tier first</small>
+                            </div>
+                        </div>
+                    </div>
+                    <p
+                        style="
+                            margin-top: 18px;
+                            color: var(--text-dim);
+                            font-size: 14.5px;
+                            max-width: 74ch;
+                        "
+                    >
+                        Tier 4 is how a text input receives ordinary typing without the framework
+                        owning any editing logic: unclaimed keys <em>and pastes</em> become
+                        <code>Msg::Input(ev)</code>, and your <code>update</code> hands them to
+                        <code>TextAreaState::handle</code>, which deliberately ignores policy keys
+                        like Enter, Tab, and Esc. Those belong to your keymap.
+                    </p>
+                </section>
 
-<!-- ================= ASYNC ================= -->
-<section class="sec" id="async">
-  <div class="sec-head"><span class="sec-num">07</span><h2>Cancellation is drop</h2></div>
-  <p class="lede">Async work enters the app as messages: <code>ctx.spawn</code> takes a
-  <code>Stream&lt;Item&nbsp;=&nbsp;Msg&gt;</code> and returns a <code>Task</code> that <strong>cancels its work
-  when dropped</strong>. Hold the task in your model, and cancellation becomes ordinary state
-  manipulation: no tokens, no flags, no channels.</p>
+                <!-- ================= ASYNC ================= -->
+                <section class="sec" id="async">
+                    <div class="sec-head">
+                        <span class="sec-num">07</span>
+                        <h2>Cancellation is drop</h2>
+                    </div>
+                    <p class="lede">
+                        Async work enters the app as messages: <code>ctx.spawn</code> takes a
+                        <code>Stream&lt;Item&nbsp;=&nbsp;Msg&gt;</code> and returns a
+                        <code>Task</code> that <strong>cancels its work when dropped</strong>. Hold
+                        the task in your model, and cancellation becomes ordinary state
+                        manipulation: no tokens, no flags, no channels.
+                    </p>
 
-  <div class="async-grid">
-    <div>
-      <div class="term">
-        <div class="term-bar">
-          <span class="term-dot r"></span><span class="term-dot y"></span><span class="term-dot g"></span>
-          <span class="term-title">a stream you can kill</span>
-        </div>
-        <div class="term-body">
-          <div class="term-scroll" style="height: 230px;">
-            <div id="as-scrollback"><div class="blk committed"><span class="dim">❯</span> <span class="tel">tell me a very long story</span></div></div>
-            <div class="tailzone" id="as-tail"><span class="tail-badge">live tail</span><div id="as-tail-content"></div></div>
-          </div>
-        </div>
-      </div>
-      <div class="kbrow" style="margin-top:12px; align-items:center;">
-        <button class="keycap" id="as-cancel">␛ Esc</button>
-        <span style="font-family:var(--font-mono); font-size:12px; color:var(--text-dim);">→ Msg::Cancel → <code>self.request = None</code></span>
-        <button class="ctl" id="as-restart" style="margin-left:auto;">↻ run it again</button>
-      </div>
-    </div>
-    <div>
-      <div class="card">
-        <div class="mc-title" style="font-family:var(--font-mono); font-size:11px; letter-spacing:1.5px; text-transform:uppercase; color:var(--text-dim); margin-bottom:8px;">the model, live</div>
-        <div style="font-family:var(--font-mono); font-size:13.5px;">
-          request: Option&lt;Task&gt; = <span class="task-val none" id="as-task">None</span>
-        </div>
-        <div class="msglog" id="as-log"><div class="mlt">messages → update()</div></div>
-      </div>
-      <pre class="code" style="margin-top:14px;">
+                    <div class="async-grid">
+                        <div>
+                            <div class="term">
+                                <div class="term-bar">
+                                    <span class="term-dot r"></span><span class="term-dot y"></span
+                                    ><span class="term-dot g"></span>
+                                    <span class="term-title">a stream you can kill</span>
+                                </div>
+                                <div class="term-body">
+                                    <div class="term-scroll" style="height: 230px">
+                                        <div id="as-scrollback">
+                                            <div class="blk committed">
+                                                <span class="dim">❯</span>
+                                                <span class="tel">tell me a very long story</span>
+                                            </div>
+                                        </div>
+                                        <div class="tailzone" id="as-tail">
+                                            <span class="tail-badge">live tail</span>
+                                            <div id="as-tail-content"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="kbrow" style="margin-top: 12px; align-items: center">
+                                <button class="keycap" id="as-cancel">␛ Esc</button>
+                                <span
+                                    style="
+                                        font-family: var(--font-mono);
+                                        font-size: 12px;
+                                        color: var(--text-dim);
+                                    "
+                                    >→ Msg::Cancel → <code>self.request = None</code></span
+                                >
+                                <button class="ctl" id="as-restart" style="margin-left: auto">
+                                    ↻ run it again
+                                </button>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="card">
+                                <div
+                                    class="mc-title"
+                                    style="
+                                        font-family: var(--font-mono);
+                                        font-size: 11px;
+                                        letter-spacing: 1.5px;
+                                        text-transform: uppercase;
+                                        color: var(--text-dim);
+                                        margin-bottom: 8px;
+                                    "
+                                >
+                                    the model, live
+                                </div>
+                                <div style="font-family: var(--font-mono); font-size: 13.5px">
+                                    request: Option&lt;Task&gt; =
+                                    <span class="task-val none" id="as-task">None</span>
+                                </div>
+                                <div class="msglog" id="as-log">
+                                    <div class="mlt">messages → update()</div>
+                                </div>
+                            </div>
+                            <pre class="code" style="margin-top: 14px">
 <span class="cm">// Esc cancels the stream. The whole implementation:</span>
 <span class="ty">Msg</span>::Cancel <span class="kw">=&gt;</span> <span class="kw">self</span>.request = <span class="ty">None</span>,
 
@@ -1118,21 +2597,37 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
 <span class="ty">Msg</span>::Chunk(delta) <span class="kw">=&gt;</span> <span class="kw">if</span> <span class="kw">self</span>.request.is_some() {
     <span class="kw">self</span>.reply.push_str(&amp;delta);
 }</pre>
-    </div>
-  </div>
-  <p style="margin-top:18px; color:var(--text-dim); font-size:14.5px; max-width:74ch;">Replacing a <code>Task</code> with a new
-  one cancels the old work the same way, and that closes a whole bug class: a replaced request can't finish later
-  and clobber shared state, because it was dropped at whatever await point it had reached. Cancel the demo above
-  and note the one already-queued chunk that still arrives: <strong>staleness is checked in the model</strong>, not the channel.</p>
+                        </div>
+                    </div>
+                    <p
+                        style="
+                            margin-top: 18px;
+                            color: var(--text-dim);
+                            font-size: 14.5px;
+                            max-width: 74ch;
+                        "
+                    >
+                        Replacing a <code>Task</code> with a new one cancels the old work the same
+                        way, and that closes a whole bug class: a replaced request can't finish
+                        later and clobber shared state, because it was dropped at whatever await
+                        point it had reached. Cancel the demo above and note the one already-queued
+                        chunk that still arrives:
+                        <strong>staleness is checked in the model</strong>, not the channel.
+                    </p>
 
-  <div class="grid2" style="margin-top:26px; align-items:center;">
-    <div class="card">
-      <h3 style="margin-bottom:6px;">Subscriptions: recurring input is declared, not managed</h3>
-      <p style="font-size:13.8px; color:var(--text-dim);">After every update the driver diffs what you declare
-      against what's running: new keys start, missing keys cancel, changed intervals restart. "Poll while a
-      session is active" is a <code>when</code> on model state; <em>to stop the poll, stop declaring it</em>.</p>
-    </div>
-    <pre class="code">
+                    <div class="grid2" style="margin-top: 26px; align-items: center">
+                        <div class="card">
+                            <h3 style="margin-bottom: 6px">
+                                Subscriptions: recurring input is declared, not managed
+                            </h3>
+                            <p style="font-size: 13.8px; color: var(--text-dim)">
+                                After every update the driver diffs what you declare against what's
+                                running: new keys start, missing keys cancel, changed intervals
+                                restart. "Poll while a session is active" is a <code>when</code> on
+                                model state; <em>to stop the poll, stop declaring it</em>.
+                            </p>
+                        </div>
+                        <pre class="code">
 <span class="kw">fn</span> <span class="fn">subscriptions</span>(&amp;<span class="kw">self</span>) -&gt; <span class="ty">Subscriptions</span>&lt;<span class="ty">Msg</span>&gt; {
     <span class="ty">Subscriptions</span>::new()
         .when(<span class="kw">self</span>.session_active, |s|
@@ -1140,51 +2635,110 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
                 || <span class="ty">Msg</span>::Poll))
         .stream(<span class="st">"fs-events"</span>, || watch_files())
 }</pre>
-  </div>
-</section>
+                    </div>
+                </section>
 
-<!-- ================= PERF ================= -->
-<section class="sec" id="perf">
-  <div class="sec-head"><span class="sec-num">08</span><h2>Rebuilding everything, every frame. It's fine.</h2></div>
-  <p class="lede">The design invariant: re-presenting the tail is <strong>unconditionally cheap</strong>:
-  cheap enough to do every frame with no dirty tracking. That's an invariant, not an optimization target.
-  Measured on the library's benchmark scenario (streaming chat, 100×40 terminal, release build):</p>
+                <!-- ================= PERF ================= -->
+                <section class="sec" id="perf">
+                    <div class="sec-head">
+                        <span class="sec-num">08</span>
+                        <h2>Rebuilding everything, every frame. It's fine.</h2>
+                    </div>
+                    <p class="lede">
+                        The design invariant: re-presenting the tail is
+                        <strong>unconditionally cheap</strong>: cheap enough to do every frame with
+                        no dirty tracking. That's an invariant, not an optimization target. Measured
+                        on the library's benchmark scenario (streaming chat, 100×40 terminal,
+                        release build):
+                    </p>
 
-  <div class="stat-grid">
-    <div class="stat"><div class="sk">unchanged frame</div><div class="sv">~780<small>µs</small></div>
-      <div class="sd">with 10KB of live markdown in the tail; roughly 1% of a core at animation cadence</div></div>
-    <div class="stat"><div class="sk">a keystroke</div><div class="sv">~790<small>µs</small></div>
-      <div class="sd">rebuild, re-measure, re-render, diff, present. All of it.</div></div>
-    <div class="stat"><div class="sk">tree construction</div><div class="sv">0.5<small>µs</small></div>
-      <div class="sd">16 allocations for a realistic tail. View builders are not the place to optimize.</div></div>
-    <div class="stat"><div class="sk">cost model</div><div class="sv">O(<small style="font-size:22px; color:var(--view); font-weight:800;">tail</small>)</div>
-      <div class="sd">per-frame cost scales with the tail's content, never the conversation's. Seal early, stay small.</div></div>
-  </div>
+                    <div class="stat-grid">
+                        <div class="stat">
+                            <div class="sk">unchanged frame</div>
+                            <div class="sv">~780<small>µs</small></div>
+                            <div class="sd">
+                                with 10KB of live markdown in the tail; roughly 1% of a core at
+                                animation cadence
+                            </div>
+                        </div>
+                        <div class="stat">
+                            <div class="sk">a keystroke</div>
+                            <div class="sv">~790<small>µs</small></div>
+                            <div class="sd">
+                                rebuild, re-measure, re-render, diff, present. All of it.
+                            </div>
+                        </div>
+                        <div class="stat">
+                            <div class="sk">tree construction</div>
+                            <div class="sv">0.5<small>µs</small></div>
+                            <div class="sd">
+                                16 allocations for a realistic tail. View builders are not the place
+                                to optimize.
+                            </div>
+                        </div>
+                        <div class="stat">
+                            <div class="sk">cost model</div>
+                            <div class="sv">
+                                O(<small
+                                    style="font-size: 22px; color: var(--view); font-weight: 800"
+                                    >tail</small
+                                >)
+                            </div>
+                            <div class="sd">
+                                per-frame cost scales with the tail's content, never the
+                                conversation's. Seal early, stay small.
+                            </div>
+                        </div>
+                    </div>
 
-  <div class="card">
-    <h3 style="margin-bottom:10px;">The driver coalesces bursts</h3>
-    <p style="font-size:14px; color:var(--text-dim); margin-bottom:14px; max-width:70ch;">When a fast LLM stream
-    queues a burst of messages, they're processed as one batch and presented as <strong>one frame</strong>.
-    You never debounce streams yourself.</p>
-    <div class="burst">
-      <div>
-        <div class="burst-dots" id="burst-dots"></div>
-        <div class="burst-arrow" style="text-align:left; margin-top:6px;">64 queued chunks</div>
-      </div>
-      <div class="burst-arrow"><span class="burst-glyph">──▶</span><br><span style="font-size:11px;">one batch of updates</span></div>
-      <div class="burst-frame">1 frame · ~1.7ms total<small>not 64 frames</small></div>
-    </div>
-  </div>
-</section>
+                    <div class="card">
+                        <h3 style="margin-bottom: 10px">The driver coalesces bursts</h3>
+                        <p
+                            style="
+                                font-size: 14px;
+                                color: var(--text-dim);
+                                margin-bottom: 14px;
+                                max-width: 70ch;
+                            "
+                        >
+                            When a fast LLM stream queues a burst of messages, they're processed as
+                            one batch and presented as <strong>one frame</strong>. You never
+                            debounce streams yourself.
+                        </p>
+                        <div class="burst">
+                            <div>
+                                <div class="burst-dots" id="burst-dots"></div>
+                                <div class="burst-arrow" style="text-align: left; margin-top: 6px">
+                                    64 queued chunks
+                                </div>
+                            </div>
+                            <div class="burst-arrow">
+                                <span class="burst-glyph">──▶</span><br /><span
+                                    style="font-size: 11px"
+                                    >one batch of updates</span
+                                >
+                            </div>
+                            <div class="burst-frame">
+                                1 frame · ~1.7ms total<small>not 64 frames</small>
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-<!-- ================= TESTING ================= -->
-<section class="sec" id="testing">
-  <div class="sec-head"><span class="sec-num">09</span><h2>Whole apps test headlessly, against a real terminal</h2></div>
-  <p class="lede">The runtime core is synchronous: events in, escape bytes out. So entire apps run in tests
-  with no TTY and no executor, asserted against <code>TestTerminal</code>, <strong>a real VTE emulator</strong>.
-  Tests check what a user would actually see, scrollback included.</p>
-  <div class="test-grid">
-    <pre class="code">
+                <!-- ================= TESTING ================= -->
+                <section class="sec" id="testing">
+                    <div class="sec-head">
+                        <span class="sec-num">09</span>
+                        <h2>Whole apps test headlessly, against a real terminal</h2>
+                    </div>
+                    <p class="lede">
+                        The runtime core is synchronous: events in, escape bytes out. So entire apps
+                        run in tests with no TTY and no executor, asserted against
+                        <code>TestTerminal</code>, <strong>a real VTE emulator</strong>. Tests check
+                        what a user would actually see, scrollback included.
+                    </p>
+                    <div class="test-grid">
+                        <pre class="code">
 <span class="kw">#[test]</span>
 <span class="kw">fn</span> <span class="fn">submit_commits_the_line</span>() {
     <span class="kw">let mut</span> rt = <span class="ty">Runtime</span>::new(my_app(), <span class="st">80</span>, <span class="st">24</span>);
@@ -1198,663 +2752,1024 @@ button.ctl:disabled { opacity: 0.45; cursor: default; }
     <span class="kw">let</span> screen = term.viewport_lines().join(<span class="st">"\n"</span>);
     <span class="fn">assert!</span>(screen.contains(<span class="st">"✓ hello"</span>));
 }</pre>
-    <div style="display:flex; flex-direction:column; gap:14px;">
-      <div class="card">
-        <h3 style="margin-bottom:6px;">Async flows, synchronously</h3>
-        <p style="font-size:13.8px; color:var(--text-dim);">Spawned work delivers messages, so tests deliver those
-        messages by hand via <code>Runtime::process</code> and skip the executor entirely. The sequence of messages
-        <em>is</em> the scenario: streaming, cancellation, and error paths become timing-free tests.</p>
-      </div>
-      <div class="card rule-card">
-        <h3 style="margin-bottom:6px;">Even cost is testable</h3>
-        <p style="font-size:13.8px; color:var(--text-dim);"><code>present()</code> on an unchanged tail should return
-        (nearly) nothing, and sealing already-displayed content shouldn't repaint it. Output-efficiency regressions
-        show up as plain assertions on <code>bytes.len()</code>. The repo also ships a perf report with
-        <em>exact, deterministic</em> allocation counts per scenario.</p>
-      </div>
-    </div>
-  </div>
-</section>
+                        <div style="display: flex; flex-direction: column; gap: 14px">
+                            <div class="card">
+                                <h3 style="margin-bottom: 6px">Async flows, synchronously</h3>
+                                <p style="font-size: 13.8px; color: var(--text-dim)">
+                                    Spawned work delivers messages, so tests deliver those messages
+                                    by hand via <code>Runtime::process</code> and skip the executor
+                                    entirely. The sequence of messages <em>is</em> the scenario:
+                                    streaming, cancellation, and error paths become timing-free
+                                    tests.
+                                </p>
+                            </div>
+                            <div class="card rule-card">
+                                <h3 style="margin-bottom: 6px">Even cost is testable</h3>
+                                <p style="font-size: 13.8px; color: var(--text-dim)">
+                                    <code>present()</code> on an unchanged tail should return
+                                    (nearly) nothing, and sealing already-displayed content
+                                    shouldn't repaint it. Output-efficiency regressions show up as
+                                    plain assertions on <code>bytes.len()</code>. The repo also
+                                    ships a perf report with
+                                    <em>exact, deterministic</em> allocation counts per scenario.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-<!-- ================= GET STARTED ================= -->
-<section class="sec" id="start">
-  <div class="sec-head"><span class="sec-num">10</span><h2>Get started</h2></div>
-  <p class="lede">The quick start builds a complete working app in about sixty lines. Every concept on this
-  page appears once.</p>
-  <div class="install">$ <span class="dim">cargo add</span> eye_declare</div>
-  <div class="foot-grid">
-    <div class="card foot-card">
-      <h3>Read</h3>
-      <ul>
-        <li><a href="/book/">eye-declare.rs/book</a> · the book</li>
-        <li><a href="https://docs.rs/eye_declare">docs.rs/eye_declare</a> · API reference</li>
-        <li><a href="https://github.com/atuinsh/eye-declare">github.com/atuinsh/eye-declare</a> · source</li>
-      </ul>
-    </div>
-    <div class="card foot-card">
-      <h3>Run the examples</h3>
-      <ul>
-        <li><code>--example echo</code> · the smallest useful app</li>
-        <li><code>--example stream</code> · a mini agent; Esc cancels</li>
-        <li><code>--example openrouter</code> · a real streaming AI chat in one commented file</li>
-      </ul>
-    </div>
-    <div class="card foot-card">
-      <h3>In the box</h3>
-      <ul>
-        <li><code>text</code> · <code>markdown</code> · <code>spinner</code> · <code>panel</code></li>
-        <li><code>text_area</code> · grapheme-aware, strict-Elm input</li>
-        <li><code>viewport</code> · <code>col</code>/<code>row</code> · your own <code>impl Element</code></li>
-      </ul>
-    </div>
-  </div>
-</section>
+                <!-- ================= GET STARTED ================= -->
+                <section class="sec" id="start">
+                    <div class="sec-head">
+                        <span class="sec-num">10</span>
+                        <h2>Get started</h2>
+                    </div>
+                    <p class="lede">
+                        The quick start builds a complete working app in about sixty lines. Every
+                        concept on this page appears once.
+                    </p>
+                    <div class="install">$ <span class="dim">cargo add</span> eye_declare</div>
+                    <div class="foot-grid">
+                        <div class="card foot-card">
+                            <h3>Read</h3>
+                            <ul>
+                                <li><a href="/book/">eye-declare.rs/book</a> · the book</li>
+                                <li>
+                                    <a href="https://docs.rs/eye_declare">docs.rs/eye_declare</a> ·
+                                    API reference
+                                </li>
+                                <li>
+                                    <a href="https://github.com/atuinsh/eye-declare"
+                                        >github.com/atuinsh/eye-declare</a
+                                    >
+                                    · source
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="card foot-card">
+                            <h3>Run the examples</h3>
+                            <ul>
+                                <li><code>--example echo</code> · the smallest useful app</li>
+                                <li><code>--example stream</code> · a mini agent; Esc cancels</li>
+                                <li>
+                                    <code>--example openrouter</code> · a real streaming AI chat in
+                                    one commented file
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="card foot-card">
+                            <h3>In the box</h3>
+                            <ul>
+                                <li>
+                                    <code>text</code> · <code>markdown</code> ·
+                                    <code>spinner</code> · <code>panel</code>
+                                </li>
+                                <li><code>text_area</code> · grapheme-aware, strict-Elm input</li>
+                                <li>
+                                    <code>viewport</code> · <code>col</code>/<code>row</code> · your
+                                    own <code>impl Element</code>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+            </div>
+            <!-- /main -->
+        </div>
+        <!-- /wrap -->
+        <script>
+            "use strict";
+            const RM = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+            const SPIN = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            const $ = (id) => document.getElementById(id);
 
-<footer class="footer">
-  <p style="max-width:74ch;"><strong>eye-declare</strong> renders inline only, on purpose. If you want a full-screen,
-  alternate-screen application, use <a href="https://ratatui.rs">Ratatui</a> directly. eye-declare is built on
-  Ratatui's primitives and hands you its <code>Buffer</code> and <code>Style</code> types, but it deliberately
-  does not do full-screen layout.</p>
-  <p class="colophon"></p>
-</footer>
+            /* ============ scroll-spy TOC ============ */
+            (function () {
+                const toc = $("toc");
+                const links = toc.querySelectorAll("a");
+                const sections = [];
+                links.forEach((link) => {
+                    const el = $(link.getAttribute("href").slice(1));
+                    if (el) sections.push({ el, link });
+                });
+                const obs = new IntersectionObserver(
+                    (entries) => {
+                        entries.forEach((entry) => {
+                            if (!entry.isIntersecting) return;
+                            links.forEach((l) => l.classList.remove("active"));
+                            const m = sections.find((s) => s.el === entry.target);
+                            if (m) {
+                                m.link.classList.add("active");
+                                if (window.innerWidth <= 1000)
+                                    m.link.scrollIntoView({
+                                        behavior: RM ? "auto" : "smooth",
+                                        block: "nearest",
+                                        inline: "center",
+                                    });
+                            }
+                        });
+                    },
+                    { rootMargin: "-10% 0px -80% 0px" },
+                );
+                sections.forEach((s) => obs.observe(s.el));
+            })();
 
+            /* ============ hero terminal demo ============ */
+            (function () {
+                const scrollback = $("hero-scrollback"),
+                    tailzone = $("hero-tail"),
+                    tailContent = $("hero-tail-content"),
+                    scroller = $("hero-scroll"),
+                    playBtn = $("hero-play");
 
-</div><!-- /main -->
-</div><!-- /wrap -->
-<script>
-"use strict";
-const RM = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-const SPIN = ["⠋","⠙","⠹","⠸","⠼","⠴","⠦","⠧","⠇","⠏"];
-const $ = (id) => document.getElementById(id);
+                // The demo practices what the page preaches: a model, an update-ish
+                // script that mutates it and commits blocks, and a tail() that rebuilds
+                // the live region from the model every time.
+                const model = { phase: "typing", typed: "", reply: "", spin: 0 };
 
-/* ============ scroll-spy TOC ============ */
-(function () {
-  const toc = $("toc");
-  const links = toc.querySelectorAll("a");
-  const sections = [];
-  links.forEach((link) => {
-    const el = $(link.getAttribute("href").slice(1));
-    if (el) sections.push({ el, link });
-  });
-  const obs = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (!entry.isIntersecting) return;
-      links.forEach((l) => l.classList.remove("active"));
-      const m = sections.find((s) => s.el === entry.target);
-      if (m) {
-        m.link.classList.add("active");
-        if (window.innerWidth <= 1000)
-          m.link.scrollIntoView({ behavior: RM ? "auto" : "smooth", block: "nearest", inline: "center" });
-      }
-    });
-  }, { rootMargin: "-10% 0px -80% 0px" });
-  sections.forEach((s) => obs.observe(s.el));
-})();
+                function esc(s) {
+                    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+                }
+                function md(s) {
+                    // the demo's tiny "markdown": **bold** and *italic*
+                    return esc(s)
+                        .replace(/\*\*(.+?)\*\*/g, "<span class='b'>$1</span>")
+                        .replace(/\*(.+?)\*/g, "<em>$1</em>");
+                }
+                function tail() {
+                    if (model.phase === "gone") {
+                        tailzone.classList.add("gone");
+                        tailContent.innerHTML = "";
+                        return;
+                    }
+                    tailzone.classList.remove("gone");
+                    if (model.phase === "typing") {
+                        tailContent.innerHTML =
+                            `<div class="tin"><span class="tel">❯</span><span>${esc(model.typed)}<span class="cursor"></span></span></div>` +
+                            `<div class="tin-foot">[Enter] send · [Ctrl+C] quit</div>`;
+                    } else {
+                        tailContent.innerHTML =
+                            `<div><span class="tel">${SPIN[model.spin]}</span> <span class="dim">Thinking…</span></div>` +
+                            `<div>${md(model.reply)}</div>`;
+                    }
+                    scroller.scrollTop = scroller.scrollHeight;
+                }
+                function commit(html) {
+                    const div = document.createElement("div");
+                    div.className = "blk committed just-committed";
+                    div.innerHTML = html;
+                    scrollback.appendChild(div);
+                    scroller.scrollTop = scroller.scrollHeight;
+                }
 
-/* ============ hero terminal demo ============ */
-(function () {
-  const scrollback = $("hero-scrollback"), tailzone = $("hero-tail"),
-        tailContent = $("hero-tail-content"), scroller = $("hero-scroll"),
-        playBtn = $("hero-play");
+                const steps = [];
+                const at = (d, fn) => steps.push({ d, fn });
+                function typeLine(s) {
+                    for (const ch of s)
+                        at(45, () => {
+                            model.typed += ch;
+                            tail();
+                        });
+                }
+                function streamReply(s) {
+                    at(500, () => {
+                        model.phase = "streaming";
+                        model.reply = "";
+                        tail();
+                    });
+                    for (const w of s.split(" "))
+                        at(60, () => {
+                            model.reply += w + " ";
+                            tail();
+                        });
+                }
+                function turn(question, reply) {
+                    typeLine(question);
+                    at(550, () => {
+                        commit(
+                            `<span class="dim">❯</span> <span class="tel">${esc(question)}</span>`,
+                        );
+                        model.typed = "";
+                    });
+                    streamReply(reply);
+                    at(700, () => {
+                        commit(md(model.reply.trim()));
+                        model.phase = "typing";
+                        model.reply = "";
+                        tail();
+                    });
+                    at(900, () => {});
+                }
 
-  // The demo practices what the page preaches: a model, an update-ish
-  // script that mutates it and commits blocks, and a tail() that rebuilds
-  // the live region from the model every time.
-  const model = { phase: "typing", typed: "", reply: "", spin: 0 };
+                // script
+                at(400, () => commit(`<span class="dim">$ cargo run --example agent</span>`));
+                at(500, () =>
+                    commit(
+                        `<span class="amb">●</span> <span class="dim">agent ready · ask me anything</span>`,
+                    ),
+                );
+                turn(
+                    "What am I looking at?",
+                    "An **inline UI**. Everything above this line is *committed*: rendered exactly once " +
+                        "via **ctx.push**, then owned by your terminal. Real scrollback, not a redraw. " +
+                        "Only the block you're reading now is live. It's the **tail**, rebuilt from the model " +
+                        "every frame, and when it finishes it seals into history. Like this.",
+                );
+                turn(
+                    "So scrolling up just… works?",
+                    "Yes. Committed blocks are ordinary terminal output: scroll, select, copy. " +
+                        "They're indistinguishable from anything printed before this program ran. " +
+                        "No alternate screen, no repainting history, nothing to reconcile.",
+                );
+                typeLine("exit");
+                at(500, () => {
+                    commit(`<span class="dim">❯</span> <span class="tel">exit</span>`);
+                    model.typed = "";
+                });
+                at(400, () => {
+                    commit(`<span class="dim">2 turns · goodbye</span>`);
+                    commit(
+                        `<span class="grn">$</span> <span class="dim">your shell is back, history intact</span>`,
+                    );
+                    model.phase = "gone";
+                    tail();
+                });
+                at(3600, () => {});
 
-  function esc(s) { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;"); }
-  function md(s) { // the demo's tiny "markdown": **bold** and *italic*
-    return esc(s).replace(/\*\*(.+?)\*\*/g, "<span class='b'>$1</span>")
-                 .replace(/\*(.+?)\*/g, "<em>$1</em>");
-  }
-  function tail() {
-    if (model.phase === "gone") {
-      tailzone.classList.add("gone"); tailContent.innerHTML = ""; return;
-    }
-    tailzone.classList.remove("gone");
-    if (model.phase === "typing") {
-      tailContent.innerHTML =
-        `<div class="tin"><span class="tel">❯</span><span>${esc(model.typed)}<span class="cursor"></span></span></div>` +
-        `<div class="tin-foot">[Enter] send · [Ctrl+C] quit</div>`;
-    } else {
-      tailContent.innerHTML =
-        `<div><span class="tel">${SPIN[model.spin]}</span> <span class="dim">Thinking…</span></div>` +
-        `<div>${md(model.reply)}</div>`;
-    }
-    scroller.scrollTop = scroller.scrollHeight;
-  }
-  function commit(html) {
-    const div = document.createElement("div");
-    div.className = "blk committed just-committed";
-    div.innerHTML = html;
-    scrollback.appendChild(div);
-    scroller.scrollTop = scroller.scrollHeight;
-  }
+                let i = 0,
+                    timer = null,
+                    paused = RM,
+                    spinTimer = null;
+                function next() {
+                    if (paused) return;
+                    if (i >= steps.length) {
+                        // loop: reset
+                        i = 0;
+                        scrollback.innerHTML = "";
+                        model.phase = "typing";
+                        model.typed = "";
+                        model.reply = "";
+                        tail();
+                    }
+                    // Advance the index only after the step runs: pausing clears the
+                    // pending timer, and the same step must re-schedule on resume.
+                    const step = steps[i];
+                    timer = setTimeout(() => {
+                        i++;
+                        step.fn();
+                        next();
+                    }, step.d);
+                }
+                function setPaused(p) {
+                    paused = p;
+                    playBtn.textContent = p ? "▶ resume" : "⏸ pause";
+                    if (p) {
+                        clearTimeout(timer);
+                    } else {
+                        next();
+                    }
+                }
+                playBtn.addEventListener("click", () => setPaused(!paused));
+                $("hero-restart").addEventListener("click", () => {
+                    clearTimeout(timer);
+                    i = 0;
+                    scrollback.innerHTML = "";
+                    model.phase = "typing";
+                    model.typed = "";
+                    model.reply = "";
+                    tail();
+                    if (paused) setPaused(false);
+                    else next();
+                });
+                if (!RM)
+                    spinTimer = setInterval(() => {
+                        if (!paused && model.phase === "streaming") {
+                            model.spin = (model.spin + 1) % SPIN.length;
+                            tail();
+                        }
+                    }, 80);
+                tail();
+                if (RM) {
+                    playBtn.textContent = "▶ play";
+                } else {
+                    next();
+                }
+            })();
 
-  const steps = [];
-  const at = (d, fn) => steps.push({ d, fn });
-  function typeLine(s) {
-    for (const ch of s) at(45, () => { model.typed += ch; tail(); });
-  }
-  function streamReply(s) {
-    at(500, () => { model.phase = "streaming"; model.reply = ""; tail(); });
-    for (const w of s.split(" ")) at(60, () => { model.reply += w + " "; tail(); });
-  }
-  function turn(question, reply) {
-    typeLine(question);
-    at(550, () => {
-      commit(`<span class="dim">❯</span> <span class="tel">${esc(question)}</span>`);
-      model.typed = "";
-    });
-    streamReply(reply);
-    at(700, () => {
-      commit(md(model.reply.trim()));
-      model.phase = "typing"; model.reply = ""; tail();
-    });
-    at(900, () => {});
-  }
+            /* ============ trees vs timelines ============ */
+            (function () {
+                const tree = $("vs-tree"),
+                    tl = $("vs-tl"),
+                    tailEl = $("vs-tail"),
+                    tailText = $("vs-tail-text"),
+                    capL = $("vs-cap-l"),
+                    capR = $("vs-cap-r");
+                let turnN = 3;
+                const PHRASES = [
+                    "how does this work?",
+                    "and sealing is cheap?",
+                    "what about resizes?",
+                    "do I ever need keys?",
+                ];
+                let pi = 0,
+                    pos = 17; // the markup starts mid-typing of the first phrase
+                const tailStr = () => "❯ " + PHRASES[pi].slice(0, pos) + "█";
+                function flashTree() {
+                    tree.querySelectorAll(".tnode").forEach((n) => {
+                        n.classList.remove("diffing");
+                        void n.offsetWidth;
+                        n.classList.add("diffing");
+                    });
+                    setTimeout(
+                        () =>
+                            tree
+                                .querySelectorAll(".tnode")
+                                .forEach((n) => n.classList.remove("diffing")),
+                        900,
+                    );
+                }
+                $("vs-change").addEventListener("click", () => {
+                    flashTree();
+                    pos = Math.min(pos + 1, PHRASES[pi].length);
+                    tailText.textContent = tailStr();
+                    tailEl.classList.remove("rerender");
+                    void tailEl.offsetWidth;
+                    tailEl.classList.add("rerender");
+                    capL.innerHTML =
+                        "One keystroke → the <strong>whole retained tree</strong> is walked and reconciled to discover that one text node changed.";
+                    capR.innerHTML =
+                        "One keystroke → <code>tail()</code> re-runs and the diff is a few cells. The committed blocks above <strong>aren't even looked at</strong>; the library forgot them.";
+                });
+                $("vs-finish").addEventListener("click", () => {
+                    // left: the tree grows and reconciles everything again
+                    const msgs = $("vs-tree-msgs");
+                    if (msgs.children.length < 5) {
+                        const n = document.createElement("div");
+                        n.className = "tnode";
+                        n.innerHTML = `<span class="tag">diff</span>&lt;Turn key=${turnN}/&gt;`;
+                        msgs.appendChild(n);
+                    }
+                    flashTree();
+                    // right: the tail's content seals into a committed block
+                    if (pos < 4) pos = PHRASES[pi].length; // commit a sensible line even if barely typed
+                    const blk = document.createElement("div");
+                    blk.className = "tl-blk flash";
+                    blk.textContent = "❯ " + PHRASES[pi].slice(0, pos);
+                    tl.insertBefore(blk, tailEl);
+                    if (tl.querySelectorAll(".tl-blk").length > 5)
+                        tl.querySelector(".tl-blk").remove();
+                    pi = (pi + 1) % PHRASES.length;
+                    pos = 0;
+                    tailText.textContent = tailStr();
+                    turnN++;
+                    capL.innerHTML =
+                        "A finished turn → a <strong>new node, retained forever</strong>. Every future render pays for it: more to walk, more to diff, and now it needs a <code>key</code>.";
+                    capR.innerHTML =
+                        "A finished turn → <code>ctx.push</code>. Rendered once, handed to the terminal, <strong>never touched again</strong>. The tail resets to just the prompt.";
+                });
+            })();
 
-  // script
-  at(400, () => commit(`<span class="dim">$ cargo run --example agent</span>`));
-  at(500, () => commit(`<span class="amb">●</span> <span class="dim">agent ready · ask me anything</span>`));
-  turn("What am I looking at?",
-    "An **inline UI**. Everything above this line is *committed*: rendered exactly once " +
-    "via **ctx.push**, then owned by your terminal. Real scrollback, not a redraw. " +
-    "Only the block you're reading now is live. It's the **tail**, rebuilt from the model " +
-    "every frame, and when it finishes it seals into history. Like this.");
-  turn("So scrolling up just… works?",
-    "Yes. Committed blocks are ordinary terminal output: scroll, select, copy. " +
-    "They're indistinguishable from anything printed before this program ran. " +
-    "No alternate screen, no repainting history, nothing to reconcile.");
-  typeLine("exit");
-  at(500, () => {
-    commit(`<span class="dim">❯</span> <span class="tel">exit</span>`);
-    model.typed = "";
-  });
-  at(400, () => {
-    commit(`<span class="dim">2 turns · goodbye</span>`);
-    commit(`<span class="grn">$</span> <span class="dim">your shell is back, history intact</span>`);
-    model.phase = "gone"; tail();
-  });
-  at(3600, () => {});
+            /* ============ the loop: narrated traces ============ */
+            (function () {
+                const nar = $("loop-nar"),
+                    dots = $("loop-dots"),
+                    autoBtn = $("loop-auto"),
+                    prevBtn = $("loop-prev"),
+                    nextBtn = $("loop-next");
+                const buttons = [...document.querySelectorAll(".loop-tr")];
+                const ALL = [
+                    "lb-ev",
+                    "lb-task",
+                    "lb-sub",
+                    "lb-msg",
+                    "lb-update",
+                    "lb-push",
+                    "lb-spawn",
+                    "lb-batch",
+                    "lb-tail",
+                    "lb-diff",
+                    "lb-term",
+                    "lb-loop",
+                ];
+                const TRACES = [
+                    [
+                        // 1 · the user submits a prompt
+                        {
+                            on: ["lb-ev"],
+                            text: "<strong>Enter pressed.</strong> The keymap, rebuilt from the model this frame, resolves it to <code>Msg::Submit</code>.",
+                        },
+                        {
+                            on: ["lb-msg", "lb-update"],
+                            text: "<strong>update runs.</strong> It takes the draft out of the model and stores <code>self.request = Some(task)</code>. Plain Rust so far.",
+                        },
+                        {
+                            on: ["lb-push"],
+                            text: "<strong>Effect one:</strong> <code>ctx.push</code> commits the user's prompt to scrollback: rendered once, at today's width, permanent.",
+                        },
+                        {
+                            on: ["lb-spawn", "lb-loop"],
+                            text: "<strong>Effect two:</strong> <code>ctx.spawn</code> starts the request. Its stream items will re-enter the loop as messages, through the same front door as keystrokes.",
+                        },
+                        {
+                            on: ["lb-batch", "lb-tail"],
+                            text: "<strong>The view turn.</strong> <code>tail(&amp;self)</code> re-runs: the input box is empty and a spinner appears, because the model now says a request is live.",
+                        },
+                        {
+                            on: ["lb-diff", "lb-term"],
+                            text: "<strong>Present.</strong> The engine diffs and sends only the bytes that changed. One message in, one frame out.",
+                        },
+                    ],
+                    [
+                        // 2 · a chunk arrives
+                        {
+                            on: ["lb-task"],
+                            text: '<strong>The spawned stream yields</strong> <code>Msg::Chunk("…")</code>.',
+                        },
+                        {
+                            on: ["lb-msg", "lb-update"],
+                            text: "<strong>update runs:</strong> <code>self.reply.push_str(&amp;delta)</code>. String mutation, nothing else.",
+                        },
+                        {
+                            on: [],
+                            text: "<strong>No effects this time.</strong> Nothing is finished and nothing new spawns, so the effect boxes stay dark. Most messages are like this.",
+                        },
+                        {
+                            on: ["lb-batch", "lb-tail"],
+                            text: "<strong><code>tail()</code> rebuilds wholesale:</strong> spinner plus the longer reply. No dirty tracking asked what changed; nothing needed to.",
+                        },
+                        {
+                            on: ["lb-diff", "lb-term"],
+                            text: "<strong>The diff is just the new cells.</strong> A burst of 64 queued chunks? Coalesced into a single frame.",
+                        },
+                    ],
+                    [
+                        // 3 · the stream ends
+                        {
+                            on: ["lb-task"],
+                            text: "<strong>The stream finishes:</strong> <code>Msg::StreamDone</code>.",
+                        },
+                        {
+                            on: ["lb-msg", "lb-update"],
+                            text: "<strong>update runs:</strong> it takes the finished reply out of the model and drops the <code>Task</code>.",
+                        },
+                        {
+                            on: ["lb-push"],
+                            text: "<strong>Effect:</strong> <code>ctx.push(markdown(reply))</code> seals the turn into scrollback. Its content was already on screen as tail, so the commit costs one newline.",
+                        },
+                        {
+                            on: ["lb-batch", "lb-tail"],
+                            text: "<strong><code>tail()</code> re-runs:</strong> no request, no spinner, just an empty input box ready for the next prompt.",
+                        },
+                        {
+                            on: ["lb-diff", "lb-term"],
+                            text: "<strong>Present.</strong> The conversation now lives in the terminal's scrollback, not in the library. The loop is idle until the next message.",
+                        },
+                    ],
+                ];
+                // Auto-advances like a slideshow until the reader takes any control
+                // themselves — then it's theirs (sticky for the session). Reduced-motion
+                // users get manual stepping from the start.
+                const STEP_MS = 5000;
+                let trace = null,
+                    stage = 0,
+                    manual = RM,
+                    timer = null,
+                    barTimer = null;
+                function stopTimers() {
+                    clearTimeout(timer);
+                    clearInterval(barTimer);
+                    autoBtn.style.setProperty("--p", "0%");
+                }
+                function apply() {
+                    stopTimers();
+                    const stages = TRACES[trace];
+                    ALL.forEach((id) => $(id).classList.remove("lit"));
+                    for (let k = 0; k <= stage; k++)
+                        stages[k].on.forEach((id) => $(id).classList.add("lit"));
+                    nar.innerHTML = stages[stage].text;
+                    dots.querySelectorAll(".sdot").forEach((d, k) =>
+                        d.classList.toggle("on", k === stage),
+                    );
+                    prevBtn.disabled = stage === 0;
+                    nextBtn.disabled = stage === stages.length - 1;
+                    autoBtn.hidden = stage === stages.length - 1;
+                    autoBtn.textContent = manual
+                        ? "⏸ paused · click to resume"
+                        : "⏵ auto-advancing · click to pause";
+                    if (!manual && stage < stages.length - 1) {
+                        timer = setTimeout(() => {
+                            stage++;
+                            apply();
+                        }, STEP_MS);
+                        const t0 = performance.now();
+                        barTimer = setInterval(() => {
+                            const pct = Math.min(100, ((performance.now() - t0) / STEP_MS) * 100);
+                            autoBtn.style.setProperty("--p", pct.toFixed(1) + "%");
+                        }, 50);
+                    }
+                }
+                function goManual() {
+                    manual = true;
+                    stopTimers();
+                    autoBtn.textContent = "⏸ paused · click to resume";
+                }
+                function pick(t) {
+                    trace = t;
+                    stage = 0;
+                    buttons.forEach((b, k) => b.classList.toggle("primary", k === t));
+                    dots.innerHTML = "";
+                    TRACES[t].forEach((_, k) => {
+                        const d = document.createElement("button");
+                        d.type = "button";
+                        d.className = "sdot";
+                        d.setAttribute("aria-label", "step " + (k + 1));
+                        d.addEventListener("click", () => {
+                            goManual();
+                            stage = k;
+                            apply();
+                        });
+                        dots.appendChild(d);
+                    });
+                    apply();
+                }
+                buttons.forEach((btn, k) => btn.addEventListener("click", () => pick(k)));
+                prevBtn.addEventListener("click", () => {
+                    goManual();
+                    if (stage > 0) stage--;
+                    apply();
+                });
+                nextBtn.addEventListener("click", () => {
+                    goManual();
+                    if (stage < TRACES[trace].length - 1) stage++;
+                    apply();
+                });
+                autoBtn.addEventListener("click", () => {
+                    if (manual) {
+                        manual = false;
+                        apply();
+                    } // resume: timer restarts from 0
+                    else goManual();
+                });
+            })();
 
-  let i = 0, timer = null, paused = RM, spinTimer = null;
-  function next() {
-    if (paused) return;
-    if (i >= steps.length) { // loop: reset
-      i = 0; scrollback.innerHTML = "";
-      model.phase = "typing"; model.typed = ""; model.reply = ""; tail();
-    }
-    // Advance the index only after the step runs: pausing clears the
-    // pending timer, and the same step must re-schedule on resume.
-    const step = steps[i];
-    timer = setTimeout(() => { i++; step.fn(); next(); }, step.d);
-  }
-  function setPaused(p) {
-    paused = p;
-    playBtn.textContent = p ? "▶ resume" : "⏸ pause";
-    if (p) { clearTimeout(timer); } else { next(); }
-  }
-  playBtn.addEventListener("click", () => setPaused(!paused));
-  $("hero-restart").addEventListener("click", () => {
-    clearTimeout(timer); i = 0; scrollback.innerHTML = "";
-    model.phase = "typing"; model.typed = ""; model.reply = ""; tail();
-    if (paused) setPaused(false); else next();
-  });
-  if (!RM) spinTimer = setInterval(() => {
-    if (!paused && model.phase === "streaming") { model.spin = (model.spin + 1) % SPIN.length; tail(); }
-  }, 80);
-  tail();
-  if (RM) { playBtn.textContent = "▶ play"; } else { next(); }
-})();
-
-/* ============ trees vs timelines ============ */
-(function () {
-  const tree = $("vs-tree"), tl = $("vs-tl"), tailEl = $("vs-tail"),
-        tailText = $("vs-tail-text"), capL = $("vs-cap-l"), capR = $("vs-cap-r");
-  let turnN = 3;
-  const PHRASES = ["how does this work?", "and sealing is cheap?", "what about resizes?", "do I ever need keys?"];
-  let pi = 0, pos = 17; // the markup starts mid-typing of the first phrase
-  const tailStr = () => "❯ " + PHRASES[pi].slice(0, pos) + "█";
-  function flashTree() {
-    tree.querySelectorAll(".tnode").forEach((n) => {
-      n.classList.remove("diffing"); void n.offsetWidth; n.classList.add("diffing");
-    });
-    setTimeout(() => tree.querySelectorAll(".tnode").forEach((n) => n.classList.remove("diffing")), 900);
-  }
-  $("vs-change").addEventListener("click", () => {
-    flashTree();
-    pos = Math.min(pos + 1, PHRASES[pi].length);
-    tailText.textContent = tailStr();
-    tailEl.classList.remove("rerender"); void tailEl.offsetWidth; tailEl.classList.add("rerender");
-    capL.innerHTML = "One keystroke → the <strong>whole retained tree</strong> is walked and reconciled to discover that one text node changed.";
-    capR.innerHTML = "One keystroke → <code>tail()</code> re-runs and the diff is a few cells. The committed blocks above <strong>aren't even looked at</strong>; the library forgot them.";
-  });
-  $("vs-finish").addEventListener("click", () => {
-    // left: the tree grows and reconciles everything again
-    const msgs = $("vs-tree-msgs");
-    if (msgs.children.length < 5) {
-      const n = document.createElement("div");
-      n.className = "tnode";
-      n.innerHTML = `<span class="tag">diff</span>&lt;Turn key=${turnN}/&gt;`;
-      msgs.appendChild(n);
-    }
-    flashTree();
-    // right: the tail's content seals into a committed block
-    if (pos < 4) pos = PHRASES[pi].length; // commit a sensible line even if barely typed
-    const blk = document.createElement("div");
-    blk.className = "tl-blk flash";
-    blk.textContent = "❯ " + PHRASES[pi].slice(0, pos);
-    tl.insertBefore(blk, tailEl);
-    if (tl.querySelectorAll(".tl-blk").length > 5) tl.querySelector(".tl-blk").remove();
-    pi = (pi + 1) % PHRASES.length;
-    pos = 0;
-    tailText.textContent = tailStr();
-    turnN++;
-    capL.innerHTML = "A finished turn → a <strong>new node, retained forever</strong>. Every future render pays for it: more to walk, more to diff, and now it needs a <code>key</code>.";
-    capR.innerHTML = "A finished turn → <code>ctx.push</code>. Rendered once, handed to the terminal, <strong>never touched again</strong>. The tail resets to just the prompt.";
-  });
-})();
-
-/* ============ the loop: narrated traces ============ */
-(function () {
-  const nar = $("loop-nar"), dots = $("loop-dots"),
-        autoBtn = $("loop-auto"), prevBtn = $("loop-prev"), nextBtn = $("loop-next");
-  const buttons = [...document.querySelectorAll(".loop-tr")];
-  const ALL = ["lb-ev", "lb-task", "lb-sub", "lb-msg", "lb-update", "lb-push",
-               "lb-spawn", "lb-batch", "lb-tail", "lb-diff", "lb-term", "lb-loop"];
-  const TRACES = [
-    [ // 1 · the user submits a prompt
-      { on: ["lb-ev"], text: "<strong>Enter pressed.</strong> The keymap, rebuilt from the model this frame, resolves it to <code>Msg::Submit</code>." },
-      { on: ["lb-msg", "lb-update"], text: "<strong>update runs.</strong> It takes the draft out of the model and stores <code>self.request = Some(task)</code>. Plain Rust so far." },
-      { on: ["lb-push"], text: "<strong>Effect one:</strong> <code>ctx.push</code> commits the user's prompt to scrollback: rendered once, at today's width, permanent." },
-      { on: ["lb-spawn", "lb-loop"], text: "<strong>Effect two:</strong> <code>ctx.spawn</code> starts the request. Its stream items will re-enter the loop as messages, through the same front door as keystrokes." },
-      { on: ["lb-batch", "lb-tail"], text: "<strong>The view turn.</strong> <code>tail(&amp;self)</code> re-runs: the input box is empty and a spinner appears, because the model now says a request is live." },
-      { on: ["lb-diff", "lb-term"], text: "<strong>Present.</strong> The engine diffs and sends only the bytes that changed. One message in, one frame out." },
-    ],
-    [ // 2 · a chunk arrives
-      { on: ["lb-task"], text: "<strong>The spawned stream yields</strong> <code>Msg::Chunk(\"…\")</code>." },
-      { on: ["lb-msg", "lb-update"], text: "<strong>update runs:</strong> <code>self.reply.push_str(&amp;delta)</code>. String mutation, nothing else." },
-      { on: [], text: "<strong>No effects this time.</strong> Nothing is finished and nothing new spawns, so the effect boxes stay dark. Most messages are like this." },
-      { on: ["lb-batch", "lb-tail"], text: "<strong><code>tail()</code> rebuilds wholesale:</strong> spinner plus the longer reply. No dirty tracking asked what changed; nothing needed to." },
-      { on: ["lb-diff", "lb-term"], text: "<strong>The diff is just the new cells.</strong> A burst of 64 queued chunks? Coalesced into a single frame." },
-    ],
-    [ // 3 · the stream ends
-      { on: ["lb-task"], text: "<strong>The stream finishes:</strong> <code>Msg::StreamDone</code>." },
-      { on: ["lb-msg", "lb-update"], text: "<strong>update runs:</strong> it takes the finished reply out of the model and drops the <code>Task</code>." },
-      { on: ["lb-push"], text: "<strong>Effect:</strong> <code>ctx.push(markdown(reply))</code> seals the turn into scrollback. Its content was already on screen as tail, so the commit costs one newline." },
-      { on: ["lb-batch", "lb-tail"], text: "<strong><code>tail()</code> re-runs:</strong> no request, no spinner, just an empty input box ready for the next prompt." },
-      { on: ["lb-diff", "lb-term"], text: "<strong>Present.</strong> The conversation now lives in the terminal's scrollback, not in the library. The loop is idle until the next message." },
-    ],
-  ];
-  // Auto-advances like a slideshow until the reader takes any control
-  // themselves — then it's theirs (sticky for the session). Reduced-motion
-  // users get manual stepping from the start.
-  const STEP_MS = 5000;
-  let trace = null, stage = 0, manual = RM, timer = null, barTimer = null;
-  function stopTimers() {
-    clearTimeout(timer); clearInterval(barTimer);
-    autoBtn.style.setProperty("--p", "0%");
-  }
-  function apply() {
-    stopTimers();
-    const stages = TRACES[trace];
-    ALL.forEach((id) => $(id).classList.remove("lit"));
-    for (let k = 0; k <= stage; k++)
-      stages[k].on.forEach((id) => $(id).classList.add("lit"));
-    nar.innerHTML = stages[stage].text;
-    dots.querySelectorAll(".sdot").forEach((d, k) => d.classList.toggle("on", k === stage));
-    prevBtn.disabled = stage === 0;
-    nextBtn.disabled = stage === stages.length - 1;
-    autoBtn.hidden = stage === stages.length - 1;
-    autoBtn.textContent = manual ? "⏸ paused · click to resume" : "⏵ auto-advancing · click to pause";
-    if (!manual && stage < stages.length - 1) {
-      timer = setTimeout(() => { stage++; apply(); }, STEP_MS);
-      const t0 = performance.now();
-      barTimer = setInterval(() => {
-        const pct = Math.min(100, ((performance.now() - t0) / STEP_MS) * 100);
-        autoBtn.style.setProperty("--p", pct.toFixed(1) + "%");
-      }, 50);
-    }
-  }
-  function goManual() {
-    manual = true; stopTimers();
-    autoBtn.textContent = "⏸ paused · click to resume";
-  }
-  function pick(t) {
-    trace = t; stage = 0;
-    buttons.forEach((b, k) => b.classList.toggle("primary", k === t));
-    dots.innerHTML = "";
-    TRACES[t].forEach((_, k) => {
-      const d = document.createElement("button");
-      d.type = "button"; d.className = "sdot";
-      d.setAttribute("aria-label", "step " + (k + 1));
-      d.addEventListener("click", () => { goManual(); stage = k; apply(); });
-      dots.appendChild(d);
-    });
-    apply();
-  }
-  buttons.forEach((btn, k) => btn.addEventListener("click", () => pick(k)));
-  prevBtn.addEventListener("click", () => { goManual(); if (stage > 0) stage--; apply(); });
-  nextBtn.addEventListener("click", () => { goManual(); if (stage < TRACES[trace].length - 1) stage++; apply(); });
-  autoBtn.addEventListener("click", () => {
-    if (manual) { manual = false; apply(); } // resume: timer restarts from 0
-    else goManual();
-  });
-})();
-
-/* ============ seal stepper ============ */
-(function () {
-  const NOTES = [
-    `<strong>The stream begins.</strong> The user's question is already committed above. The tail,
+            /* ============ seal stepper ============ */
+            (function () {
+                const NOTES = [
+                    `<strong>The stream begins.</strong> The user's question is already committed above. The tail,
      rebuilt every frame from the model, shows a spinner because <code>self.streaming()</code> is true.
      <span class="stat">tail: spinner only</span>`,
-    `<strong>Msg::Chunk arrives.</strong> <code>update</code> appends to <code>self.reply</code>: plain
+                    `<strong>Msg::Chunk arrives.</strong> <code>update</code> appends to <code>self.reply</code>: plain
      string mutation, no framework calls. Then <code>tail()</code> re-runs and the engine diffs.
      <span class="stat">diff: only the new cells</span>`,
-    `<strong>More chunks.</strong> Same thing, every frame. A burst of queued chunks coalesces into one
+                    `<strong>More chunks.</strong> Same thing, every frame. A burst of queued chunks coalesces into one
      frame. The content is already on screen, as the tail.
      <span class="stat">cost: O(tail), ~1ms at 10KB</span>`,
-    `<strong>Msg::StreamDone → ctx.push.</strong> The pushed block's content is exactly what the tail was
+                    `<strong>Msg::StreamDone → ctx.push.</strong> The pushed block's content is exactly what the tail was
      already showing, so the commit costs <em>a single newline</em>. Nothing repaints. The text simply
      stops being live. <span class="stat">commit cost: 1 byte ("\\n")</span>`,
-    `<strong>Sealed.</strong> The block now belongs to the terminal: scroll it, select it. On resize it
+                    `<strong>Sealed.</strong> The block now belongs to the terminal: scroll it, select it. On resize it
      reflows like your shell history, because it <em>is</em> shell-history-grade output. The tail is
      small again, ready for the next turn. <span class="stat">library memory of this block: none</span>`,
-  ];
-  const LABELS = ["the stream begins", "a chunk arrives", "more chunks", "StreamDone → push", "sealed"];
-  const REPLY = "Because the pushed block is exactly what the tail was already showing; nothing needs to repaint.";
-  const PARTIAL = [0, 6, REPLY.split(" ").length];
-  const scrollback = $("seal-scrollback"), tailContent = $("seal-tail-content"),
-        note = $("seal-note"), lbl = $("seal-lbl"), dots = $("seal-dots"),
-        code = $("seal-code");
-  const spans = [...code.querySelectorAll("[data-sl]")];
-  const tailFnStart = spans.findIndex((s) => s.textContent.includes("fn tail"));
-  let step = 0;
-  for (let k = 0; k < 5; k++) {
-    const d = document.createElement("button");
-    d.type = "button"; d.className = "sdot";
-    d.setAttribute("aria-label", "step " + (k + 1));
-    d.addEventListener("click", () => { const p = step; step = k; render(p); });
-    dots.appendChild(d);
-  }
-  function replyAt(s) {
-    const words = REPLY.split(" ");
-    const n = s === 1 ? PARTIAL[1] : s >= 2 ? words.length : 0;
-    return words.slice(0, n).join(" ");
-  }
-  function render(fromStep) {
-    // scrollback: question always; reply block once we've pushed
-    let sb = `<div class="blk committed"><span class="dim">❯</span> <span class="tel">why is sealing cheap?</span></div>`;
-    if (step >= 3) sb += `<div class="blk committed ${fromStep === 2 ? "just-committed" : ""}">${REPLY}</div>`;
-    scrollback.innerHTML = sb;
-    // tail
-    if (step <= 2) {
-      tailContent.innerHTML =
-        `<div><span class="tel">${SPIN[3]}</span> <span class="dim">Thinking…</span></div>` +
-        (step >= 1 ? `<div>${replyAt(step)}<span class="cursor" style="animation:none;"></span></div>` : "");
-    } else {
-      tailContent.innerHTML =
-        `<div class="tin"><span class="tel">❯</span><span><span class="cursor"></span></span></div>` +
-        `<div class="tin-foot">[Enter] send</div>`;
-    }
-    note.innerHTML = NOTES[step];
-    lbl.textContent = `step ${step + 1}/5 · ${LABELS[step]}`;
-    dots.querySelectorAll(".sdot").forEach((d, k) => d.classList.toggle("on", k === step));
-    $("seal-prev").disabled = step === 0;
-    $("seal-next").disabled = step === 4;
-    // code highlighting: amber for update arms, teal for the tail fn
-    spans.forEach((s, idx) => {
-      s.classList.remove("hl-line", "v");
-      const list = s.dataset.sl;
-      if (list !== "all" && list.split(",").includes(String(step))) {
-        s.classList.add("hl-line");
-        if (idx >= tailFnStart) s.classList.add("v");
-      }
-    });
-  }
-  $("seal-next").addEventListener("click", () => { const p = step; step = Math.min(4, step + 1); render(p); });
-  $("seal-prev").addEventListener("click", () => { const p = step; step = Math.max(0, step - 1); render(p); });
-  render(0);
-})();
+                ];
+                const LABELS = [
+                    "the stream begins",
+                    "a chunk arrives",
+                    "more chunks",
+                    "StreamDone → push",
+                    "sealed",
+                ];
+                const REPLY =
+                    "Because the pushed block is exactly what the tail was already showing; nothing needs to repaint.";
+                const PARTIAL = [0, 6, REPLY.split(" ").length];
+                const scrollback = $("seal-scrollback"),
+                    tailContent = $("seal-tail-content"),
+                    note = $("seal-note"),
+                    lbl = $("seal-lbl"),
+                    dots = $("seal-dots"),
+                    code = $("seal-code");
+                const spans = [...code.querySelectorAll("[data-sl]")];
+                const tailFnStart = spans.findIndex((s) => s.textContent.includes("fn tail"));
+                let step = 0;
+                for (let k = 0; k < 5; k++) {
+                    const d = document.createElement("button");
+                    d.type = "button";
+                    d.className = "sdot";
+                    d.setAttribute("aria-label", "step " + (k + 1));
+                    d.addEventListener("click", () => {
+                        const p = step;
+                        step = k;
+                        render(p);
+                    });
+                    dots.appendChild(d);
+                }
+                function replyAt(s) {
+                    const words = REPLY.split(" ");
+                    const n = s === 1 ? PARTIAL[1] : s >= 2 ? words.length : 0;
+                    return words.slice(0, n).join(" ");
+                }
+                function render(fromStep) {
+                    // scrollback: question always; reply block once we've pushed
+                    let sb = `<div class="blk committed"><span class="dim">❯</span> <span class="tel">why is sealing cheap?</span></div>`;
+                    if (step >= 3)
+                        sb += `<div class="blk committed ${fromStep === 2 ? "just-committed" : ""}">${REPLY}</div>`;
+                    scrollback.innerHTML = sb;
+                    // tail
+                    if (step <= 2) {
+                        tailContent.innerHTML =
+                            `<div><span class="tel">${SPIN[3]}</span> <span class="dim">Thinking…</span></div>` +
+                            (step >= 1
+                                ? `<div>${replyAt(step)}<span class="cursor" style="animation:none;"></span></div>`
+                                : "");
+                    } else {
+                        tailContent.innerHTML =
+                            `<div class="tin"><span class="tel">❯</span><span><span class="cursor"></span></span></div>` +
+                            `<div class="tin-foot">[Enter] send</div>`;
+                    }
+                    note.innerHTML = NOTES[step];
+                    lbl.textContent = `step ${step + 1}/5 · ${LABELS[step]}`;
+                    dots.querySelectorAll(".sdot").forEach((d, k) =>
+                        d.classList.toggle("on", k === step),
+                    );
+                    $("seal-prev").disabled = step === 0;
+                    $("seal-next").disabled = step === 4;
+                    // code highlighting: amber for update arms, teal for the tail fn
+                    spans.forEach((s, idx) => {
+                        s.classList.remove("hl-line", "v");
+                        const list = s.dataset.sl;
+                        if (list !== "all" && list.split(",").includes(String(step))) {
+                            s.classList.add("hl-line");
+                            if (idx >= tailFnStart) s.classList.add("v");
+                        }
+                    });
+                }
+                $("seal-next").addEventListener("click", () => {
+                    const p = step;
+                    step = Math.min(4, step + 1);
+                    render(p);
+                });
+                $("seal-prev").addEventListener("click", () => {
+                    const p = step;
+                    step = Math.max(0, step - 1);
+                    render(p);
+                });
+                render(0);
+            })();
 
-/* ============ elements playground ============ */
-(function () {
-  const model = { streaming: false, results: 2, input: "", focused: false };
-  const HITS = [
-    "The seal pattern · guide/the-timeline",
-    "Cancellation is drop · guide/async",
-    "Keys are data · guide/input",
-    "Honest height · guide/elements",
-  ];
-  const tailZone = $("pg-tail"), tailContent = $("pg-tail-content"), frames = $("pg-frames");
-  let frameCount = 0, spin = 3;
-  function esc(s) { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;"); }
-  function render(flash) {
-    frameCount++;
-    let html = "";
-    if (model.streaming) html += `<div class="fk-spin">${SPIN[spin]} <span class="dim">Thinking…</span></div>`;
-    // The block cursor tracks the REAL input's focus — this is track_focus
-    const inner = model.focused
-      ? `${esc(model.input)}<span class="cursor"></span>`
-      : model.input ? esc(model.input) : `<span class="ph">Type a message…</span>`;
-    html += `<div class="fk-panel${model.focused ? " focused" : ""}"><span class="fk-title">Ask</span><div>${inner}</div><span class="fk-foot">[Enter] Send</span></div>`;
-    for (let k = 0; k < model.results; k++)
-      html += `<div class="fk-hit"><b>${k + 1}.</b> ${HITS[k]}</div>`;
-    tailContent.innerHTML = html;
-    frames.textContent = frameCount;
-    $("pg-streaming-val").textContent = model.streaming;
-    $("pg-results-val").textContent = model.results;
-    if (flash) { tailZone.classList.remove("rr"); void tailZone.offsetWidth; tailZone.classList.add("rr"); }
-  }
-  $("pg-streaming").addEventListener("change", (e) => { model.streaming = e.target.checked; render(true); });
-  $("pg-res-minus").addEventListener("click", () => { model.results = Math.max(0, model.results - 1); render(true); });
-  $("pg-res-plus").addEventListener("click", () => { model.results = Math.min(4, model.results + 1); render(true); });
-  $("pg-input").addEventListener("input", (e) => { model.input = e.target.value; render(true); });
-  $("pg-input").addEventListener("focus", () => { model.focused = true; render(true); });
-  $("pg-input").addEventListener("blur", () => { model.focused = false; render(true); });
-  if (!RM) setInterval(() => { if (model.streaming) { spin = (spin + 1) % SPIN.length; render(false); } }, 80);
-  render(false);
-})();
+            /* ============ elements playground ============ */
+            (function () {
+                const model = { streaming: false, results: 2, input: "", focused: false };
+                const HITS = [
+                    "The seal pattern · guide/the-timeline",
+                    "Cancellation is drop · guide/async",
+                    "Keys are data · guide/input",
+                    "Honest height · guide/elements",
+                ];
+                const tailZone = $("pg-tail"),
+                    tailContent = $("pg-tail-content"),
+                    frames = $("pg-frames");
+                let frameCount = 0,
+                    spin = 3;
+                function esc(s) {
+                    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+                }
+                function render(flash) {
+                    frameCount++;
+                    let html = "";
+                    if (model.streaming)
+                        html += `<div class="fk-spin">${SPIN[spin]} <span class="dim">Thinking…</span></div>`;
+                    // The block cursor tracks the REAL input's focus — this is track_focus
+                    const inner = model.focused
+                        ? `${esc(model.input)}<span class="cursor"></span>`
+                        : model.input
+                          ? esc(model.input)
+                          : `<span class="ph">Type a message…</span>`;
+                    html += `<div class="fk-panel${model.focused ? " focused" : ""}"><span class="fk-title">Ask</span><div>${inner}</div><span class="fk-foot">[Enter] Send</span></div>`;
+                    for (let k = 0; k < model.results; k++)
+                        html += `<div class="fk-hit"><b>${k + 1}.</b> ${HITS[k]}</div>`;
+                    tailContent.innerHTML = html;
+                    frames.textContent = frameCount;
+                    $("pg-streaming-val").textContent = model.streaming;
+                    $("pg-results-val").textContent = model.results;
+                    if (flash) {
+                        tailZone.classList.remove("rr");
+                        void tailZone.offsetWidth;
+                        tailZone.classList.add("rr");
+                    }
+                }
+                $("pg-streaming").addEventListener("change", (e) => {
+                    model.streaming = e.target.checked;
+                    render(true);
+                });
+                $("pg-res-minus").addEventListener("click", () => {
+                    model.results = Math.max(0, model.results - 1);
+                    render(true);
+                });
+                $("pg-res-plus").addEventListener("click", () => {
+                    model.results = Math.min(4, model.results + 1);
+                    render(true);
+                });
+                $("pg-input").addEventListener("input", (e) => {
+                    model.input = e.target.value;
+                    render(true);
+                });
+                $("pg-input").addEventListener("focus", () => {
+                    model.focused = true;
+                    render(true);
+                });
+                $("pg-input").addEventListener("blur", () => {
+                    model.focused = false;
+                    render(true);
+                });
+                if (!RM)
+                    setInterval(() => {
+                        if (model.streaming) {
+                            spin = (spin + 1) % SPIN.length;
+                            render(false);
+                        }
+                    }, 80);
+                render(false);
+            })();
 
-/* ============ keymap dispatch ============ */
-(function () {
-  const state = { focus: "input", busy: false };
-  const tiers = [1, 2, 3, 4].map((n) => $("tier-" + n));
-  const result = $("km-result");
-  let running = false;
-  function syncState() {
-    tiers[1].classList.toggle("ghost", state.busy);
-    $("tier-2-bind").textContent = state.busy
-      ? "not in the keymap this frame (self.busy)"
-      : "Enter → Msg::Submit";
-    $("km-cond-line").classList.toggle("ghost", state.busy);
-    $("km-foc-input").classList.toggle("on", state.focus === "input");
-    $("km-foc-list").classList.toggle("on", state.focus === "list");
-  }
-  $("km-foc-input").addEventListener("click", () => { state.focus = "input"; syncState(); });
-  $("km-foc-list").addEventListener("click", () => { state.focus = "list"; syncState(); });
-  $("km-busy").addEventListener("change", (e) => { state.busy = e.target.checked; syncState(); });
+            /* ============ keymap dispatch ============ */
+            (function () {
+                const state = { focus: "input", busy: false };
+                const tiers = [1, 2, 3, 4].map((n) => $("tier-" + n));
+                const result = $("km-result");
+                let running = false;
+                function syncState() {
+                    tiers[1].classList.toggle("ghost", state.busy);
+                    $("tier-2-bind").textContent = state.busy
+                        ? "not in the keymap this frame (self.busy)"
+                        : "Enter → Msg::Submit";
+                    $("km-cond-line").classList.toggle("ghost", state.busy);
+                    $("km-foc-input").classList.toggle("on", state.focus === "input");
+                    $("km-foc-list").classList.toggle("on", state.focus === "list");
+                }
+                $("km-foc-input").addEventListener("click", () => {
+                    state.focus = "input";
+                    syncState();
+                });
+                $("km-foc-list").addEventListener("click", () => {
+                    state.focus = "list";
+                    syncState();
+                });
+                $("km-busy").addEventListener("change", (e) => {
+                    state.busy = e.target.checked;
+                    syncState();
+                });
 
-  function dispatch(keyId) {
-    const inFocus = state.focus === "input";
-    const seq = []; // {tier: 0-3, verdict: 'pass'|'claim', why}
-    let claim = null;
-    function tier(t, matched, why, msg, note) {
-      if (claim) return;
-      if (matched) { claim = { msg, note }; seq.push({ t, v: "claim", why }); }
-      else seq.push({ t, v: "pass", why });
-    }
-    switch (keyId) {
-      case "ctrlc":
-        tier(0, true, "claimed", "Msg::Quit", "on_override fires regardless of focus. It's for Ctrl+C-tier chords only.");
-        break;
-      case "enter":
-        tier(0, false, "not Ctrl+C");
-        if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
-        else tier(1, inFocus, inFocus ? "claimed" : "input not focused", "Msg::Submit",
-          "Bound only because !self.busy; the condition is an if statement, not a runtime check.");
-        tier(2, false, "not Esc");
-        tier(3, inFocus, inFocus ? "claimed" : "input not focused", "Msg::Input(Key(Enter))",
-          "Fallthrough catches it, and TextAreaState::handle deliberately ignores policy keys like Enter, so while busy it does nothing.");
-        break;
-      case "esc":
-        tier(0, false, "not Ctrl+C");
-        if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
-        else tier(1, false, "not Enter");
-        tier(2, true, "claimed", "Msg::Cancel",
-          "One global binding; update decides what cancelling means in the current state.");
-        break;
-      case "s": case "tab": {
-        const label = keyId === "s" ? "Msg::Input(Typed('s'))" : "Msg::Input(Key(Tab))";
-        tier(0, false, "not Ctrl+C");
-        if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
-        else tier(1, false, "not Enter");
-        tier(2, false, "not Esc");
-        tier(3, inFocus, inFocus ? "claimed" : "input not focused", label,
-          "This is how the text area receives typing; the framework owns no editing logic.");
-        break;
-      }
-      case "paste":
-        for (const t of [0, 1, 2]) seq.push({ t, v: "pass", why: "pastes only match fallthrough" });
-        tier(3, inFocus, inFocus ? "claimed" : "input not focused", 'Msg::Input(Paste("hi"))',
-          "Fallthrough receives keys AND pastes, so a paste lands in your model like any other edit.");
-        break;
-    }
-    return { seq, claim };
-  }
+                function dispatch(keyId) {
+                    const inFocus = state.focus === "input";
+                    const seq = []; // {tier: 0-3, verdict: 'pass'|'claim', why}
+                    let claim = null;
+                    function tier(t, matched, why, msg, note) {
+                        if (claim) return;
+                        if (matched) {
+                            claim = { msg, note };
+                            seq.push({ t, v: "claim", why });
+                        } else seq.push({ t, v: "pass", why });
+                    }
+                    switch (keyId) {
+                        case "ctrlc":
+                            tier(
+                                0,
+                                true,
+                                "claimed",
+                                "Msg::Quit",
+                                "on_override fires regardless of focus. It's for Ctrl+C-tier chords only.",
+                            );
+                            break;
+                        case "enter":
+                            tier(0, false, "not Ctrl+C");
+                            if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
+                            else
+                                tier(
+                                    1,
+                                    inFocus,
+                                    inFocus ? "claimed" : "input not focused",
+                                    "Msg::Submit",
+                                    "Bound only because !self.busy; the condition is an if statement, not a runtime check.",
+                                );
+                            tier(2, false, "not Esc");
+                            tier(
+                                3,
+                                inFocus,
+                                inFocus ? "claimed" : "input not focused",
+                                "Msg::Input(Key(Enter))",
+                                "Fallthrough catches it, and TextAreaState::handle deliberately ignores policy keys like Enter, so while busy it does nothing.",
+                            );
+                            break;
+                        case "esc":
+                            tier(0, false, "not Ctrl+C");
+                            if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
+                            else tier(1, false, "not Enter");
+                            tier(
+                                2,
+                                true,
+                                "claimed",
+                                "Msg::Cancel",
+                                "One global binding; update decides what cancelling means in the current state.",
+                            );
+                            break;
+                        case "s":
+                        case "tab": {
+                            const label =
+                                keyId === "s" ? "Msg::Input(Typed('s'))" : "Msg::Input(Key(Tab))";
+                            tier(0, false, "not Ctrl+C");
+                            if (state.busy) seq.push({ t: 1, v: "pass", why: "binding absent" });
+                            else tier(1, false, "not Enter");
+                            tier(2, false, "not Esc");
+                            tier(
+                                3,
+                                inFocus,
+                                inFocus ? "claimed" : "input not focused",
+                                label,
+                                "This is how the text area receives typing; the framework owns no editing logic.",
+                            );
+                            break;
+                        }
+                        case "paste":
+                            for (const t of [0, 1, 2])
+                                seq.push({ t, v: "pass", why: "pastes only match fallthrough" });
+                            tier(
+                                3,
+                                inFocus,
+                                inFocus ? "claimed" : "input not focused",
+                                'Msg::Input(Paste("hi"))',
+                                "Fallthrough receives keys AND pastes, so a paste lands in your model like any other edit.",
+                            );
+                            break;
+                    }
+                    return { seq, claim };
+                }
 
-  document.querySelectorAll(".km-key").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      if (running) return;
-      running = true;
-      const { seq, claim } = dispatch(btn.dataset.key);
-      tiers.forEach((t) => { t.classList.remove("checking", "claim", "pass"); t.querySelector(".tstate").textContent = "·"; });
-      result.className = "kresult";
-      result.innerHTML = "<small>dispatching…</small>";
-      const stepMs = RM ? 0 : 320;
-      seq.forEach((s, k) => {
-        setTimeout(() => {
-          const el = tiers[s.t], st = el.querySelector(".tstate");
-          el.classList.add("checking");
-          setTimeout(() => {
-            el.classList.remove("checking");
-            el.classList.add(s.v);
-            st.textContent = s.v === "claim" ? "claimed ✓" : `pass ↓ (${s.why})`;
-          }, RM ? 0 : 200);
-        }, k * stepMs);
-      });
-      setTimeout(() => {
-        if (claim) {
-          result.className = "kresult got";
-          result.innerHTML = `update() receives → <strong>${claim.msg}</strong><small>${claim.note}</small>`;
-        } else {
-          result.className = "kresult drop";
-          result.innerHTML = `dropped: no binding claimed it<small>The key is simply ignored. No handler existed for this state, so no stale behavior can fire.</small>`;
-        }
-        running = false;
-      }, seq.length * stepMs + 260);
-    });
-  });
-  syncState();
-})();
+                document.querySelectorAll(".km-key").forEach((btn) => {
+                    btn.addEventListener("click", () => {
+                        if (running) return;
+                        running = true;
+                        const { seq, claim } = dispatch(btn.dataset.key);
+                        tiers.forEach((t) => {
+                            t.classList.remove("checking", "claim", "pass");
+                            t.querySelector(".tstate").textContent = "·";
+                        });
+                        result.className = "kresult";
+                        result.innerHTML = "<small>dispatching…</small>";
+                        const stepMs = RM ? 0 : 320;
+                        seq.forEach((s, k) => {
+                            setTimeout(() => {
+                                const el = tiers[s.t],
+                                    st = el.querySelector(".tstate");
+                                el.classList.add("checking");
+                                setTimeout(
+                                    () => {
+                                        el.classList.remove("checking");
+                                        el.classList.add(s.v);
+                                        st.textContent =
+                                            s.v === "claim" ? "claimed ✓" : `pass ↓ (${s.why})`;
+                                    },
+                                    RM ? 0 : 200,
+                                );
+                            }, k * stepMs);
+                        });
+                        setTimeout(
+                            () => {
+                                if (claim) {
+                                    result.className = "kresult got";
+                                    result.innerHTML = `update() receives → <strong>${claim.msg}</strong><small>${claim.note}</small>`;
+                                } else {
+                                    result.className = "kresult drop";
+                                    result.innerHTML = `dropped: no binding claimed it<small>The key is simply ignored. No handler existed for this state, so no stale behavior can fire.</small>`;
+                                }
+                                running = false;
+                            },
+                            seq.length * stepMs + 260,
+                        );
+                    });
+                });
+                syncState();
+            })();
 
-/* ============ async: cancellation is drop ============ */
-(function () {
-  const WORDS = ("Once upon a time a request streamed happily into a model, one chunk at a " +
-    "time, never once worrying about cancellation tokens, atomic flags, or cleanup " +
-    "channels, because the moment its Task is dropped it simply stops existing at " +
-    "whatever await point it had reached. The end.").split(" ");
-  const taskEl = $("as-task"), log = $("as-log"), tailContent = $("as-tail-content"),
-        scrollback = $("as-scrollback");
-  const scroller = tailContent.closest(".term-scroll");
-  const model = { taskN: 1, alive: true, idx: 0, spin: 0 };
-  let timer = null;
-  function esc(s) { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;"); }
-  function reply() { return WORDS.slice(0, model.idx).join(" "); }
-  function setTask(alive) {
-    model.alive = alive;
-    taskEl.textContent = alive ? `Some(Task #${model.taskN})` : "None";
-    taskEl.className = "task-val " + (alive ? "some" : "none");
-  }
-  function addLog(text, cls) {
-    log.querySelectorAll(".mline").forEach((l) => l.classList.remove("new"));
-    const d = document.createElement("div");
-    d.className = "mline " + (cls || "new");
-    d.textContent = text;
-    log.appendChild(d);
-    while (log.querySelectorAll(".mline").length > 6) log.querySelector(".mline").remove();
-  }
-  function renderTail(status) {
-    let html = "";
-    if (status === "streaming")
-      html += `<div><span class="tel">${SPIN[model.spin]}</span> <span class="dim">streaming…</span></div>`;
-    if (status === "cancelled")
-      html += `<div><span class="red">✗</span> <span class="dim">cancelled; the partial reply is still in the model</span></div>`;
-    if (status === "done")
-      html += `<div><span class="grn">✓</span> <span class="dim">done · sealed above</span></div>`;
-    if (status !== "done") html += `<div>${esc(reply())}</div>`;
-    tailContent.innerHTML = html;
-    scroller.scrollTop = scroller.scrollHeight;
-  }
-  function tick() {
-    if (!model.alive) return;
-    if (model.idx >= WORDS.length) {
-      clearInterval(timer);
-      const blk = document.createElement("div");
-      blk.className = "blk committed just-committed";
-      blk.textContent = reply();
-      scrollback.appendChild(blk);
-      addLog("Msg::StreamDone");
-      setTask(false);
-      model.idx = 0;
-      renderTail("done");
-      return;
-    }
-    model.idx++;
-    model.spin = (model.spin + 1) % SPIN.length;
-    if (model.idx % 6 === 0) addLog(`Msg::Chunk("${WORDS[model.idx - 1]} …")`);
-    renderTail("streaming");
-  }
-  function start() {
-    clearInterval(timer);
-    model.taskN++; model.idx = 0;
-    setTask(true);
-    addLog(`· spawned Task #${model.taskN}`, "mline");
-    if (RM) { model.idx = WORDS.length; tick(); }
-    else timer = setInterval(tick, 110);
-  }
-  $("as-cancel").addEventListener("click", () => {
-    if (!model.alive) return;
-    clearInterval(timer);
-    setTask(false);
-    addLog("Msg::Cancel → self.request = None");
-    renderTail("cancelled");
-    // one already-queued chunk still arrives; the model check ignores it
-    setTimeout(() => addLog(`Msg::Chunk("${WORDS[Math.min(model.idx, WORDS.length - 1)]} …")`, "stale"), 600);
-  });
-  $("as-restart").addEventListener("click", start);
-  // Idle until the demo scrolls into view, so the reader sees the stream
-  // (and can cancel it) instead of arriving after it already finished.
-  model.taskN = 0;
-  tailContent.innerHTML = `<div class="dim">· about to spawn a request…</div>`;
-  const obs = new IntersectionObserver((entries) => {
-    entries.forEach((e) => {
-      if (e.isIntersecting) { obs.disconnect(); start(); }
-    });
-  }, { threshold: 0.4 });
-  obs.observe(tailContent.closest(".term"));
-})();
+            /* ============ async: cancellation is drop ============ */
+            (function () {
+                const WORDS = (
+                    "Once upon a time a request streamed happily into a model, one chunk at a " +
+                    "time, never once worrying about cancellation tokens, atomic flags, or cleanup " +
+                    "channels, because the moment its Task is dropped it simply stops existing at " +
+                    "whatever await point it had reached. The end."
+                ).split(" ");
+                const taskEl = $("as-task"),
+                    log = $("as-log"),
+                    tailContent = $("as-tail-content"),
+                    scrollback = $("as-scrollback");
+                const scroller = tailContent.closest(".term-scroll");
+                const model = { taskN: 1, alive: true, idx: 0, spin: 0 };
+                let timer = null;
+                function esc(s) {
+                    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+                }
+                function reply() {
+                    return WORDS.slice(0, model.idx).join(" ");
+                }
+                function setTask(alive) {
+                    model.alive = alive;
+                    taskEl.textContent = alive ? `Some(Task #${model.taskN})` : "None";
+                    taskEl.className = "task-val " + (alive ? "some" : "none");
+                }
+                function addLog(text, cls) {
+                    log.querySelectorAll(".mline").forEach((l) => l.classList.remove("new"));
+                    const d = document.createElement("div");
+                    d.className = "mline " + (cls || "new");
+                    d.textContent = text;
+                    log.appendChild(d);
+                    while (log.querySelectorAll(".mline").length > 6)
+                        log.querySelector(".mline").remove();
+                }
+                function renderTail(status) {
+                    let html = "";
+                    if (status === "streaming")
+                        html += `<div><span class="tel">${SPIN[model.spin]}</span> <span class="dim">streaming…</span></div>`;
+                    if (status === "cancelled")
+                        html += `<div><span class="red">✗</span> <span class="dim">cancelled; the partial reply is still in the model</span></div>`;
+                    if (status === "done")
+                        html += `<div><span class="grn">✓</span> <span class="dim">done · sealed above</span></div>`;
+                    if (status !== "done") html += `<div>${esc(reply())}</div>`;
+                    tailContent.innerHTML = html;
+                    scroller.scrollTop = scroller.scrollHeight;
+                }
+                function tick() {
+                    if (!model.alive) return;
+                    if (model.idx >= WORDS.length) {
+                        clearInterval(timer);
+                        const blk = document.createElement("div");
+                        blk.className = "blk committed just-committed";
+                        blk.textContent = reply();
+                        scrollback.appendChild(blk);
+                        addLog("Msg::StreamDone");
+                        setTask(false);
+                        model.idx = 0;
+                        renderTail("done");
+                        return;
+                    }
+                    model.idx++;
+                    model.spin = (model.spin + 1) % SPIN.length;
+                    if (model.idx % 6 === 0) addLog(`Msg::Chunk("${WORDS[model.idx - 1]} …")`);
+                    renderTail("streaming");
+                }
+                function start() {
+                    clearInterval(timer);
+                    model.taskN++;
+                    model.idx = 0;
+                    setTask(true);
+                    addLog(`· spawned Task #${model.taskN}`, "mline");
+                    if (RM) {
+                        model.idx = WORDS.length;
+                        tick();
+                    } else timer = setInterval(tick, 110);
+                }
+                $("as-cancel").addEventListener("click", () => {
+                    if (!model.alive) return;
+                    clearInterval(timer);
+                    setTask(false);
+                    addLog("Msg::Cancel → self.request = None");
+                    renderTail("cancelled");
+                    // one already-queued chunk still arrives; the model check ignores it
+                    setTimeout(
+                        () =>
+                            addLog(
+                                `Msg::Chunk("${WORDS[Math.min(model.idx, WORDS.length - 1)]} …")`,
+                                "stale",
+                            ),
+                        600,
+                    );
+                });
+                $("as-restart").addEventListener("click", start);
+                // Idle until the demo scrolls into view, so the reader sees the stream
+                // (and can cancel it) instead of arriving after it already finished.
+                model.taskN = 0;
+                tailContent.innerHTML = `<div class="dim">· about to spawn a request…</div>`;
+                const obs = new IntersectionObserver(
+                    (entries) => {
+                        entries.forEach((e) => {
+                            if (e.isIntersecting) {
+                                obs.disconnect();
+                                start();
+                            }
+                        });
+                    },
+                    { threshold: 0.4 },
+                );
+                obs.observe(tailContent.closest(".term"));
+            })();
 
-/* ============ burst dots ============ */
-(function () {
-  const holder = $("burst-dots");
-  for (let k = 0; k < 64; k++) {
-    const d = document.createElement("div");
-    d.className = "bdot";
-    holder.appendChild(d);
-  }
-})();
-</script>
-</body>
+            /* ============ burst dots ============ */
+            (function () {
+                const holder = $("burst-dots");
+                for (let k = 0; k < 64; k++) {
+                    const d = document.createElement("div");
+                    d.className = "bdot";
+                    holder.appendChild(d);
+                }
+            })();
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
`ScreenMode::AltScreen` has run whole apps fullscreen since 0.6.5 (atuin's search TUI ships on it), but the book still said eye-declare "renders inline only" and "deliberately does not do full-screen layout."

Three content changes: the introduction's "What it's not" becomes "Inline first, fullscreen too" — same model/`update`/`tail`, sized via `on_resize`, with an honest restatement of what eye-declare still isn't (a component-tree framework); the book index gets the inline-first framing plus a pointer to the alt-screen reference; and the timeline guide closes with "When there is no timeline," saying what the timeline model stops meaning on the alternate screen. The runtime reference already documents the mechanics — the book now routes readers to it instead of denying the feature exists.

The landing page (`docs/index.html`) is deliberately untouched — that line's removal is being handled separately.
